### PR TITLE
Install PowSyBl math native library

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -21,6 +21,19 @@ set(PYPOWSYBL_JAVA_BIN_DIR ${CMAKE_CURRENT_BINARY_DIR}/java)
 set(PYPOWSYBL_JAVA_OLD_LIB pypowsybl-java${CMAKE_SHARED_LIBRARY_SUFFIX})
 set(PYPOWSYBL_JAVA_LIB ${CMAKE_SHARED_LIBRARY_PREFIX}pypowsybl-java${CMAKE_SHARED_LIBRARY_SUFFIX})
 
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+    set(POWSYBL_MATH_NATIVE_LIB math.dll)
+    set(POWSYBL_MATH_NATIVE_JAR_ENTRY_DIR natives/windows_64)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    set(POWSYBL_MATH_NATIVE_LIB libmath.so)
+    set(POWSYBL_MATH_NATIVE_JAR_ENTRY_DIR natives/linux_64)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+    set(POWSYBL_MATH_NATIVE_LIB libmath.dylib)
+    set(POWSYBL_MATH_NATIVE_JAR_ENTRY_DIR natives/osx_64)
+else()
+    message(FATAL_ERROR "System not supported: ${CMAKE_SYSTEM_NAME}")
+endif()
+
 # on MacOS, java library is created with an absolute path id, we need to fix it using install_name_tool before
 # linking with our shared library
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
@@ -52,15 +65,18 @@ set(SOURCE_DIR "src")
 include_directories(${SOURCE_DIR} ${PYPOWSYBL_JAVA_BIN_DIR} ${PYPOWSYBL_JAVA_SRC_DIR}/src/main/resources)
 set(SOURCES "${SOURCE_DIR}/pypowsybl.cpp")
 
-link_directories(${PYPOWSYBL_JAVA_BIN_DIR})
+link_directories(${PYPOWSYBL_JAVA_BIN_DIR} ${CMAKE_CURRENT_BINARY_DIR}/${POWSYBL_MATH_NATIVE_JAR_ENTRY_DIR})
 
 add_subdirectory(lib/pybind11)
 pybind11_add_module(_pypowsybl ${SOURCES} "${SOURCE_DIR}/bindings.cpp")
 
-add_dependencies(_pypowsybl native-image)
-target_link_libraries(_pypowsybl PRIVATE ${PYPOWSYBL_JAVA_LIB})
+# extract powsybl math native from jar for current platform
+add_custom_target(math-native ALL COMMAND ${CMAKE_COMMAND} -E tar x ${PYPOWSYBL_JAVA_SRC_DIR}/target/dependency/powsybl-math-native.jar ${POWSYBL_MATH_NATIVE_JAR_ENTRY_DIR}/${POWSYBL_MATH_NATIVE_LIB})
+
+add_dependencies(_pypowsybl native-image math-native)
+target_link_libraries(_pypowsybl PRIVATE ${PYPOWSYBL_JAVA_LIB} ${POWSYBL_MATH_NATIVE_LIB})
 
 # copy auxiliary java lib so that it can be installed with module one
 if(DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY)
