### PR TITLE
add alpha and rho for ratio tap changers

### DIFF
--- a/java/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -539,7 +539,15 @@ public final class NetworkDataframes {
                 .doubles("target_v", t -> t.getRatioTapChanger().getTargetV(), (t, v) -> t.getRatioTapChanger().setTargetV(v))
                 .doubles("target_deadband", t -> t.getRatioTapChanger().getTargetDeadband(), (t, v) -> t.getRatioTapChanger().setTargetDeadband(v))
                 .strings("regulating_bus_id", t -> getBusId(t.getRatioTapChanger().getRegulationTerminal()))
+                .doubles("rho", NetworkDataframes::computeRho)
+                .doubles("alpha", ifExistsDouble(TwoWindingsTransformer::getPhaseTapChanger, pc -> pc.getCurrentStep().getAlpha()))
                 .build();
+    }
+
+    private static double computeRho(TwoWindingsTransformer twoWindingsTransformer) {
+        return twoWindingsTransformer.getRatedU2() / twoWindingsTransformer.getRatedU1()
+                * (twoWindingsTransformer.getRatioTapChanger() != null ? twoWindingsTransformer.getRatioTapChanger().getCurrentStep().getRho() : 1)
+                * (twoWindingsTransformer.getPhaseTapChanger() != null ? twoWindingsTransformer.getPhaseTapChanger().getCurrentStep().getRho() : 1);
     }
 
     private static NetworkDataframeMapper ptcs() {

--- a/java/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
+++ b/java/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
@@ -138,7 +138,7 @@ class NetworkDataframesTest {
         assertThat(series)
             .extracting(Series::getName)
             .containsExactly("id", "g", "b", "model_type", "max_section_count", "section_count", "voltage_regulation_on", "" +
-                            "target_v", "target_deadband", "regulating_bus_id",  "p", "q", "i", "voltage_level_id", "bus_id", "connected");
+                "target_v", "target_deadband", "regulating_bus_id", "p", "q", "i", "voltage_level_id", "bus_id", "connected");
     }
 
     @Test
@@ -266,7 +266,8 @@ class NetworkDataframesTest {
 
         assertThat(series)
             .extracting(Series::getName)
-            .containsExactly("id", "tap", "low_tap", "high_tap", "step_count", "on_load", "regulating", "target_v", "target_deadband", "regulating_bus_id");
+            .containsExactly("id", "tap", "low_tap", "high_tap", "step_count", "on_load", "regulating", "target_v",
+                    "target_deadband", "regulating_bus_id", "rho", "alpha");
     }
 
     @Test
@@ -276,7 +277,8 @@ class NetworkDataframesTest {
 
         assertThat(series)
             .extracting(Series::getName)
-            .containsExactly("id", "tap", "low_tap", "high_tap", "step_count", "regulating", "regulation_mode", "regulation_value", "target_deadband", "regulating_bus_id");
+            .containsExactly("id", "tap", "low_tap", "high_tap", "step_count", "regulating", "regulation_mode",
+                    "regulation_value", "target_deadband", "regulating_bus_id");
     }
 
     @Test

--- a/pypowsybl/network.py
+++ b/pypowsybl/network.py
@@ -6,6 +6,7 @@
 #
 import _pypowsybl
 import sys
+
 from _pypowsybl import ElementType
 from _pypowsybl import PyPowsyblError
 from typing import List

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -261,14 +261,11 @@ BBE1AA1               0 2 400.00 3000.00 0.00000 -1500.0 0.00000 0.00000 -9000.0
                                 columns=['r', 'x', 'g', 'b', 'rated_u1', 'rated_u2', 'rated_s', 'p1', 'q1', 'i1', 'p2',
                                          'q2', 'i2', 'voltage_level1_id', 'voltage_level2_id', 'bus1_id', 'bus2_id',
                                          'connected1', 'connected2'],
-                                data=[
-                                    [0.266585, 11.1045, 0, 0, 24, 400, NaN, NaN, NaN, NaN, NaN, NaN, NaN, 'VLGEN',
-                                     'VLHV1',
-                                     'VLGEN_0', 'VLHV1_0', True, True],
-                                    [0.04725, 4.04972, 0, 0, 400, 158, NaN, NaN, NaN, NaN, NaN, NaN, NaN, 'VLHV2',
-                                     'VLLOAD', 'VLHV2_0', 'VLLOAD_0', True, True]
-                                ])
-        pd.testing.assert_frame_equal(expected, n.get_2_windings_transformers(), check_dtype=False)
+                                data=[[0.27, 11.10, 0, 0, 24, 400, NaN, NaN, NaN, NaN, NaN, NaN,
+                                       NaN, 'VLGEN', 'VLHV1', 'VLGEN_0', 'VLHV1_0', True, True],
+                                      [0.05, 4.05, 0, 0, 400, 158, NaN, NaN, NaN, NaN, NaN, NaN, NaN,
+                                       'VLHV2', 'VLLOAD', 'VLHV2_0', 'VLLOAD_0', True, True]])
+        pd.testing.assert_frame_equal(expected, n.get_2_windings_transformers(), check_dtype=False, atol=10 ** -2)
         n.update_2_windings_transformers(
             pd.DataFrame(index=['NGEN_NHV1'],
                          columns=['r', 'x', 'g', 'b', 'rated_u1', 'rated_u2', 'connected1', 'connected2'],
@@ -277,14 +274,11 @@ BBE1AA1               0 2 400.00 3000.00 0.00000 -1500.0 0.00000 0.00000 -9000.0
                                 columns=['r', 'x', 'g', 'b', 'rated_u1', 'rated_u2', 'rated_s', 'p1', 'q1', 'i1', 'p2',
                                          'q2', 'i2', 'voltage_level1_id', 'voltage_level2_id', 'bus1_id', 'bus2_id',
                                          'connected1', 'connected2'],
-                                data=[
-                                    [0.3, 11.2, 1, 1, 90, 225, NaN, NaN, NaN, NaN, NaN, NaN, NaN, 'VLGEN',
-                                     'VLHV1',
-                                     '', '', False, False],
-                                    [0.04725, 4.04972, 0, 0, 400, 158, NaN, NaN, NaN, NaN, NaN, NaN, NaN, 'VLHV2',
-                                     'VLLOAD', 'VLHV2_0', 'VLLOAD_0', True, True]
-                                ])
-        pd.testing.assert_frame_equal(expected, n.get_2_windings_transformers(), check_dtype=False)
+                                data=[[0.3, 11.2, 1, 1, 90, 225, NaN, NaN, NaN, NaN, NaN, NaN, NaN,
+                                       'VLGEN', 'VLHV1', '', '', False, False],
+                                      [0.047, 4.05, 0, 0, 400, 158, NaN, NaN, NaN, NaN, NaN, NaN, NaN,
+                                       'VLHV2', 'VLLOAD', 'VLHV2_0', 'VLLOAD_0', True, True]])
+        pd.testing.assert_frame_equal(expected, n.get_2_windings_transformers(), check_dtype=False, atol=10 ** -2)
 
     def test_voltage_levels_data_frame(self):
         n = pp.network.create_eurostag_tutorial_example1_network()
