### PR TITLE
Fix regression : IIDM properties were not included anymore in dataframes

### DIFF
--- a/java/src/main/java/com/powsybl/dataframe/network/AbstractNetworkDataframeMapper.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/AbstractNetworkDataframeMapper.java
@@ -10,7 +10,9 @@ import com.powsybl.dataframe.*;
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -29,20 +31,22 @@ public abstract class AbstractNetworkDataframeMapper<T> extends AbstractDatafram
     public void createDataframe(Network network, DataframeHandler dataframeHandler) {
         dataframeHandler.allocate(seriesMappers.size());
         List<T> items = getItems(network);
-        seriesMappers.values().stream().forEach(mapper -> mapper.createSeries(items, dataframeHandler));
+
+        List<SeriesMapper<T>> mappers = new ArrayList<>(seriesMappers.values());
         if (addProperties) {
-            addPropertiesSeries(items);
+            mappers.addAll(getPropertiesSeries(items));
         }
+        mappers.stream().forEach(mapper -> mapper.createSeries(items, dataframeHandler));
     }
 
-    private void addPropertiesSeries(List<T> items) {
+    private List<SeriesMapper<T>> getPropertiesSeries(List<T> items) {
         Stream<String> propertyNames = items.stream()
             .map(Identifiable.class::cast)
             .filter(Identifiable::hasProperty)
             .flatMap(e -> e.getPropertyNames().stream())
             .distinct();
-        propertyNames.forEach(property -> {
-            new StringSeriesMapper<T>(property, t -> ((Identifiable) t).getProperty(property));
-        });
+        return propertyNames
+            .map(property -> new StringSeriesMapper<T>(property, t -> ((Identifiable) t).getProperty(property)))
+            .collect(Collectors.toList());
     }
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/AbstractNetworkDataframeMapper.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/AbstractNetworkDataframeMapper.java
@@ -29,13 +29,12 @@ public abstract class AbstractNetworkDataframeMapper<T> extends AbstractDatafram
 
     @Override
     public void createDataframe(Network network, DataframeHandler dataframeHandler) {
-        dataframeHandler.allocate(seriesMappers.size());
         List<T> items = getItems(network);
-
         List<SeriesMapper<T>> mappers = new ArrayList<>(seriesMappers.values());
         if (addProperties) {
             mappers.addAll(getPropertiesSeries(items));
         }
+        dataframeHandler.allocate(mappers.size());
         mappers.stream().forEach(mapper -> mapper.createSeries(items, dataframeHandler));
     }
 

--- a/java/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
+++ b/java/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
@@ -218,6 +218,18 @@ class NetworkDataframesTest {
     }
 
     @Test
+    void properties() {
+        Network network = EurostagTutorialExample1Factory.create();
+        network.getSubstation("P1").setProperty("prop1", "val1");
+        network.getSubstation("P2").setProperty("prop2", "val2");
+        List<Series> series = createDataFrame(SUBSTATION, network);
+
+        assertThat(series)
+            .extracting(Series::getName)
+            .containsExactly("id", "TSO", "geo_tags", "country", "prop1", "prop2");
+    }
+
+    @Test
     void voltageLevels() {
         Network network = EurostagTutorialExample1Factory.create();
         List<Series> series = createDataFrame(VOLTAGE_LEVEL, network);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*

Network element generic properties are not anymore returned in dataframes.

**What is the new behavior (if this is a feature change)?**

Network element generic properties are correctly exported to dataframes.