-    add_custom_command(TARGET _pypowsybl POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${PYPOWSYBL_JAVA_BIN_DIR}/${PYPOWSYBL_JAVA_LIB} ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+    add_custom_command(TARGET _pypowsybl POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${PYPOWSYBL_JAVA_BIN_DIR}/${PYPOWSYBL_JAVA_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${POWSYBL_MATH_NATIVE_JAR_ENTRY_DIR}/${POWSYBL_MATH_NATIVE_LIB} ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 endif(DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -66,7 +66,7 @@ set(SOURCE_DIR "src")
 include_directories(${SOURCE_DIR} ${PYPOWSYBL_JAVA_BIN_DIR} ${PYPOWSYBL_JAVA_SRC_DIR}/src/main/resources)
 set(SOURCES "${SOURCE_DIR}/pypowsybl.cpp")
 
-link_directories(${PYPOWSYBL_JAVA_BIN_DIR} ${CMAKE_CURRENT_BINARY_DIR}/${POWSYBL_MATH_NATIVE_JAR_ENTRY_DIR})
+link_directories(${PYPOWSYBL_JAVA_BIN_DIR})
 
 add_subdirectory(lib/pybind11)
 pybind11_add_module(_pypowsybl ${SOURCES} "${SOURCE_DIR}/bindings.cpp")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -75,9 +75,9 @@ pybind11_add_module(_pypowsybl ${SOURCES} "${SOURCE_DIR}/bindings.cpp")
 # powsybl-math-native.jar has been previously copied by maven build
 add_custom_target(math-native ALL COMMAND ${CMAKE_COMMAND} -E tar x ${PYPOWSYBL_JAVA_SRC_DIR}/target/dependency/powsybl-math-native.jar ${POWSYBL_MATH_NATIVE_JAR_ENTRY_DIR}/${POWSYBL_MATH_NATIVE_LIB} ${MATH_NATIVE_INSTALL_EXTRA_COMMAND})
 
-add_dependencies(_pypowsybl native-image math-native )
+add_dependencies(_pypowsybl native-image math-native)
 add_dependencies(math-native native-image) # because mvn command also copy math native jar
-target_link_libraries(_pypowsybl PRIVATE ${PYPOWSYBL_JAVA_LIB} ${POWSYBL_MATH_NATIVE_LIB})
+target_link_libraries(_pypowsybl PRIVATE ${PYPOWSYBL_JAVA_LIB})
 
 # copy auxiliary java lib so that it can be installed with module one
 if(DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -37,7 +37,8 @@ endif()
 # on MacOS, java library is created with an absolute path id, we need to fix it using install_name_tool before
 # linking with our shared library
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-    set(INSTALL_EXTRA_COMMAND COMMAND install_name_tool -id @loader_path/${PYPOWSYBL_JAVA_LIB} ${PYPOWSYBL_JAVA_BIN_DIR}/${PYPOWSYBL_JAVA_LIB})
+    set(NATIVE_IMAGE_INSTALL_EXTRA_COMMAND COMMAND install_name_tool -id @loader_path/${PYPOWSYBL_JAVA_LIB} ${PYPOWSYBL_JAVA_BIN_DIR}/${PYPOWSYBL_JAVA_LIB})
+    set(MATH_NATIVE_INSTALL_EXTRA_COMMAND COMMAND install_name_tool -id @loader_path/${POWSYBL_MATH_NATIVE_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${POWSYBL_MATH_NATIVE_JAR_ENTRY_DIR}/${POWSYBL_MATH_NATIVE_LIB})
 endif()
 
 ExternalProject_Add(mvn
@@ -57,7 +58,7 @@ ExternalProject_Add(native-image
     PATCH_COMMAND $ENV{JAVA_HOME}/bin/native-image --class-path ${PYPOWSYBL_JAVA_SRC_DIR}/target/pypowsybl-java.jar${EXTRA_JARS} --no-fallback --allow-incomplete-classpath --shared -H:Name=pypowsybl-java -H:CLibraryPath=${PYPOWSYBL_JAVA_SRC_DIR}/src/main/resources
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
-    INSTALL_COMMAND ${CMAKE_COMMAND} -E copy ${PYPOWSYBL_JAVA_BIN_DIR}/${PYPOWSYBL_JAVA_OLD_LIB} ${PYPOWSYBL_JAVA_BIN_DIR}/${PYPOWSYBL_JAVA_LIB} ${INSTALL_EXTRA_COMMAND}
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E copy ${PYPOWSYBL_JAVA_BIN_DIR}/${PYPOWSYBL_JAVA_OLD_LIB} ${PYPOWSYBL_JAVA_BIN_DIR}/${PYPOWSYBL_JAVA_LIB} ${NATIVE_IMAGE_INSTALL_EXTRA_COMMAND}
 )
 
 set(SOURCE_DIR "src")
@@ -72,7 +73,7 @@ pybind11_add_module(_pypowsybl ${SOURCES} "${SOURCE_DIR}/bindings.cpp")
 
 # extract powsybl math native from jar for current platform
 # powsybl-math-native.jar has been previously copied by maven build
-add_custom_target(math-native ALL COMMAND ${CMAKE_COMMAND} -E tar x ${PYPOWSYBL_JAVA_SRC_DIR}/target/dependency/powsybl-math-native.jar ${POWSYBL_MATH_NATIVE_JAR_ENTRY_DIR}/${POWSYBL_MATH_NATIVE_LIB})
+add_custom_target(math-native ALL COMMAND ${CMAKE_COMMAND} -E tar x ${PYPOWSYBL_JAVA_SRC_DIR}/target/dependency/powsybl-math-native.jar ${POWSYBL_MATH_NATIVE_JAR_ENTRY_DIR}/${POWSYBL_MATH_NATIVE_LIB} ${MATH_NATIVE_INSTALL_EXTRA_COMMAND})
 
 add_dependencies(_pypowsybl native-image math-native )
 add_dependencies(math-native native-image) # because mvn command also copy math native jar

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -71,9 +71,11 @@ add_subdirectory(lib/pybind11)
 pybind11_add_module(_pypowsybl ${SOURCES} "${SOURCE_DIR}/bindings.cpp")
 
 # extract powsybl math native from jar for current platform
+# powsybl-math-native.jar has been previously copied by maven build
 add_custom_target(math-native ALL COMMAND ${CMAKE_COMMAND} -E tar x ${PYPOWSYBL_JAVA_SRC_DIR}/target/dependency/powsybl-math-native.jar ${POWSYBL_MATH_NATIVE_JAR_ENTRY_DIR}/${POWSYBL_MATH_NATIVE_LIB})
 
-add_dependencies(_pypowsybl native-image math-native)
+add_dependencies(_pypowsybl native-image math-native )
+add_dependencies(math-native native-image) # because mvn command also copy math native jar
 target_link_libraries(_pypowsybl PRIVATE ${PYPOWSYBL_JAVA_LIB} ${POWSYBL_MATH_NATIVE_LIB})
 
 # copy auxiliary java lib so that it can be installed with module one

--- a/cpp/src/bindings.cpp
+++ b/cpp/src/bindings.cpp
@@ -73,6 +73,8 @@ PYBIND11_MODULE(_pypowsybl, m) {
 
     py::class_<pypowsybl::JavaHandle>(m, "JavaHandle");
 
+    m.def("set_java_library_path", &pypowsybl::setJavaLibraryPath, "Set java.library.path JVM property");
+
     m.def("set_debug_mode", &pypowsybl::setDebugMode, "Set debug mode");
 
     m.def("set_config_read", &pypowsybl::setConfigRead, "Set config read mode");

--- a/cpp/src/pypowsybl.cpp
+++ b/cpp/src/pypowsybl.cpp
@@ -220,6 +220,10 @@ std::string toString(char* cstring) {
     return res;
 }
 
+void setJavaLibraryPath(const std::string& javaLibraryPath) {
+    callJava<>(::setJavaLibraryPath, (char*) javaLibraryPath.data());
+}
+
 void setDebugMode(bool debug) {
     callJava<>(::setDebugMode, debug);
 }

--- a/cpp/src/pypowsybl.h
+++ b/cpp/src/pypowsybl.h
@@ -132,6 +132,8 @@ void deleteCharPtrPtr(char** charPtrPtr, int length);
 
 void init();
 
+void setJavaLibraryPath(const std::string& javaLibraryPath);
+
 void setDebugMode(bool debug);
 
 void setConfigRead(bool configRead);

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -179,6 +179,10 @@
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-api</artifactId>
             <version>${powsybl-core.version}</version>
+            <!--
+            We exclude PowSyBl math native jar from maven build because native library will be installed by the wheel
+            for the current platform
+            -->
             <exclusions>
                 <exclusion>
                     <groupId>com.powsybl</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -30,6 +30,7 @@
         <junit-jupiter.version>5.5.2</junit-jupiter.version>
         <logback.version>1.2.3</logback.version>
         <mapdb.version>3.0.8</mapdb.version>
+        <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
         <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
         <slf4j.version>1.7.30</slf4j.version>
         <powsybl-math-native.version>1.0.3</powsybl-math-native.version>
@@ -71,6 +72,30 @@
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven-dependency-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.powsybl</groupId>
+                                    <artifactId>powsybl-math-native</artifactId>
+                                    <version>${powsybl-math-native.version}</version>
+                                    <destFileName>powsybl-math-native.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
                         </configuration>
                     </execution>
                 </executions>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -32,6 +32,7 @@
         <mapdb.version>3.0.8</mapdb.version>
         <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
         <slf4j.version>1.7.30</slf4j.version>
+        <powsybl-math-native.version>1.0.3</powsybl-math-native.version>
         <powsybl-core.version>4.3.1</powsybl-core.version>
         <powsybl-rte-core.version>3.3.1</powsybl-rte-core.version>
         <powsybl-single-line-diagram.version>2.3.0</powsybl-single-line-diagram.version>
@@ -153,6 +154,12 @@
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-api</artifactId>
             <version>${powsybl-core.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.powsybl</groupId>
+                    <artifactId>powsybl-math-native</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
@@ -227,6 +234,12 @@
             <groupId>com.rte-france.powsybl</groupId>
             <artifactId>powsybl-hades2-integration</artifactId>
             <version>${powsybl-rte-core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-math-native</artifactId>
+            <version>${powsybl-math-native.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- test -->

--- a/java/src/main/java/com/powsybl/python/PyPowsyblApiLib.java
+++ b/java/src/main/java/com/powsybl/python/PyPowsyblApiLib.java
@@ -60,6 +60,13 @@ public final class PyPowsyblApiLib {
     private PyPowsyblApiLib() {
     }
 
+    @CEntryPoint(name = "setJavaLibraryPath")
+    public static void setJavaLibraryPath(IsolateThread thread, CCharPointer javaLibraryPath, ExceptionHandlerPointer exceptionHandlerPtr) {
+        doCatch(exceptionHandlerPtr, () -> {
+            System.setProperty("java.library.path", CTypeUtil.toString(javaLibraryPath));
+        });
+    }
+
     @CEntryPoint(name = "setDebugMode")
     public static void setDebugMode(IsolateThread thread, boolean debug, ExceptionHandlerPointer exceptionHandlerPtr) {
         doCatch(exceptionHandlerPtr, () -> {

--- a/pypowsybl/__init__.py
+++ b/pypowsybl/__init__.py
@@ -5,9 +5,14 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 import _pypowsybl
+import os as _os
+import inspect as _inspect
 from _pypowsybl import PyPowsyblError
 
 __version__ = '0.10.0'
+
+# set JVM java.library.path to pypowsybl module installation directory to be able to load math library
+_pypowsybl.set_java_library_path(_os.path.dirname(_inspect.getfile(_pypowsybl)))
 
 import pypowsybl.network
 import pypowsybl.loadflow


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
powsybl-math-native.jar contains native libraries for the 3 supported platforms. Thanks to native loader lib, it extract at runtime to a temporary folder the library for the right platform and add it to java class path.
With GraalVM native image build, all these libraries like any other jar resources are embedded into the final binary and like with java runtime extracted at runtime.
  - this is ugly (a .so contains a .so as internal data...)
  - it takes places in the binary
  - binary contains the 3 math native libraries and not only the one for the right platform
  - it slow down the execution (extraction, etc) 


**What is the new behavior (if this is a feature change)?**
powsybl-math-native.jar is exluded from native image compilation and math native lib for each of the platform are added to python wheel build


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
