### PR TITLE
JNI configuration for matrix exception

### DIFF
--- a/java/src/main/resources/META-INF/native-image/com.powsybl/powsybl-math/jni-config.json
+++ b/java/src/main/resources/META-INF/native-image/com.powsybl/powsybl-math/jni-config.json
@@ -2,5 +2,9 @@
 {
   "name":"com.powsybl.math.matrix.SparseMatrix",
   "methods":[{"name":"<init>","parameterTypes":["int","int","int[]","int[]","double[]"] }]
+},
+{
+  "name":"com.powsybl.math.matrix.MatrixException",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.String"] }]
 }
 ]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*

Matrix exceptions raised by native code end in an NPE instead,
leading to an obscure NPE for the user, instead of an explicit
solver failure:
```
022-05-24 16:07:34,726 - DEBUG - Start iteration 18
2022-05-24 16:07:34,726 - DEBUG - Jacobian matrix values updated in 124 us
2022-05-24 16:07:34,726 - DEBUG - java.lang.NullPointerException
java.util.concurrent.CompletionException: java.lang.NullPointerException
...
...
Caused by: java.lang.NullPointerException: null
at com.oracle.svm.jni.functions.JNIFunctions$Support.getMethodID(JNIFunctions.java:1105)
at com.oracle.svm.jni.functions.JNIFunctions$Support.access$000(JNIFunctions.java:980)
at com.oracle.svm.jni.functions.JNIFunctions.ThrowNew(JNIFunctions.java:807)
at com.powsybl.math.matrix.SparseLUDecomposition.update(SparseLUDecomposition.java)
at com.powsybl.math.matrix.SparseLUDecomposition.update(SparseLUDecomposition.java:88)
at com.powsybl.math.matrix.LUDecomposition.update(LUDecomposition.java:36)
```

**What is the new behavior (if this is a feature change)?**

In case of KLU failure in powsybl-math-native, the `MatrixException` is correctly thrown, and the user receives a "solver failure" status:
```
>>> pp.loadflow.run_ac(network, params)
[ComponentResult(connected_component_num=0, synchronous_component_num=0, status=SOLVER_FAILED, iteration_count=18, slack_bus_id='VL-113_0', slack_bus_active_power_mismatch=4565.1246242657135),
 ComponentResult(connected_component_num=1, synchronous_component_num=1, status=CONVERGED, iteration_count=3, slack_bus_id='VL-322_0', slack_bus_active_power_mismatch=-561.5569983769097)]
```

