### PR TITLE
Add stack trace to logs

### DIFF
--- a/java/src/main/java/com/powsybl/python/CustomAppender.java
+++ b/java/src/main/java/com/powsybl/python/CustomAppender.java
@@ -7,7 +7,10 @@
 package com.powsybl.python;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.ThrowableProxyUtil;
 import ch.qos.logback.core.AppenderBase;
+import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.encoder.Encoder;
 
 /**
@@ -22,8 +25,14 @@ public class CustomAppender extends AppenderBase<ILoggingEvent> {
     @Override
     protected void append(final ILoggingEvent e) {
         PyPowsyblApiLib.LoggerCallback logMessage = (PyPowsyblApiLib.LoggerCallback) PyPowsyblApiLib.loggerCallback;
+
+        String message = e.getFormattedMessage();
+        IThrowableProxy throwable = e.getThrowableProxy();
+        if (throwable != null) {
+            message = message + CoreConstants.LINE_SEPARATOR + ThrowableProxyUtil.asString(throwable);
+        }
         logMessage.invoke(PyLoggingUtil.logbackLevelToPythonLevel(e.getLevel()), e.getTimeStamp(),
-                CTypeUtil.toCharPtr(e.getLoggerName()), CTypeUtil.toCharPtr(e.getFormattedMessage()));
+                CTypeUtil.toCharPtr(e.getLoggerName()), CTypeUtil.toCharPtr(message));
     }
 
     public Encoder<ILoggingEvent> getEncoder() {

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+#Change those options to get logs
+log_cli=false
+log_level=ERROR


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Feature

**What is the current behavior?** *(You can also link to an open issue here)*

Java exceptions report their message in python logger, but not the stack trace.

**What is the new behavior (if this is a feature change)?**

The stack trace is reported altogether:

```
2022-04-22 14:09:56,921 :: DEBUG   :: _update_elements          :: line 2024 :: Generator 'toto' not found
com.powsybl.commons.PowsyblException: Generator 'toto' not found
	at com.powsybl.dataframe.network.NetworkDataframes.lambda$getOrThrow$289(NetworkDataframes.java:896)
	at com.powsybl.dataframe.BaseDataframeMapperBuilder.lambda$itemGetter$2(BaseDataframeMapperBuilder.java:53)
	at com.powsybl.dataframe.network.NetworkDataframeMapperBuilder$1.getItem(NetworkDataframeMapperBuilder.java:66)
	at com.powsybl.dataframe.network.NetworkDataframeMapperBuilder$1.getItem(NetworkDataframeMapperBuilder.java:58)
	at com.powsybl.dataframe.AbstractDataframeMapper.updateSeries(AbstractDataframeMapper.java:136)
	at com.powsybl.python.PyPowsyblNetworkApiLib.lambda$updateNetworkElementsWithSeries$17(PyPowsyblNetworkApiLib.java:360)
	at com.powsybl.python.Util.doCatch(Util.java:49)
	at com.powsybl.python.PyPowsyblNetworkApiLib.updateNetworkElementsWithSeries(PyPowsyblNetworkApiLib.java:357)

```

