### PR TITLE
Fix strings memory leaks

### DIFF
--- a/cpp/src/bindings.cpp
+++ b/cpp/src/bindings.cpp
@@ -30,11 +30,6 @@ py::array seriesAsNumpyArray(const series& series) {
     return py::array(py::dtype::of<T>(), series.data.length, series.data.ptr, py::cast(series));
 }
 
-template<typename F>
-py::str toPythonString(F function) {
-
-}
-
 PYBIND11_MODULE(_pypowsybl, m) {
     pypowsybl::init();
 

--- a/cpp/src/bindings.cpp
+++ b/cpp/src/bindings.cpp
@@ -30,6 +30,11 @@ py::array seriesAsNumpyArray(const series& series) {
     return py::array(py::dtype::of<T>(), series.data.length, series.data.ptr, py::cast(series));
 }
 
+template<typename F>
+py::str toPythonString(F function) {
+
+}
+
 PYBIND11_MODULE(_pypowsybl, m) {
     pypowsybl::init();
 

--- a/cpp/src/pypowsybl.cpp
+++ b/cpp/src/pypowsybl.cpp
@@ -91,7 +91,6 @@ Array<limit_violation>::~Array() {
 
 template<>
 Array<series>::~Array() {
-    std::cout<<"Destroying series array"<<std::endl;
     callJava<>(::freeSeriesArray, delegate_);
 }
 
@@ -459,7 +458,6 @@ matrix* getReferenceVoltages(const JavaHandle& sensitivityAnalysisResultContext,
 }
 
 SeriesArray* createNetworkElementsSeriesArray(const JavaHandle& network, element_type elementType) {
-    std::cout<<"Creating series array"<<std::endl;
     return new SeriesArray(callJava<array*>(::createNetworkElementsSeriesArray, network, elementType));
 }
 

--- a/cpp/src/pypowsybl.cpp
+++ b/cpp/src/pypowsybl.cpp
@@ -28,15 +28,18 @@ public:
         }
         //if thread already attached to the isolate,
         //we assume it's a nested call --> do nothing
-        if (graal_get_current_thread(isolate) == nullptr) {
+
+        thread_ = graal_get_current_thread(isolate);
+        if (thread_ == nullptr) {
             if (graal_attach_thread(isolate, &thread_) != 0) {
                 throw std::runtime_error("graal_create_isolate error");
             }
-        }
+            shouldDetach = true;
+       }
     }
 
     ~GraalVmGuard() noexcept(false) {
-        if (thread_ != nullptr && graal_detach_thread(thread_) != 0) {
+        if (shouldDetach && graal_detach_thread(thread_) != 0) {
             throw std::runtime_error("graal_detach_thread error");
         }
     }
@@ -46,6 +49,7 @@ public:
     }
 
 private:
+    bool shouldDetach = false;
     graal_isolatethread_t* thread_ = nullptr;
 };
 

--- a/cpp/src/pypowsybl.cpp
+++ b/cpp/src/pypowsybl.cpp
@@ -91,6 +91,7 @@ Array<limit_violation>::~Array() {
 
 template<>
 Array<series>::~Array() {
+    std::cout<<"Destroying series array"<<std::endl;
     callJava<>(::freeSeriesArray, delegate_);
 }
 
@@ -458,6 +459,7 @@ matrix* getReferenceVoltages(const JavaHandle& sensitivityAnalysisResultContext,
 }
 
 SeriesArray* createNetworkElementsSeriesArray(const JavaHandle& network, element_type elementType) {
+    std::cout<<"Creating series array"<<std::endl;
     return new SeriesArray(callJava<array*>(::createNetworkElementsSeriesArray, network, elementType));
 }
 

--- a/cpp/src/pypowsybl.cpp
+++ b/cpp/src/pypowsybl.cpp
@@ -45,13 +45,16 @@ private:
     graal_isolatethread_t* thread_ = nullptr;
 };
 
+//copies to string and frees memory allocated by java
+std::string toString(char* cstring);
+
 template<typename F, typename... ARGS>
 void callJava(F f, ARGS... args) {
     GraalVmGuard guard;
     exception_handler exc;
     f(guard.thread(), args..., &exc);
     if (exc.message) {
-        throw PyPowsyblError(exc.message);
+        throw PyPowsyblError(toString(exc.message));
     }
 }
 
