### PR TITLE
Add columns to buses dataframe: component numbers and voltage level IDs

### DIFF
--- a/java/src/main/java/com/powsybl/dataframe/DataframeHandlerImpl.java
+++ b/java/src/main/java/com/powsybl/dataframe/DataframeHandlerImpl.java
@@ -6,7 +6,10 @@
  */
 package com.powsybl.dataframe;
 
+import com.powsybl.commons.PowsyblException;
+
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 /**
@@ -77,19 +80,23 @@ public class DataframeHandlerImpl implements DataframeHandler {
         }
 
         public double[] getDoubles() {
-            return doubles;
+            return Optional.ofNullable(doubles)
+                .orElseThrow(() -> new PowsyblException("Series " + getName() + " is not of type double"));
         }
 
         public int[] getInts() {
-            return ints;
+            return Optional.ofNullable(ints)
+                .orElseThrow(() -> new PowsyblException("Series " + getName() + " is not of type int"));
         }
 
         public boolean[] getBooleans() {
-            return booleans;
+            return Optional.ofNullable(booleans)
+                .orElseThrow(() -> new PowsyblException("Series " + getName() + " is not of type boolean"));
         }
 
         public String[] getStrings() {
-            return strings;
+            return Optional.ofNullable(strings)
+                .orElseThrow(() -> new PowsyblException("Series " + getName() + " is not of type string"));
         }
     }
 

--- a/java/src/main/java/com/powsybl/dataframe/NetworkDataframes.java
+++ b/java/src/main/java/com/powsybl/dataframe/NetworkDataframes.java
@@ -146,10 +146,14 @@ public final class NetworkDataframes {
     }
 
     static DataframeMapper buses() {
-        return DataframeMapperBuilder.ofStream(n -> n.getBusView().getBusStream())
+        return DataframeMapperBuilder.ofStream(n -> n.getBusView().getBusStream(),
+                                               getOrThrow((n, id) -> n.getBusView().getBus(id), "Bus"))
             .stringsIndex("id", Bus::getId)
             .doubles("v_mag", Bus::getV, Bus::setV)
             .doubles("v_angle", Bus::getAngle, Bus::setAngle)
+            .ints("connected_component", ifExistsInt(Bus::getConnectedComponent, Component::getNum))
+            .ints("synchronous_component", ifExistsInt(Bus::getSynchronousComponent, Component::getNum))
+            .strings("voltage_level_id", b -> b.getVoltageLevel().getId())
             .addProperties()
             .build();
     }

--- a/java/src/test/java/com/powsybl/dataframe/NetworkDataframesTest.java
+++ b/java/src/test/java/com/powsybl/dataframe/NetworkDataframesTest.java
@@ -58,9 +58,15 @@ class NetworkDataframesTest {
 
         assertThat(series)
             .extracting(Series::getName)
-            .containsExactly("id", "v_mag", "v_angle");
+            .containsExactly("id", "v_mag", "v_angle", "connected_component", "synchronous_component", "voltage_level_id");
         assertThat(series.get(1).getDoubles())
             .containsExactly(Double.NaN, Double.NaN, Double.NaN, Double.NaN);
+        assertThat(series.get(3).getInts())
+            .containsExactly(0, 0, 0, 0);
+        assertThat(series.get(4).getInts())
+            .containsExactly(0, 0, 0, 0);
+        assertThat(series.get(5).getStrings())
+            .containsExactly("VLGEN", "VLHV1", "VLHV2", "VLLOAD");
     }
 
     @Test

--- a/pypowsybl/network.py
+++ b/pypowsybl/network.py
@@ -274,6 +274,14 @@ class Network(ObjectHandle):
                 raise PyPowsyblError(
                     f'Unsupported series type {series_type}, element type: {element_type}, series_name: {seriesName}')
 
+    def update_buses(self, df: pd.DataFrame):
+        """ Update buses with a ``Pandas`` data frame.
+
+        Args:
+            df (DataFrame): the ``Pandas`` data frame
+        """
+        return self.update_elements(_pypowsybl.ElementType.BUS, df)
+
     def update_switches(self, df: pd.DataFrame):
         """ Update switches with a ``Pandas`` data frame.
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -14,6 +14,7 @@ import pypowsybl.sensitivity
 import pypowsybl as pp
 import pandas as pd
 import pathlib
+from numpy import NaN
 
 TEST_DIR = pathlib.Path(__file__).parent
 DATA_DIR = TEST_DIR.parent.joinpath('data')
@@ -78,6 +79,27 @@ class PyPowsyblTestCase(unittest.TestCase):
         self.assertEqual([], n.get_elements_ids(element_type=pp.network.ElementType.LOAD, nominal_voltages={150}, countries={'BE'}))
         self.assertEqual(['NGEN_NHV1'], n.get_elements_ids(element_type=pp.network.ElementType.TWO_WINDINGS_TRANSFORMER, nominal_voltages={24}, countries={'FR'}))
         self.assertEqual([], n.get_elements_ids(element_type=pp.network.ElementType.TWO_WINDINGS_TRANSFORMER, nominal_voltages={24}, countries={'BE'}))
+
+    def test_buses(self):
+        n = pp.network.create_eurostag_tutorial_example1_network()
+        buses = n.get_buses()
+        expected = pd.DataFrame(index=pd.Series(name='id', data=['VLGEN_0', 'VLHV1_0', 'VLHV2_0', 'VLLOAD_0']),
+                                columns=['v_mag', 'v_angle', 'connected_component', 'synchronous_component', 'voltage_level_id'],
+                                data=[[NaN, NaN, 0, 0, 'VLGEN'],
+                                      [NaN, NaN, 0, 0, 'VLHV1'],
+                                      [NaN, NaN, 0, 0, 'VLHV2'],
+                                      [NaN, NaN, 0, 0, 'VLLOAD']])
+        pd.testing.assert_frame_equal(expected, buses, check_dtype=False)
+
+        n.update_buses(pd.DataFrame(index=['VLGEN_0'], columns=['v_mag', 'v_angle'], data=[[400, 0]]))
+        buses = n.get_buses()
+        expected = pd.DataFrame(index=pd.Series(name='id', data=['VLGEN_0', 'VLHV1_0', 'VLHV2_0', 'VLLOAD_0']),
+                                columns=['v_mag', 'v_angle', 'connected_component', 'synchronous_component', 'voltage_level_id'],
+                                data=[[400, 0, 0, 0, 'VLGEN'],
+                                      [NaN, NaN, 0, 0, 'VLHV1'],
+                                      [NaN, NaN, 0, 0, 'VLHV2'],
+                                      [NaN, NaN, 0, 0, 'VLLOAD']])
+        pd.testing.assert_frame_equal(expected, buses, check_dtype=False)
 
     def test_loads_data_frame(self):
         n = pp.network.create_eurostag_tutorial_example1_network()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Feature

**What is the current behavior?** *(You can also link to an open issue here)*

Buses dataframe only reports the bus ID, voltage magnitude and angles, which is not sufficient to link them to voltage levels.
It does not either contain information about synchronous and connected components.

**What is the new behavior (if this is a feature change)?**

Buses dataframe has 3 new columns : `connected_component`, `synchronous_component` and `voltagel_level_id`.
