### PR TITLE
Add N-1 contingency flow transfer in security analysis

### DIFF
--- a/docs/user_guide/security.rst
+++ b/docs/user_guide/security.rst
@@ -76,12 +76,32 @@ Information can be obtained on buses, branches and three windings transformers.
     NGEN_NHV1      VLHV2            NHV2    569.04    -1.71
     NHV1_NHV2_1    VLHV2            NHV2    366.58    -7.50
     >>> results.branch_results
-                                   p1     q1       i1      p2      q2       i2
+                                   p1     q1       i1      p2      q2       i2  flow_transfer
     contingency_id branch_id
-                   NHV1_NHV2_2 302.44  98.74   456.77 -300.43 -137.19   488.99
-    NGEN_NHV1      NHV1_NHV2_2 301.06   0.00   302.80 -300.19 -116.60   326.75
-                   NHV1_NHV2_1 301.06   0.00   302.80 -300.19 -116.60   326.75
-    NHV1_NHV2_1    NHV1_NHV2_2 610.56 334.06 1,008.93 -601.00 -285.38 1,047.83
+                   NHV1_NHV2_2 302.44  98.74   456.77 -300.43 -137.19   488.99            NaN
+    NGEN_NHV1      NHV1_NHV2_2 301.06   0.00   302.80 -300.19 -116.60   326.75            NaN
+                   NHV1_NHV2_1 301.06   0.00   302.80 -300.19 -116.60   326.75            NaN
+    NHV1_NHV2_1    NHV1_NHV2_2 610.56 334.06 1,008.93 -601.00 -285.38 1,047.83            NaN
+
+.. testcleanup:: security.monitored_elements
+
+It also possible to get flow transfer on monitored branches in case of N-1 branch contingencies:
+
+.. doctest::
+    :options: +NORMALIZE_WHITESPACE
+
+    >>> n = pp.network.create_eurostag_tutorial_example1_network()
+    >>> sa = pp.security.create_analysis()
+    >>> sa.add_single_element_contingencies(['NHV1_NHV2_1', 'NHV1_NHV2_2'])
+    >>> sa.add_monitored_elements(branch_ids=['NHV1_NHV2_1', 'NHV1_NHV2_2'])
+    >>> sa_result = sa.run_ac(n)
+    >>> sa_result.branch_results
+                                        p1          q1           i1          p2          q2           i2  flow_transfer
+    contingency_id branch_id
+                   NHV1_NHV2_2  302.444049   98.740275   456.768978 -300.433895 -137.188493   488.992798            NaN
+                   NHV1_NHV2_1  302.444049   98.740275   456.768978 -300.433895 -137.188493   488.992798            NaN
+    NHV1_NHV2_2    NHV1_NHV2_1  610.562154  334.056272  1008.928788 -600.996156 -285.379147  1047.825769       1.018761
+    NHV1_NHV2_1    NHV1_NHV2_2  610.562154  334.056272  1008.928788 -600.996156 -285.379147  1047.825769       1.018761
 
 .. testcleanup:: security.monitored_elements
 

--- a/java/src/main/java/com/powsybl/python/BranchResultContext.java
+++ b/java/src/main/java/com/powsybl/python/BranchResultContext.java
@@ -17,7 +17,7 @@ public class BranchResultContext extends BranchResult {
 
     public BranchResultContext(BranchResult branchResult, String contingency) {
         super(branchResult.getBranchId(), branchResult.getP1(), branchResult.getQ1(), branchResult.getI1(),
-            branchResult.getP2(), branchResult.getQ2(), branchResult.getI2());
+            branchResult.getP2(), branchResult.getQ2(), branchResult.getI2(), branchResult.getFlowTransfer());
         this.contingencyId = contingency;
     }
 

--- a/java/src/main/java/com/powsybl/python/Dataframes.java
+++ b/java/src/main/java/com/powsybl/python/Dataframes.java
@@ -160,6 +160,7 @@ public final class Dataframes {
                 .doubles("p2", BranchResultContext::getP2)
                 .doubles("q2", BranchResultContext::getQ2)
                 .doubles("i2", BranchResultContext::getI2)
+                .doubles("flow_transfer", BranchResultContext::getFlowTransfer)
                 .build();
     }
 

--- a/tests/test_security_analysis.py
+++ b/tests/test_security_analysis.py
@@ -102,12 +102,23 @@ def test_monitored_elements():
     pd.testing.assert_frame_equal(expected, bus_results)
 
     assert branch_results.index.to_frame().columns.tolist() == ['contingency_id', 'branch_id']
-    assert branch_results.columns.tolist() == ['p1', 'q1', 'i1', 'p2', 'q2', 'i2']
+    assert branch_results.columns.tolist() == ['p1', 'q1', 'i1', 'p2', 'q2', 'i2', 'flow_transfer']
     assert len(branch_results) == 4
     assert branch_results.loc['', 'NHV1_NHV2_2']['p1'] == pytest.approx(302.44, abs=1e-2)
     assert branch_results.loc['NHV1_NHV2_1', 'NHV1_NHV2_2']['p1'] == pytest.approx(610.56, abs=1e-2)
     assert branch_results.loc['NGEN_NHV1', 'NHV1_NHV2_2']['p1'] == pytest.approx(301.06, abs=1e-2)
     assert branch_results.loc['NGEN_NHV1', 'NHV1_NHV2_1']['p1'] == pytest.approx(301.06, abs=1e-2)
+
+
+def test_flow_transfer():
+    n = pp.network.create_eurostag_tutorial_example1_network()
+    sa = pp.security.create_analysis()
+    sa.add_single_element_contingencies(['NHV1_NHV2_1', 'NHV1_NHV2_2'])
+    sa.add_monitored_elements(branch_ids=['NHV1_NHV2_1', 'NHV1_NHV2_2'])
+    sa_result = sa.run_ac(n)
+    branch_results = sa_result.branch_results
+    assert branch_results.loc['NHV1_NHV2_1', 'NHV1_NHV2_2']['flow_transfer'] == pytest.approx(1.01876, abs=1e-5)
+    assert branch_results.loc['NHV1_NHV2_2', 'NHV1_NHV2_1']['flow_transfer'] == pytest.approx(1.01876, abs=1e-5)
 
 
 def test_dc_analysis():


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature



**What is the new behavior (if this is a feature change)?**
N-1 branch contingency flow transfer are available in security analysis result data frame.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
