### PR TITLE
Fix TSO column name case

### DIFF
--- a/java/src/main/java/com/powsybl/dataframe/network/adders/SubstationDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/SubstationDataframeAdder.java
@@ -26,7 +26,8 @@ public class SubstationDataframeAdder extends AbstractSimpleAdder {
             SeriesMetadata.stringIndex("id"),
             SeriesMetadata.strings("name"),
             SeriesMetadata.strings("country"),
-            SeriesMetadata.strings("tso")
+            SeriesMetadata.strings("tso"),
+            SeriesMetadata.strings("TSO")
     );
 
     @Override
@@ -40,6 +41,7 @@ public class SubstationDataframeAdder extends AbstractSimpleAdder {
         NetworkElementCreationUtils.createIdentifiable(adder, dataframe, indexElement);
         dataframe.getStringValue("country", indexElement).map(Country::valueOf).ifPresent(adder::setCountry);
         dataframe.getStringValue("tso", indexElement).ifPresent(adder::setTso);
+        dataframe.getStringValue("TSO", indexElement).ifPresent(adder::setTso);
         adder.add();
     }
 }

--- a/pypowsybl/network.py
+++ b/pypowsybl/network.py
@@ -2831,7 +2831,7 @@ class Network:  # pylint: disable=too-many-public-methods
             - **id**: the identifier of the substation
             - **name**: an optional human readable name for the substation
             - **country**: an optional country code ('DE', 'IT', ...)
-            - **tso**: an optional TSO name
+            - **TSO**: an optional TSO name
 
         Examples:
             Using keyword arguments:

--- a/tests/test_network_elements_creation.py
+++ b/tests/test_network_elements_creation.py
@@ -39,6 +39,18 @@ def test_substation_kwargs():
     assert s3.country == 'DE'
 
 
+def test_substation_tso():
+    # accepting lower case for backward compat
+    n = pn.create_eurostag_tutorial_example1_network()
+    n.create_substations(id='S3', tso='TERNA')
+    s3 = n.get_substations().loc['S3']
+    assert s3.TSO == 'TERNA'
+
+    n.create_substations(id='S4', TSO='TERNA')
+    s4 = n.get_substations().loc['S4']
+    assert s4.TSO == 'TERNA'
+
+
 def test_substation_exceptions():
     n = pn.create_eurostag_tutorial_example1_network()
     with pytest.raises(ValueError) as exc:
@@ -616,6 +628,7 @@ def test_create_limits():
     one_minute_limits = limits[limits['name'] == '1\'']
     pd.testing.assert_frame_equal(expected, one_minute_limits, check_dtype=False)
 
+
 def test_delete_elements_eurostag():
     pypowsybl.set_debug_mode(True)
     net = pypowsybl.network.create_eurostag_tutorial_example1_network()
@@ -634,6 +647,7 @@ def test_delete_elements_eurostag():
     assert net.get_2_windings_transformers().empty
     assert net.get_loads().empty
 
+
 def test_delete_elements_four_substations():
     net = pypowsybl.network.create_four_substations_node_breaker_network()
     net.remove_elements(['TWT', 'HVDC1', 'HVDC2', 'S1'])
@@ -648,6 +662,7 @@ def test_delete_elements_four_substations():
     assert 'The voltage level \'S2VL1\' cannot be removed because of a remaining LINE' in str(err.value)
     net.remove_elements(['LINE_S2S3', 'S2VL1'])
     assert 'S2VL1' not in net.get_voltage_levels().index
+
 
 def test_remove_elements_switches():
     net = pypowsybl.network.create_four_substations_node_breaker_network()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Fix

**What is the current behavior?** *(You can also link to an open issue here)*

TSO column is upper case in substations dataframes, but lower case in substation creation.
Plus, the doc is not correct.

**What is the new behavior (if this is a feature change)?**

Both upper and lower case are accepted.

