### PR TITLE
Pythonic imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,42 @@ build/
 
 # Documentation
 /docs/_build
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+#build
+build/*
+.idea/*
+*.iml
+.vscode
+
+*.orig
+

--- a/pypowsybl/__init__.py
+++ b/pypowsybl/__init__.py
@@ -9,6 +9,23 @@ from _pypowsybl import PyPowsyblError
 
 __version__ = '0.8.0'
 
+import pypowsybl.network
+import pypowsybl.loadflow
+import pypowsybl.security_analysis
+import pypowsybl.sensitivity_analysis
+
+
+# make this modules importable with pythonic syntax "from pypowsybl.XXX import YYY
+# for example:
+# >>> import pypowsybl as pp
+# >>> network  = pp.network.create_ieee14()
+__all__ = [
+    "network",
+    "loadflow",
+    "security_analysis",
+    "sensitivity_analysis"
+]
+
 
 def set_debug_mode(debug: bool = True):
     _pypowsybl.set_debug_mode(debug)

--- a/setup.py
+++ b/setup.py
@@ -109,12 +109,17 @@ class PyPowsyblBuild(build_ext):
         subprocess.check_call(['cmake', cpp_source_dir] + cmake_args, cwd=self.build_temp, env=env)
         subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
 
+
+# long description from the github readme
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
 setup(
     name='pypowsybl',
     author='Geoffroy Jamgotchian',
     author_email="geoffroy.jamgotchian@gmail.com",
     description='A PowSyBl Python API',
-    long_description='',
+    long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/powsybl/pypowsybl",
     packages=find_packages(),


### PR DESCRIPTION
# Please check if the PR fulfills these requirements
 *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


# Does this PR already have an issue describing the problem ?
 *If so, link to this issue using `'#XXX'` and skip the rest*

No, but i can make one if needed (or even two)


# What kind of change does this PR introduce?
*(Bug fix, feature, docs update, ...)*

This PR introduces 2 new "features":

The first one is the display of the readme on the pypi website. Today it shows:
> The author of this package has not provided a project description

If this PR is merge, at next release, it will show the readme. Modifications were directly inspired from: https://packaging.python.org/guides/making-a-pypi-friendly-readme/

The second one aims at making the import slightly more user friendly. You can now do:
```python
import pypowsybl as pp
network = pp.network.create_ieee14()
results = pp.loadflow.run_ac(network)
# etc.
```

# What is the current behavior?
*(You can also link to an open issue here)*

For "issue 1":
Currently, on pypi it is written 
> The author of this package has not provided a project description

For "issue 2":
And you have to perform the following imports

```python
import pypowsybl.network
import pypowsybl.loadflow
import pypowsybl as pp
network = pp.network.create_ieee14()
results = pp.loadflow.run_ac(network)
# etc.
```

If you don't do the first two, you end up with the error:
> Traceback (most recent call last):
> File "<stdin>", line 1, in <module>
> AttributeError: module 'pypowsybl' has no attribute 'network'



# What is the new behavior (if this is a feature change)?
For "issue 1": Now the readme will be displayed on pypi page (https://pypi.org/project/pypowsybl/)

For "issue 2": You will be able to do:

```python
import pypowsybl as pp
network = pp.network.create_ieee14()
results = pp.loadflow.run_ac(network)
# etc.
```
Which is more "pythonic"


# Does this PR introduce a breaking change or deprecate an API?
*If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*

 It does not impact current behaviour, and tests pass.
