### PR TITLE
Fix memory leak on security analysis result

### DIFF
--- a/pypowsybl/security.py
+++ b/pypowsybl/security.py
@@ -15,7 +15,7 @@ from _pypowsybl import Side
 from _pypowsybl import ContingencyContextType
 from pypowsybl.network import Network
 from pypowsybl.loadflow import Parameters
-from pypowsybl.util import ContingencyContainer
+from pypowsybl.util import ContingencyContainer, ObjectHandle as _ObjectHandle
 from prettytable import PrettyTable
 
 ContingencyResult.__repr__ = lambda self: f"{self.__class__.__name__}(" \
@@ -37,9 +37,13 @@ LimitViolation.__repr__ = lambda self: f"{self.__class__.__name__}(" \
                                        f")"
 
 
-class SecurityAnalysisResult:
+class SecurityAnalysisResult(_ObjectHandle):
+    """
+    The result of a security analysis.
+    """
+
     def __init__(self, result):
-        self.ptr = result
+        super().__init__(result)
         results = _pypowsybl.get_security_analysis_result(result)
         self._post_contingency_results = {}
         for result in results:


### PR DESCRIPTION
The handle to java object needs to be deleted.

Signed-off-by: Sylvain Leclerc <sylvain.leclerc@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*

Security analysis result handle is never released

**What is the new behavior (if this is a feature change)?**

The handle to java result is correctly released when the python object is destroyed.

