### PR TITLE
fix getters on power in lines

### DIFF
--- a/java/src/main/java/com/powsybl/dataframe/NetworkDataframes.java
+++ b/java/src/main/java/com/powsybl/dataframe/NetworkDataframes.java
@@ -89,7 +89,7 @@ public final class NetworkDataframes {
     }
 
     static <U extends Branch<U>> ToDoubleFunction<U> getQ1() {
-        return b -> b.getTerminal1().getP();
+        return b -> b.getTerminal1().getQ();
     }
 
     static <U extends Branch<U>> DoubleUpdater<U> setP1() {
@@ -105,7 +105,7 @@ public final class NetworkDataframes {
     }
 
     static <U extends Branch<U>> ToDoubleFunction<U> getQ2() {
-        return b -> b.getTerminal2().getP();
+        return b -> b.getTerminal2().getQ();
     }
 
     static <U extends Branch<U>> DoubleUpdater<U> setP2() {

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -90,7 +90,8 @@ BBE1AA1               0 2 400.00 3000.00 0.00000 -1500.0 0.00000 0.00000 -9000.0
         n = pp.network.create_eurostag_tutorial_example1_network()
         buses = n.get_buses()
         expected = pd.DataFrame(index=pd.Series(name='id', data=['VLGEN_0', 'VLHV1_0', 'VLHV2_0', 'VLLOAD_0']),
-                                columns=['v_mag', 'v_angle', 'connected_component', 'synchronous_component', 'voltage_level_id'],
+                                columns=['v_mag', 'v_angle', 'connected_component', 'synchronous_component',
+                                         'voltage_level_id'],
                                 data=[[NaN, NaN, 0, 0, 'VLGEN'],
                                       [380, NaN, 0, 0, 'VLHV1'],
                                       [380, NaN, 0, 0, 'VLHV2'],
@@ -100,7 +101,8 @@ BBE1AA1               0 2 400.00 3000.00 0.00000 -1500.0 0.00000 0.00000 -9000.0
         n.update_buses(pd.DataFrame(index=['VLGEN_0'], columns=['v_mag', 'v_angle'], data=[[400, 0]]))
         buses = n.get_buses()
         expected = pd.DataFrame(index=pd.Series(name='id', data=['VLGEN_0', 'VLHV1_0', 'VLHV2_0', 'VLLOAD_0']),
-                                columns=['v_mag', 'v_angle', 'connected_component', 'synchronous_component', 'voltage_level_id'],
+                                columns=['v_mag', 'v_angle', 'connected_component', 'synchronous_component',
+                                         'voltage_level_id'],
                                 data=[[400, 0, 0, 0, 'VLGEN'],
                                       [380, NaN, 0, 0, 'VLHV1'],
                                       [380, NaN, 0, 0, 'VLHV2'],
@@ -328,6 +330,20 @@ BBE1AA1               0 2 400.00 3000.00 0.00000 -1500.0 0.00000 0.00000 -9000.0
         copy_n = copy.deepcopy(n)
         self.assertEqual(['NGEN_NHV1', 'NHV2_NLOAD'],
                          copy_n.get_elements_ids(pp.network.ElementType.TWO_WINDINGS_TRANSFORMER))
+
+    def test_get_lines(self):
+        n = pp.network.create_four_substations_node_breaker_network()
+        expected = pd.DataFrame(index=pd.Series(name='id', data=['LINE_S2S3', 'LINE_S3S4']),
+                                columns=['r', 'x', 'g1', 'b1', 'g2', 'b2', 'p1', 'q1', 'p2', 'q2', 'voltage_level1_id',
+                                         'voltage_level2_id', 'bus1_id', 'bus2_id'],
+                                data=[[0.01, 19.1, 0, 0, 0, 0, 109.889, 190.023, -109.886, -184.517, 'S2VL1', 'S3VL1',
+                                       'S2VL1_0', 'S3VL1_0'],
+                                      [0.01, 13.1, 0, 0, 0, 0, 240.004, 2.1751, -240, 2.5415, 'S3VL1', 'S4VL1',
+                                       'S3VL1_0', 'S4VL1_0']])
+
+        lines = n.get_lines()
+        pd.testing.assert_frame_equal(expected, lines, check_dtype=False)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Etienne Lesot <etienne.lesot@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

bug

**What is the current behavior?** *(You can also link to an open issue here)*

reactiv power is not gotten when gotten lines it is activ power instead. 

**What is the new behavior (if this is a feature change)?**
fix it


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
