### PR TITLE
Add short string representation of the network based on metadata

### DIFF
--- a/pypowsybl/network.py
+++ b/pypowsybl/network.py
@@ -79,6 +79,13 @@ class Network(object):
         """
         return self._forecast_distance
 
+    def __str__(self) -> str:
+        return f'Network(id={self.id}, name={self.name}, case_date={self.case_date}, ' \
+               f'forecast_distance={self.forecast_distance}, source_format={self.source_format})'
+
+    def __repr__(self) -> str:
+        return str(self)
+
     def __getstate__(self):
         return {'xml': self.dump_to_string()}
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -75,6 +75,13 @@ BBE1AA1               0 2 400.00 3000.00 0.00000 -1500.0 0.00000 0.00000 -9000.0
         self.assertEqual(datetime.timedelta(0), n.forecast_distance)
         self.assertEqual('test', n.source_format)
 
+    def test_network_representation(self):
+        n = pp.network.create_eurostag_tutorial_example1_network()
+        expected = 'Network(id=sim1, name=sim1, case_date=2018-01-01 10:00:00, ' \
+                   'forecast_distance=0:00:00, source_format=test)'
+        self.assertEqual(expected, str(n))
+        self.assertEqual(expected, repr(n))
+
     def test_get_network_element_ids(self):
         n = pp.network.create_eurostag_tutorial_example1_network()
         self.assertEqual(['NGEN_NHV1', 'NHV2_NLOAD'],


### PR DESCRIPTION
Signed-off-by: Sylvain Leclerc <sylvain.leclerc@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

#171 

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Feature

**What is the new behavior (if this is a feature change)?**

Conversion to string of a network now returns a simple description of the network, based on network metadata.