@@ -315,24 +309,24 @@ BBE1AA1               0 2 400.00 3000.00 0.00000 -1500.0 0.00000 0.00000 -9000.0
         except pp.PyPowsyblError as e:
             self.assertEqual("Switch 'aa' not found", str(e))
 
-
     def test_ratio_tap_changers(self):
         n = pp.network.create_eurostag_tutorial_example1_network()
-        tap_changers = n.get_ratio_tap_changers()
-        self.assertEqual(['tap', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
-                          'target_v', 'target_deadband', 'regulating_bus_id'], tap_changers.columns.tolist())
-        self.assertEqual([1, 0, 2, 3, True, True, 158.0, 0.0, 'VLLOAD_0'], tap_changers.loc['NHV2_NLOAD'].tolist())
-
+        expected = pd.DataFrame(index=pd.Series(name='id', data=['NHV2_NLOAD']),
+                                columns=['tap', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+                                         'target_v', 'target_deadband', 'regulating_bus_id', 'rho',
+                                         'alpha'],
+                                data=[[1, 0, 2, 3, True, True, 158.0, 0.0, 'VLLOAD_0', 0.4, NaN]])
+        pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=10 ** -2)
         update = pd.DataFrame(index=['NHV2_NLOAD'],
                               columns=['tap', 'regulating', 'target_v'],
                               data=[[0, False, 180]])
         n.update_ratio_tap_changers(update)
-
-        tap_changers = n.get_ratio_tap_changers()
-        values = tap_changers.loc['NHV2_NLOAD']
-        self.assertFalse(values.regulating)
-        self.assertEqual(0, values.tap)
-        self.assertAlmostEqual(180, values.target_v, 1)
+        expected = pd.DataFrame(index=pd.Series(name='id', data=['NHV2_NLOAD']),
+                                columns=['tap', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+                                         'target_v', 'target_deadband', 'regulating_bus_id', 'rho',
+                                         'alpha'],
+                                data=[[0, 0, 2, 3, True, False, 180.0, 0.0, 'VLLOAD_0', 0.34, NaN]])
+        pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=10 ** -2)
 
     def test_phase_tap_changers(self):
         n = pp.network.create_four_substations_node_breaker_network()
@@ -489,9 +483,8 @@ BBE1AA1               0 2 400.00 3000.00 0.00000 -1500.0 0.00000 0.00000 -9000.0
                                          'p3', 'q3', 'i3', 'voltage_level3_id', 'bus3_id', 'connected3'],
                                 data=[[132, 17.424, 1.7424, 0.00573921, 0.000573921, 132, NaN, -99999, -99999, NaN, NaN,
                                        NaN, 'VL_132', 'VL_132_0', True, 1.089, 0.1089, 0, 0, 33, NaN, 2, -99999, NaN,
-                                       NaN,
-                                       NaN, 'VL_33', 'VL_33_0', True, 0.121, 0.0121, 0, 0, 11, NaN, 0, -99999, NaN, NaN,
-                                       NaN, 'VL_11', 'VL_11_0', True]])
+                                       NaN, NaN, 'VL_33', 'VL_33_0', True, 0.121, 0.0121, 0, 0, 11, NaN, 0, -99999, NaN,
+                                       NaN, NaN, 'VL_11', 'VL_11_0', True]])
         pd.testing.assert_frame_equal(expected, n.get_3_windings_transformers(), check_dtype=False)
         # test update
 
@@ -512,7 +505,7 @@ BBE1AA1               0 2 400.00 3000.00 0.00000 -1500.0 0.00000 0.00000 -9000.0
     def test_non_linear_shunt(self):
         n = self.create_non_linear_shunt_network()
         expected = pd.DataFrame(index=pd.MultiIndex.from_tuples([('SHUNT', 0), ('SHUNT', 1)],
-                                            names=['id', 'section']),
+                                                                names=['id', 'section']),
                                 columns=['g', 'b'],
                                 data=[[0.0, 0.00001],
                                       [0.3, 0.02000]])


### PR DESCRIPTION
Signed-off-by: Etienne LESOT <etienne.lesot@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

features

**What is the new behavior (if this is a feature change)?**

add tap ratio and phase ration in two windings transformers dataframe
