### PR TITLE
add min max limits for vsc and batteries

### DIFF
--- a/java/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -154,7 +154,7 @@ public final class NetworkDataframes {
         };
     }
 
-    static DoubleUpdater<Generator> setMinQ() {
+    static <U extends ReactiveLimitsHolder> DoubleUpdater<U> setMinQ() {
         return (g, minQ) -> {
             MinMaxReactiveLimits minMaxReactiveLimits = getMinMaxReactiveLimits(g);
             if (minMaxReactiveLimits != null) {
@@ -166,7 +166,7 @@ public final class NetworkDataframes {
         };
     }
 
-    static DoubleUpdater<Generator> setMaxQ() {
+    static <U extends ReactiveLimitsHolder> DoubleUpdater<U> setMaxQ() {
         return (g, maxQ) -> {
             MinMaxReactiveLimits minMaxReactiveLimits = getMinMaxReactiveLimits(g);
             if (minMaxReactiveLimits != null) {
@@ -327,6 +327,8 @@ public final class NetworkDataframes {
                 .strings("name", b -> b.getOptionalName().orElse(""))
                 .doubles("max_p", Battery::getMaxP, Battery::setMaxP)
                 .doubles("min_p", Battery::getMinP, Battery::setMinP)
+                .doubles("min_q", ifExistsDouble(NetworkDataframes::getMinMaxReactiveLimits, MinMaxReactiveLimits::getMinQ), setMinQ())
+                .doubles("max_q", ifExistsDouble(NetworkDataframes::getMinMaxReactiveLimits, MinMaxReactiveLimits::getMaxQ), setMaxQ())
                 .doubles("p0", Battery::getP0, Battery::setP0)
                 .doubles("q0", Battery::getQ0, Battery::setQ0)
                 .doubles("p", getP(), setP())
@@ -588,6 +590,8 @@ public final class NetworkDataframes {
                 .stringsIndex("id", VscConverterStation::getId)
                 .strings("name", st -> st.getOptionalName().orElse(""))
                 .doubles("loss_factor", VscConverterStation::getLossFactor, (vscConverterStation, lf) -> vscConverterStation.setLossFactor((float) lf))
+                .doubles("min_q", ifExistsDouble(NetworkDataframes::getMinMaxReactiveLimits, MinMaxReactiveLimits::getMinQ), setMinQ())
+                .doubles("max_q", ifExistsDouble(NetworkDataframes::getMinMaxReactiveLimits, MinMaxReactiveLimits::getMaxQ), setMaxQ())
                 .doubles("min_q_at_p", getMinQ(getOppositeP()), false)
                 .doubles("max_q_at_p", getMaxQ(getOppositeP()), false)
                 .doubles("target_v", VscConverterStation::getVoltageSetpoint, VscConverterStation::setVoltageSetpoint)

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/MinMaxReactiveLimitsDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/MinMaxReactiveLimitsDataframeAdder.java
@@ -11,8 +11,7 @@ import com.powsybl.dataframe.SeriesMetadata;
 import com.powsybl.dataframe.update.DoubleSeries;
 import com.powsybl.dataframe.update.StringSeries;
 import com.powsybl.dataframe.update.UpdatingDataframe;
-import com.powsybl.iidm.network.Generator;
-import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.*;
 
 import java.util.Collections;
 import java.util.List;
@@ -74,10 +73,11 @@ public class MinMaxReactiveLimitsDataframeAdder implements NetworkElementAdder {
     }
 
     private static void createLimits(Network network, String elementId, double minQ, double maxQ) {
-        Generator generator = network.getGenerator(elementId);
-        if (generator == null) {
-            throw new PowsyblException("Generator " + elementId + " does not exist.");
+        Identifiable identifiable = network.getIdentifiable(elementId);
+        if (identifiable instanceof ReactiveLimitsHolder) {
+            ((ReactiveLimitsHolder) identifiable).newMinMaxReactiveLimits().setMinQ(minQ).setMaxQ(maxQ).add();
+        } else {
+            throw new PowsyblException("Element " + elementId + " does not have reactive limits.");
         }
-        generator.newMinMaxReactiveLimits().setMinQ(minQ).setMaxQ(maxQ).add();
     }
 }

--- a/java/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
+++ b/java/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
@@ -182,11 +182,11 @@ class NetworkDataframesTest {
         List<Series> series = createDataFrame(BATTERY, network);
         assertThat(series)
                 .extracting(Series::getName)
-                .containsExactly("id", "name", "max_p", "min_p", "p0", "q0", "p", "q", "i", "voltage_level_id", "bus_id", "connected");
+                .containsExactly("id", "name", "max_p", "min_p", "min_q", "max_q", "p0", "q0", "p", "q", "i", "voltage_level_id", "bus_id", "connected");
         List<Series> allAttributeSeries = createDataFrame(BATTERY, network, new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()));
         assertThat(allAttributeSeries)
                 .extracting(Series::getName)
-                .containsExactly("id", "name", "max_p", "min_p", "p0", "q0", "p", "q", "i", "voltage_level_id",
+                .containsExactly("id", "name", "max_p", "min_p", "min_q", "max_q", "p0", "q0", "p", "q", "i", "voltage_level_id",
                         "bus_id", "bus_breaker_bus_id", "node", "connected");
     }
 
@@ -276,12 +276,12 @@ class NetworkDataframesTest {
 
         assertThat(series)
                 .extracting(Series::getName)
-                .containsExactly("id", "name", "loss_factor", "target_v", "target_q", "voltage_regulator_on", "regulated_element_id",
+                .containsExactly("id", "name", "loss_factor", "min_q", "max_q", "target_v", "target_q", "voltage_regulator_on", "regulated_element_id",
                         "p", "q", "i", "voltage_level_id", "bus_id", "connected");
         List<Series> allAttributeSeries = createDataFrame(VSC_CONVERTER_STATION, network, new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()));
         assertThat(allAttributeSeries)
                 .extracting(Series::getName)
-                .containsExactly("id", "name", "loss_factor", "min_q_at_p", "max_q_at_p", "target_v", "target_q", "voltage_regulator_on", "regulated_element_id",
+                .containsExactly("id", "name", "loss_factor", "min_q", "max_q", "min_q_at_p", "max_q_at_p", "target_v", "target_q", "voltage_regulator_on", "regulated_element_id",
                         "p", "q", "i", "voltage_level_id", "bus_id", "bus_breaker_bus_id", "node", "connected");
     }
 

--- a/pypowsybl/network.py
+++ b/pypowsybl/network.py
@@ -618,6 +618,7 @@ class Network:  # pylint: disable=too-many-public-methods
               - **bus_id**: bus where this load is connected
               - **bus_breaker_bus_id** (optional): bus of the bus-breaker view where this load is connected
               - **node**  (optional): node where this load is connected, in node-breaker voltage levels
+              - **connected**: ``True`` if the load is connected to a bus
 
             This dataframe is indexed on the load ID.
 
@@ -709,6 +710,27 @@ class Network:  # pylint: disable=too-many-public-methods
 
         Returns:
             A dataframe of batteries.
+
+        Notes:
+            The resulting dataframe, depending on the parameters, will include the following columns:
+
+              - **name**: type of load
+              - **max_p**: the maximum active value for the battery  (MW)
+              - **min_p**: the minimum active value for the battery  (MW)
+              - **min_q**: the maximum reactive value for the battery only if reactive_limits_kind is MIN_MAX (MVar)
+              - **max_q**: the minimum reactive value for the battery only if reactive_limits_kind is MIN_MAX (MVar)
+              - **p0**: The active power setpoint  (MVAr)
+              - **q0**: The reactive power setpoint  (MVAr)
+              - **p**: the result active battery consumption, it is ``NaN`` is not loadflow has been computed (MW)
+              - **q**: the result reactive battery consumption, it is ``NaN`` is not loadflow has been computed (MVAr)
+              - **i**: the current on the battery, ``NaN`` if no loadflow has been computed (in A)
+              - **voltage_level_id**: at which substation this load is connected
+              - **bus_id**: bus where this load is connected
+              - **bus_breaker_bus_id** (optional): bus of the bus-breaker view where this battery is connected
+              - **node**  (optional): node where this battery is connected, in node-breaker voltage levels
+              - **connected**: ``True`` if the battery is connected to a bus
+
+            This dataframe is indexed on the battery ID.
         """
         return self.get_elements(ElementType.BATTERY, all_attributes, attributes, **kwargs)
 
@@ -1211,6 +1233,8 @@ class Network:  # pylint: disable=too-many-public-methods
               - **loss_factor**: correspond to the loss of power due to ac dc conversion
               - **target_v**: The voltage setpoint
               - **target_q**: The reactive power setpoint
+              - **max_q**: the maximum reactive value for the generator only if reactive_limits_kind is MIN_MAX (MVar)
+              - **min_q**: the minimum reactive value for the generator only if reactive_limits_kind is MIN_MAX (MVar)
               - **max_q_at_p** (optional): the maximum reactive value for the generator at current p (MVar)
               - **min_q_at_p** (optional): the minimum reactive value for the generator at current p (MVar)
               - **voltage_regulator_on**: The voltage regulator status
@@ -2210,6 +2234,8 @@ class Network:  # pylint: disable=too-many-public-methods
             - `p0`
             - `q0`
             - `connected`
+            - `max_q`
+            - `min_q`
 
         See Also:
             :meth:`get_batteries`

--- a/pypowsybl/perunit.py
+++ b/pypowsybl/perunit.py
@@ -264,7 +264,7 @@ class PerUnitView:  # pylint: disable=too-many-public-methods
         """
         vsc_converter_stations = self._network.get_vsc_converter_stations()
         nominal_v = self._get_indexed_nominal_v(vsc_converter_stations)
-        self._per_unit_p(vsc_converter_stations, ['p', 'q', 'target_q'])
+        self._per_unit_p(vsc_converter_stations, ['p', 'q', 'target_q', 'max_q', 'min_q'])
         self._per_unit_i(vsc_converter_stations, ['i'], nominal_v)
         self._per_unit_v(vsc_converter_stations, ['target_v'], nominal_v)
         return vsc_converter_stations
@@ -339,7 +339,7 @@ class PerUnitView:  # pylint: disable=too-many-public-methods
         """
         batteries = self._network.get_batteries()
         nominal_v = self._get_indexed_nominal_v(batteries)
-        self._per_unit_p(batteries, ['p0', 'q0', 'p', 'q', 'min_p', 'max_p'])
+        self._per_unit_p(batteries, ['p0', 'q0', 'p', 'q', 'min_p', 'max_p', 'min_q', 'max_q'])
         self._per_unit_i(batteries, ['i'], nominal_v)
         return batteries
 
@@ -397,7 +397,7 @@ class PerUnitView:  # pylint: disable=too-many-public-methods
         """
         to_update = _adapt_to_dataframe(ElementType.BATTERY, df, **kwargs).copy()
         nominal_v = self._get_indexed_nominal_v(self._network.get_batteries())
-        self._un_per_unit_p(to_update, ['p0', 'q0', 'p', 'q', 'max_p', 'min_p'])
+        self._un_per_unit_p(to_update, ['p0', 'q0', 'p', 'q', 'max_p', 'min_p', 'min_q', 'max_q'])
         self._un_per_unit_i(to_update, ['i'], nominal_v)
         self._network.update_batteries(to_update)
 
@@ -419,7 +419,7 @@ class PerUnitView:  # pylint: disable=too-many-public-methods
         """
         to_update = _adapt_to_dataframe(ElementType.VSC_CONVERTER_STATION, df, **kwargs).copy()
         nominal_v = self._get_indexed_nominal_v(self._network.get_vsc_converter_stations())
-        self._un_per_unit_p(to_update, ['p', 'q', 'target_q'])
+        self._un_per_unit_p(to_update, ['p', 'q', 'target_q', 'max_q', 'min_q'])
         self._un_per_unit_i(to_update, ['i'], nominal_v)
         self._un_per_unit_v(to_update, ['target_v'], nominal_v)
         self._network.update_vsc_converter_stations(to_update)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -197,28 +197,31 @@ def test_vsc_data_frame():
     n = pp.network.create_four_substations_node_breaker_network()
     stations = n.get_vsc_converter_stations()
     expected = pd.DataFrame(index=pd.Series(name='id', data=['VSC1', 'VSC2']),
-                            columns=['name', 'loss_factor', 'target_v', 'target_q', 'voltage_regulator_on',
+                            columns=['name', 'loss_factor', 'min_q', 'max_q', 'target_v', 'target_q', 'voltage_regulator_on',
                                      'regulated_element_id', 'p', 'q', 'i', 'voltage_level_id',
                                      'bus_id',
                                      'connected'],
-                            data=[['VSC1', 1.1, 400, 500, True, 'VSC1', 10.11, -512.081, 739.27, 'S1VL2', 'S1VL2_0',
+                            data=[['VSC1', 1.1, NaN, NaN, 400, 500, True, 'VSC1', 10.11, -512.081, 739.27, 'S1VL2', 'S1VL2_0',
                                    True],
-                                  ['VSC2', 1.1, 0, 120, False, 'VSC2', -9.89, -120, 170.032, 'S2VL1', 'S2VL1_0',
+                                  ['VSC2', 1.1, -400, 500, 0, 120, False, 'VSC2', -9.89, -120, 170.032, 'S2VL1', 'S2VL1_0',
                                    True]])
     pd.testing.assert_frame_equal(expected, stations, check_dtype=False, atol=10 ** -2)
 
     stations2 = pd.DataFrame(data=[[300.0, 400.0, 'VSC2'], [1.0, 2.0, 'VSC1']],
                              columns=['target_v', 'target_q', 'regulated_element_id'], index=['VSC1', 'VSC2'])
     n.update_vsc_converter_stations(stations2)
+    stations3 = pd.DataFrame(data=[[-350, 400]],
+                             columns=['min_q', 'max_q'], index=['VSC2'])
+    n.update_vsc_converter_stations(stations3)
     stations = n.get_vsc_converter_stations()
     expected = pd.DataFrame(index=pd.Series(name='id', data=['VSC1', 'VSC2']),
-                            columns=['name', 'loss_factor', 'target_v', 'target_q', 'voltage_regulator_on',
+                            columns=['name', 'loss_factor', 'min_q', 'max_q', 'target_v', 'target_q', 'voltage_regulator_on',
                                      'regulated_element_id', 'p', 'q', 'i', 'voltage_level_id',
                                      'bus_id',
                                      'connected'],
-                            data=[['VSC1', 1.1, 300, 400, True, 'VSC2', 10.11, -512.081, 739.27, 'S1VL2', 'S1VL2_0',
+                            data=[['VSC1', 1.1, NaN, NaN, 300, 400, True, 'VSC2', 10.11, -512.081, 739.27, 'S1VL2', 'S1VL2_0',
                                    True],
-                                  ['VSC2', 1.1, 1, 2, False, 'VSC1', -9.89, -120, 170.032, 'S2VL1', 'S2VL1_0',
+                                  ['VSC2', 1.1, -350, 400, 1, 2, False, 'VSC1', -9.89, -120, 170.032, 'S2VL1', 'S2VL1_0',
                                    True]])
     pd.testing.assert_frame_equal(expected, stations, check_dtype=False, atol=10 ** -2)
     stations = n.get_vsc_converter_stations(attributes=['bus_breaker_bus_id', 'node'])
@@ -764,21 +767,22 @@ def test_dangling_lines():
 def test_batteries():
     n = util.create_battery_network()
     expected = pd.DataFrame(index=pd.Series(name='id', data=['BAT', 'BAT2']),
-                            columns=['name', 'max_p', 'min_p', 'p0', 'q0', 'p', 'q', 'i', 'voltage_level_id',
+                            columns=['name', 'max_p', 'min_p', 'min_q', 'max_q', 'p0', 'q0', 'p', 'q', 'i', 'voltage_level_id',
                                      'bus_id',
                                      'connected'],
-                            data=[['', 9999.99, -9999.99, 9999.99, 9999.99, -605, -225, NaN, 'VLBAT', 'VLBAT_0',
+                            data=[['', 9999.99, -9999.99, -9999.99, 9999.99, 9999.99, 9999.99, -605, -225, NaN, 'VLBAT', 'VLBAT_0',
                                    True],
-                                  ['', 200, -200, 100, 200, -605, -225, NaN, 'VLBAT', 'VLBAT_0', True]])
+                                  ['', 200, -200, NaN, NaN, 100, 200, -605, -225, NaN, 'VLBAT', 'VLBAT_0', True]])
     pd.testing.assert_frame_equal(expected, n.get_batteries(), check_dtype=False)
     n.update_batteries(pd.DataFrame(index=['BAT2'], columns=['p0', 'q0'], data=[[50, 100]]))
+    n.update_batteries(pd.DataFrame(index=['BAT'], columns=['min_q', 'max_q'], data=[[-500, 500]]))
     expected = pd.DataFrame(index=pd.Series(name='id', data=['BAT', 'BAT2']),
-                            columns=['name', 'max_p', 'min_p', 'p0', 'q0', 'p', 'q', 'i', 'voltage_level_id',
+                            columns=['name', 'max_p', 'min_p', 'min_q', 'max_q', 'p0', 'q0', 'p', 'q', 'i', 'voltage_level_id',
                                      'bus_id',
                                      'connected'],
-                            data=[['', 9999.99, -9999.99, 9999.99, 9999.99, -605, -225, NaN, 'VLBAT', 'VLBAT_0',
+                            data=[['', 9999.99, -9999.99, -500, 500, 9999.99, 9999.99, -605, -225, NaN, 'VLBAT', 'VLBAT_0',
                                    True],
-                                  ['', 200, -200, 50, 100, -605, -225, NaN, 'VLBAT', 'VLBAT_0', True]])
+                                  ['', 200, -200, NaN, NaN, 50, 100, -605, -225, NaN, 'VLBAT', 'VLBAT_0', True]])
     pd.testing.assert_frame_equal(expected, n.get_batteries(), check_dtype=False)
 
 

--- a/tests/test_network_elements_creation.py
+++ b/tests/test_network_elements_creation.py
@@ -629,17 +629,37 @@ def test_create_limits():
 
 
 def test_create_minmax_reactive_limits():
-    network = pn.create_eurostag_tutorial_example1_network()
+    network = pn.create_four_substations_node_breaker_network()
     network.create_minmax_reactive_limits(pd.DataFrame.from_records(index='id', data=[
-        {'id': 'GEN', 'min_q': -201.0, 'max_q': 201.0},
-        {'id': 'GEN2', 'min_q': -205.0, 'max_q': 205.0}
+        {'id': 'GH1', 'min_q': -201.0, 'max_q': 201.0},
+        {'id': 'GH2', 'min_q': -205.0, 'max_q': 205.0},
+        {'id': 'VSC1', 'min_q': -355.0, 'max_q': 405.0},
+        {'id': 'VSC2', 'min_q': -405.0, 'max_q': 505.0},
     ]))
     expected = pd.DataFrame.from_records(
         index='id',
         columns=['id', 'min_q', 'max_q'],
-        data=[['GEN', -201.0, 201.0],
-              ['GEN2', -205.0, 205.0]])
-    pd.testing.assert_frame_equal(expected, network.get_generators(attributes=['min_q', 'max_q']), check_dtype=False)
+        data=[['GH1', -201.0, 201.0],
+              ['GH2', -205.0, 205.0]])
+    pd.testing.assert_frame_equal(expected, network.get_generators(id=['GH1', 'GH2'], attributes=['min_q', 'max_q']), check_dtype=False)
+    expected = pd.DataFrame.from_records(
+        index='id',
+        columns=['id', 'min_q', 'max_q'],
+        data=[['VSC1', -355.0, 405.0],
+              ['VSC2', -405.0, 505.0]])
+    pd.testing.assert_frame_equal(expected, network.get_vsc_converter_stations(id=['VSC1', 'VSC2'], attributes=['min_q', 'max_q']),
+                                  check_dtype=False)
+    network = util.create_battery_network()
+    network.create_minmax_reactive_limits(pd.DataFrame.from_records(index='id', data=[
+        {'id': 'BAT', 'min_q': -201.0, 'max_q': 201.0}
+    ]))
+    expected = pd.DataFrame.from_records(
+        index='id',
+        columns=['id', 'min_q', 'max_q'],
+        data=[['BAT', -201.0, 201.0]])
+    pd.testing.assert_frame_equal(expected, network.get_batteries(id='BAT', attributes=['min_q', 'max_q']),
+                                  check_dtype=False)
+
 
 def test_create_curve_reactive_limits():
     network = pn.create_eurostag_tutorial_example1_network()

--- a/tests/test_per_unit.py
+++ b/tests/test_per_unit.py
@@ -243,20 +243,21 @@ def test_vsc_converter_stations_per_unit():
     n = per_unit_view(n, 100)
     expected = pd.DataFrame.from_records(
         index='id',
-        columns=['id', 'name', 'loss_factor', 'target_v', 'target_q', 'voltage_regulator_on', 'regulated_element_id',
+        columns=['id', 'name', 'loss_factor', 'min_q', 'max_q', 'target_v', 'target_q', 'voltage_regulator_on',
+                 'regulated_element_id',
                  'p', 'q', 'i', 'voltage_level_id', 'bus_id', 'connected'],
-        data=[['VSC1', 'VSC1', 1.1, 1, 5, True, 'VSC1', 0.10, -5.12, 5.12, 'S1VL2', 'S1VL2_0', True],
-              ['VSC2', 'VSC2', 1.1, 0, 1.2, False, 'VSC2', -0.1, -1.2, 1.18, 'S2VL1', 'S2VL1_0', True]])
+        data=[['VSC1', 'VSC1', 1.1, NaN, NaN, 1, 5, True, 'VSC1', 0.10, -5.12, 5.12, 'S1VL2', 'S1VL2_0', True],
+              ['VSC2', 'VSC2', 1.1, -4, 5, 0, 1.2, False, 'VSC2', -0.1, -1.2, 1.18, 'S2VL1', 'S2VL1_0', True]])
     pd.testing.assert_frame_equal(expected, n.get_vsc_converter_stations(), check_dtype=False, atol=10 ** -2)
     n.update_vsc_converter_stations(pd.DataFrame(data=[[3.0, 4.0], [1.0, 2.0]],
                                                  columns=['target_v', 'target_q'],
                                                  index=['VSC1', 'VSC2']))
     expected = pd.DataFrame.from_records(
         index='id',
-        columns=['id', 'name', 'loss_factor', 'target_v', 'target_q', 'voltage_regulator_on', 'regulated_element_id',
+        columns=['id', 'name', 'loss_factor', 'min_q', 'max_q', 'target_v', 'target_q', 'voltage_regulator_on', 'regulated_element_id',
                  'p', 'q', 'i', 'voltage_level_id', 'bus_id', 'connected'],
-        data=[['VSC1', 'VSC1', 1.1, 3, 4, True, 'VSC1', 0.10, -5.12, 5.12, 'S1VL2', 'S1VL2_0', True],
-              ['VSC2', 'VSC2', 1.1, 1, 2, False, 'VSC2', -0.1, -1.2, 1.18, 'S2VL1', 'S2VL1_0', True]])
+        data=[['VSC1', 'VSC1', 1.1, NaN, NaN, 3, 4, True, 'VSC1', 0.10, -5.12, 5.12, 'S1VL2', 'S1VL2_0', True],
+              ['VSC2', 'VSC2', 1.1, -4, 5, 1, 2, False, 'VSC2', -0.1, -1.2, 1.18, 'S2VL1', 'S2VL1_0', True]])
     pd.testing.assert_frame_equal(expected, n.get_vsc_converter_stations(), check_dtype=False, atol=10 ** -2)
 
 
@@ -359,21 +360,21 @@ def test_batteries():
     n = util.create_battery_network()
     n = per_unit_view(n, 100)
     expected = pd.DataFrame(index=pd.Series(name='id', data=['BAT', 'BAT2']),
-                            columns=['name', 'max_p', 'min_p', 'p0', 'q0', 'p', 'q', 'i', 'voltage_level_id',
+                            columns=['name', 'max_p', 'min_p', 'min_q', 'max_q', 'p0', 'q0', 'p', 'q', 'i', 'voltage_level_id',
                                      'bus_id',
                                      'connected'],
-                            data=[['', 100, -100, 100, 100, -6.05, -2.25, NaN, 'VLBAT', 'VLBAT_0', True],
-                                  ['', 2, -2, 1, 2, -6.05, -2.25, NaN, 'VLBAT', 'VLBAT_0', True]])
+                            data=[['', 100, -100, -100, 100, 100, 100, -6.05, -2.25, NaN, 'VLBAT', 'VLBAT_0', True],
+                                  ['', 2, -2, NaN, NaN, 1, 2, -6.05, -2.25, NaN, 'VLBAT', 'VLBAT_0', True]])
     pd.testing.assert_frame_equal(expected, n.get_batteries(), check_dtype=False, atol=10 ** -2)
     n.update_batteries(pd.DataFrame(data=[[50, -50, 50, 50, -7, -3]],
                                     columns=['max_p', 'min_p', 'p0', 'q0', 'p', 'q'],
                                     index=['BAT']))
     expected = pd.DataFrame(index=pd.Series(name='id', data=['BAT', 'BAT2']),
-                            columns=['name', 'max_p', 'min_p', 'p0', 'q0', 'p', 'q', 'i', 'voltage_level_id',
+                            columns=['name', 'max_p', 'min_p', 'min_q', 'max_q', 'p0', 'q0', 'p', 'q', 'i', 'voltage_level_id',
                                      'bus_id',
                                      'connected'],
-                            data=[['', 50, -50, 50, 50, -7, -3, NaN, 'VLBAT', 'VLBAT_0', True],
-                                  ['', 2, -2, 1, 2, -6.05, -2.25, NaN, 'VLBAT', 'VLBAT_0', True]])
+                            data=[['', 50, -50, -100, 100, 50, 50, -7, -3, NaN, 'VLBAT', 'VLBAT_0', True],
+                                  ['', 2, -2, NaN, NaN, 1, 2, -6.05, -2.25, NaN, 'VLBAT', 'VLBAT_0', True]])
     pd.testing.assert_frame_equal(expected, n.get_batteries(), check_dtype=False, atol=10 ** -2)
 
 


### PR DESCRIPTION
Signed-off-by: Etienne LESOT <etienne.lesot@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

feature


**What is the new behavior (if this is a feature change)?**

min_q and max_q attributes are now avalaible for vsc stations and batteries (get, create and update)
