### PR TITLE
add min/max_q_at_p for vsc stations

### DIFF
--- a/java/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -83,7 +83,7 @@ public final class NetworkDataframes {
         return inj -> inj.getTerminal().getP();
     }
 
-    static <U extends Injection<U>> ToDoubleFunction<U> getOppositeP() {
+    static <U extends Injection> ToDoubleFunction<U> getOppositeP() {
         return inj -> -inj.getTerminal().getP();
     }
 
@@ -140,14 +140,14 @@ public final class NetworkDataframes {
         return reactiveLimits instanceof MinMaxReactiveLimits ? (MinMaxReactiveLimits) reactiveLimits : null;
     }
 
-    static ToDoubleFunction<Generator> getMinQ(ToDoubleFunction<Generator> pGetter) {
+    static <U extends ReactiveLimitsHolder> ToDoubleFunction<U> getMinQ(ToDoubleFunction<U> pGetter) {
         return g -> {
             ReactiveLimits reactiveLimits = g.getReactiveLimits();
             return (reactiveLimits == null) ? Double.NaN : reactiveLimits.getMinQ(pGetter.applyAsDouble(g));
         };
     }
 
-    static ToDoubleFunction<Generator> getMaxQ(ToDoubleFunction<Generator> pGetter) {
+    static <U extends ReactiveLimitsHolder> ToDoubleFunction<U> getMaxQ(ToDoubleFunction<U> pGetter) {
         return g -> {
             ReactiveLimits reactiveLimits = g.getReactiveLimits();
             return (reactiveLimits == null) ? Double.NaN : reactiveLimits.getMaxQ(pGetter.applyAsDouble(g));
@@ -588,6 +588,8 @@ public final class NetworkDataframes {
                 .stringsIndex("id", VscConverterStation::getId)
                 .strings("name", st -> st.getOptionalName().orElse(""))
                 .doubles("loss_factor", VscConverterStation::getLossFactor, (vscConverterStation, lf) -> vscConverterStation.setLossFactor((float) lf))
+                .doubles("min_q_at_p", getMinQ(getOppositeP()), false)
+                .doubles("max_q_at_p", getMaxQ(getOppositeP()), false)
                 .doubles("target_v", VscConverterStation::getVoltageSetpoint, VscConverterStation::setVoltageSetpoint)
                 .doubles("target_q", VscConverterStation::getReactivePowerSetpoint, VscConverterStation::setReactivePowerSetpoint)
                 .booleans("voltage_regulator_on", VscConverterStation::isVoltageRegulatorOn, VscConverterStation::setVoltageRegulatorOn)

--- a/java/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
+++ b/java/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
@@ -131,14 +131,14 @@ class NetworkDataframesTest {
     @Test
     void generatorsDisconnected() {
         Network network = EurostagTutorialExample1Factory.create();
-        Map<String, Series> attributes =  createDataFrame(GENERATOR, network, new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()))
+        Map<String, Series> attributes = createDataFrame(GENERATOR, network, new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()))
                 .stream().collect(ImmutableMap.toImmutableMap(Series::getName, Function.identity()));
         assertThat(attributes.get("bus_id").getStrings()).containsExactly("VLGEN_0");
         assertThat(attributes.get("bus_breaker_bus_id").getStrings()).containsExactly("NGEN");
         assertThat(attributes.get("connected").getBooleans()).containsExactly(true);
 
         network.getGenerator("GEN").getTerminal().disconnect();
-        attributes =  createDataFrame(GENERATOR, network, new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()))
+        attributes = createDataFrame(GENERATOR, network, new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()))
                 .stream().collect(ImmutableMap.toImmutableMap(Series::getName, Function.identity()));
         assertThat(attributes.get("bus_id").getStrings()).containsExactly("");
         assertThat(attributes.get("bus_breaker_bus_id").getStrings()).containsExactly("NGEN");
@@ -281,7 +281,7 @@ class NetworkDataframesTest {
         List<Series> allAttributeSeries = createDataFrame(VSC_CONVERTER_STATION, network, new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()));
         assertThat(allAttributeSeries)
                 .extracting(Series::getName)
-                .containsExactly("id", "name", "loss_factor", "target_v", "target_q", "voltage_regulator_on", "regulated_element_id",
+                .containsExactly("id", "name", "loss_factor", "min_q_at_p", "max_q_at_p", "target_v", "target_q", "voltage_regulator_on", "regulated_element_id",
                         "p", "q", "i", "voltage_level_id", "bus_id", "bus_breaker_bus_id", "node", "connected");
     }
 
@@ -396,7 +396,14 @@ class NetworkDataframesTest {
 
         assertThat(series)
                 .extracting(Series::getName)
-                .containsExactly("id", "name", "b_min", "b_max", "target_v", "target_q", "regulation_mode", "regulated_element_id", "p", "q", "i", "voltage_level_id", "bus_id", "connected");
+                .containsExactly("id", "name", "b_min", "b_max", "target_v", "target_q", "regulation_mode", "regulated_element_id",
+                        "p", "q", "i", "voltage_level_id", "bus_id", "connected");
+        List<Series> allAttributeSeries = createDataFrame(STATIC_VAR_COMPENSATOR, network, new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()));
+        assertThat(allAttributeSeries)
+                .extracting(Series::getName)
+                .containsExactly("id", "name", "b_min", "b_max", "target_v", "target_q", "regulation_mode",
+                        "regulated_element_id", "p", "q", "i", "voltage_level_id", "bus_id", "bus_breaker_bus_id",
+                        "node", "connected");
     }
 
     @Test

--- a/pypowsybl/network.py
+++ b/pypowsybl/network.py
@@ -502,16 +502,25 @@ class Network:  # pylint: disable=too-many-public-methods
               - **target_p**: the target active value for the generator (in MW)
               - **max_p**: the maximum active value for the generator  (MW)
               - **min_p**: the minimum active value for the generator  (MW)
+              - **max_q**: the maximum reactive value for the generator only if reactive_limits_kind is MIN_MAX (MVar)
+              - **min_q**: the minimum reactive value for the generator only if reactive_limits_kind is MIN_MAX (MVar)
+              - **max_q_at_target_p** (optional): the maximum reactive value for the generator for the target p specified (MVar)
+              - **min_q_at_target_p** (optional): the minimum reactive value for the generator for the target p specified (MVar)
+              - **max_q_at_p** (optional): the maximum reactive value for the generator at current p (MVar)
+              - **min_q_at_p** (optional): the minimum reactive value for the generator at current p (MVar)
+              - **reactive_limits_kind**: type of the reactive limit of the generator (can be MIN_MAX, CURVE or NONE)
               - **target_v**: the target voltage magnitude value for the generator (in kV)
               - **target_q**: the target reactive value for the generator (in MVAr)
               - **voltage_regulator_on**: ``True`` if the generator regulates voltage
               - **regulated_element_id**: the ID of the network element where voltage is regulated
               - **p**: the actual active production of the generator (``NaN`` if no loadflow has been computed)
               - **q**: the actual reactive production of the generator (``NaN`` if no loadflow has been computed)
+              - **i**: the current on the load, ``NaN`` if no loadflow has been computed (in A)
               - **voltage_level_id**: at which substation this generator is connected
               - **bus_id**: bus where this generator is connected
               - **bus_breaker_bus_id** (optional): bus of the bus-breaker view where this generator is connected
               - **node**  (optional): node where this generator is connected, in node-breaker voltage levels
+              - **connected**: ``True`` if the generator is connected to a bus
 
             This dataframe is indexed on the generator ID.
 
@@ -1202,6 +1211,8 @@ class Network:  # pylint: disable=too-many-public-methods
               - **loss_factor**: correspond to the loss of power due to ac dc conversion
               - **target_v**: The voltage setpoint
               - **target_q**: The reactive power setpoint
+              - **max_q_at_p** (optional): the maximum reactive value for the generator at current p (MVar)
+              - **min_q_at_p** (optional): the minimum reactive value for the generator at current p (MVar)
               - **voltage_regulator_on**: The voltage regulator status
               - **regulated_element_id**: The ID of the network element where voltage is regulated
               - **p**: active flow on the VSC  converter station, ``NaN`` if no loadflow has been computed (in MW)


### PR DESCRIPTION
Signed-off-by: Etienne LESOT <etienne.lesot@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

feature 

**What is the new behavior (if this is a feature change)?**

add two new attributs to vsc stations dataframe min and max_q_at_p. 