@@ -61,7 +64,7 @@ T callJava(F f, ARGS... args) {
     exception_handler exc;
     auto r = f(guard.thread(), args..., &exc);
     if (exc.message) {
-        throw PyPowsyblError(exc.message);
+        throw PyPowsyblError(toString(exc.message));
     }
     return r;
 }

--- a/cpp/src/pypowsybl.cpp
+++ b/cpp/src/pypowsybl.cpp
@@ -198,12 +198,23 @@ void deleteCharPtrPtr(char** charPtrPtr, int length) {
     delete charPtrPtr;
 }
 
+void freeCString(char* str) {
+    callJava<>(::freeString, str);
+}
+
+//copies to string and frees memory allocated by java
+std::string toString(char* cstring) {
+    std::string res = cstring;
+    freeCString(cstring);
+    return res;
+}
+
 void setDebugMode(bool debug) {
     callJava<>(::setDebugMode, debug);
 }
 
 std::string getVersionTable() {
-    return std::string(callJava<char*>(::getVersionTable));
+    return toString(callJava<char*>(::getVersionTable));
 }
 
 JavaHandle createEmptyNetwork(const std::string& id) {
@@ -303,7 +314,7 @@ std::string dumpNetworkToString(const JavaHandle& network, const std::string& fo
     }
     ToCharPtrPtr parameterNamesPtr(parameterNames);
     ToCharPtrPtr parameterValuesPtr(parameterValues);
-    return std::string(callJava<char*>(::dumpNetworkToString, network, (char*) format.data(), parameterNamesPtr.get(), parameterNames.size(),
+    return toString(callJava<char*>(::dumpNetworkToString, network, (char*) format.data(), parameterNamesPtr.get(), parameterNames.size(),
              parameterValuesPtr.get(), parameterValues.size()));
 }
 
@@ -347,7 +358,7 @@ void writeSingleLineDiagramSvg(const JavaHandle& network, const std::string& con
 }
 
 std::string getSingleLineDiagramSvg(const JavaHandle& network, const std::string& containerId) {
-    return std::string(callJava<char*>(::getSingleLineDiagramSvg, network, (char*) containerId.data()));
+    return toString(callJava<char*>(::getSingleLineDiagramSvg, network, (char*) containerId.data()));
 }
 
 JavaHandle createSecurityAnalysis() {
@@ -490,7 +501,7 @@ void updateNetworkElementsWithStringSeries(const JavaHandle& network, element_ty
 }
 
 std::string getWorkingVariantId(const JavaHandle& network) {
-    return std::string(callJava<char*>(::getWorkingVariantId, network));
+    return toString(callJava<char*>(::getWorkingVariantId, network));
 }
 
 void setWorkingVariant(const JavaHandle& network, std::string& variant) {
@@ -542,4 +553,5 @@ SeriesArray* getBusResults(const JavaHandle& securityAnalysisResult) {
 SeriesArray* getThreeWindingsTransformerResults(const JavaHandle& securityAnalysisResult) {
     return new SeriesArray(callJava<array*>(::getThreeWindingsTransformerResults, securityAnalysisResult));
 }
+
 }

--- a/cpp/src/pypowsybl.cpp
+++ b/cpp/src/pypowsybl.cpp
@@ -26,13 +26,17 @@ public:
         if (!isolate) {
             throw std::runtime_error("isolate has not been created");
         }
-        if (graal_attach_thread(isolate, &thread_) != 0) {
-            throw std::runtime_error("graal_create_isolate error");
+        //if thread already attached to the isolate,
+        //we assume it's a nested call --> do nothing
+        if (graal_get_current_thread(isolate) == nullptr) {
+            if (graal_attach_thread(isolate, &thread_) != 0) {
+                throw std::runtime_error("graal_create_isolate error");
+            }
         }
     }
 
     ~GraalVmGuard() noexcept(false) {
-        if (graal_detach_thread(thread_) != 0) {
+        if (thread_ != nullptr && graal_detach_thread(thread_) != 0) {
             throw std::runtime_error("graal_detach_thread error");
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bugfix

**What is the current behavior?** *(You can also link to an open issue here)*

String allocated by java code are not correctly freed when not used anymore.

**Info**
In order to confirm the leak, I tested the following code on a large network (like 100000 switches):
```python
import pypowsybl.network as pn

network = pn.load('larger_network.xiidm')

for i in range(1, 100):
    df = network.get_switches()
```

Prior to the fix, I can see the memory usage linearly growing, whereas it remains stable after the fix.
