### PR TITLE
More error messages at network element creation

### DIFF
--- a/java/src/main/java/com/powsybl/dataframe/network/adders/BatteryDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/BatteryDataframeAdder.java
@@ -17,6 +17,7 @@ import com.powsybl.iidm.network.Network;
 import java.util.Collections;
 import java.util.List;
 
+import static com.powsybl.dataframe.network.adders.NetworkUtils.getVoltageLevelOrThrow;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
 
 /**
@@ -65,7 +66,7 @@ public class BatteryDataframeAdder extends AbstractSimpleAdder {
         }
 
         void createBattery(Network network, int row) {
-            BatteryAdder batteryAdder = network.getVoltageLevel(voltageLevels.get(row))
+            BatteryAdder batteryAdder = getVoltageLevelOrThrow(network, voltageLevels.get(row))
                     .newBattery();
             setInjectionAttributes(batteryAdder, row);
             applyIfPresent(maxP, row, batteryAdder::setMaxP);

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/BusBarDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/BusBarDataframeAdder.java
@@ -17,6 +17,7 @@ import com.powsybl.iidm.network.Network;
 import java.util.Collections;
 import java.util.List;
 
+import static com.powsybl.dataframe.network.adders.NetworkUtils.getVoltageLevelOrThrow;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
 
 /**
@@ -53,7 +54,7 @@ public class BusBarDataframeAdder extends AbstractSimpleAdder {
         }
 
         void createBusBar(Network network, int row) {
-            BusbarSectionAdder adder = network.getVoltageLevel(voltageLevels.get(row))
+            BusbarSectionAdder adder = getVoltageLevelOrThrow(network, voltageLevels.get(row))
                     .getNodeBreakerView()
                     .newBusbarSection();
             setIdentifiableAttributes(adder, row);

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/BusDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/BusDataframeAdder.java
@@ -16,6 +16,8 @@ import com.powsybl.iidm.network.Network;
 import java.util.Collections;
 import java.util.List;
 
+import static com.powsybl.dataframe.network.adders.NetworkUtils.getVoltageLevelOrThrow;
+
 /**
  * @author Yichen TANG <yichen.tang at rte-france.com>
  * @author Etienne Lesot <etienne.lesot at rte-france.com>
@@ -47,7 +49,7 @@ public class BusDataframeAdder extends AbstractSimpleAdder {
         }
 
         void createBus(Network network, int row) {
-            BusAdder adder = network.getVoltageLevel(voltageLevels.get(row))
+            BusAdder adder = getVoltageLevelOrThrow(network, voltageLevels.get(row))
                     .getBusBreakerView()
                     .newBus();
             setIdentifiableAttributes(adder, row);

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/CurveReactiveLimitsDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/CurveReactiveLimitsDataframeAdder.java
@@ -15,6 +15,7 @@ import com.powsybl.iidm.network.*;
 
 import java.util.*;
 
+import static com.powsybl.dataframe.network.adders.NetworkUtils.getIdentifiableOrThrow;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.getRequiredDoubles;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.getRequiredStrings;
 
@@ -109,7 +110,7 @@ public class CurveReactiveLimitsDataframeAdder implements NetworkElementAdder {
     }
 
     private static void createLimits(Network network, String elementId, List<CurvePoint> curvePoints) {
-        Identifiable identifiable = network.getIdentifiable(elementId);
+        Identifiable identifiable = getIdentifiableOrThrow(network, elementId);
         if (identifiable instanceof ReactiveLimitsHolder) {
             ReactiveCapabilityCurveAdder curveAdder = ((ReactiveLimitsHolder) identifiable)
                     .newReactiveCapabilityCurve();

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/DanglingLineDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/DanglingLineDataframeAdder.java
@@ -17,6 +17,7 @@ import com.powsybl.iidm.network.Network;
 import java.util.Collections;
 import java.util.List;
 
+import static com.powsybl.dataframe.network.adders.NetworkUtils.getVoltageLevelOrThrow;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
 
 /**
@@ -71,7 +72,7 @@ public class DanglingLineDataframeAdder extends AbstractSimpleAdder {
         }
 
         void create(Network network, int row) {
-            DanglingLineAdder adder = network.getVoltageLevel(voltageLevels.get(row))
+            DanglingLineAdder adder = getVoltageLevelOrThrow(network, voltageLevels.get(row))
                     .newDanglingLine();
             setInjectionAttributes(adder, row);
             applyIfPresent(p0, row, adder::setP0);

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/GeneratorDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/GeneratorDataframeAdder.java
@@ -17,6 +17,7 @@ import com.powsybl.iidm.network.*;
 import java.util.Collections;
 import java.util.List;
 
+import static com.powsybl.dataframe.network.adders.NetworkUtils.getVoltageLevelOrThrow;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyBooleanIfPresent;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
 
@@ -77,7 +78,7 @@ public class GeneratorDataframeAdder extends AbstractSimpleAdder {
         }
 
         void create(Network network, int row) {
-            GeneratorAdder adder = network.getVoltageLevel(voltageLevels.get(row))
+            GeneratorAdder adder = getVoltageLevelOrThrow(network, voltageLevels.get(row))
                     .newGenerator();
             setInjectionAttributes(adder, row);
             applyIfPresent(maxP, row, adder::setMaxP);

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/LccStationDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/LccStationDataframeAdder.java
@@ -17,6 +17,7 @@ import com.powsybl.iidm.network.Network;
 import java.util.Collections;
 import java.util.List;
 
+import static com.powsybl.dataframe.network.adders.NetworkUtils.getVoltageLevelOrThrow;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
 
 /**
@@ -59,7 +60,7 @@ public class LccStationDataframeAdder extends AbstractSimpleAdder {
         }
 
         void create(Network network, int row) {
-            LccConverterStationAdder adder = network.getVoltageLevel(voltageLevels.get(row))
+            LccConverterStationAdder adder = getVoltageLevelOrThrow(network, voltageLevels.get(row))
                     .newLccConverterStation();
             setInjectionAttributes(adder, row);
             applyIfPresent(lossFactors, row, f -> adder.setLossFactor((float) f));

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/LoadDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/LoadDataframeAdder.java
@@ -18,6 +18,7 @@ import com.powsybl.iidm.network.Network;
 import java.util.Collections;
 import java.util.List;
 
+import static com.powsybl.dataframe.network.adders.NetworkUtils.getVoltageLevelOrThrow;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
 
 /**
@@ -64,7 +65,7 @@ public class LoadDataframeAdder extends AbstractSimpleAdder {
         }
 
         void create(Network network, int row) {
-            LoadAdder adder = network.getVoltageLevel(voltageLevels.get(row))
+            LoadAdder adder = getVoltageLevelOrThrow(network, voltageLevels.get(row))
                     .newLoad();
             setInjectionAttributes(adder, row);
             applyIfPresent(p0, row, adder::setP0);

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/MinMaxReactiveLimitsDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/MinMaxReactiveLimitsDataframeAdder.java
@@ -11,11 +11,14 @@ import com.powsybl.dataframe.SeriesMetadata;
 import com.powsybl.dataframe.update.DoubleSeries;
 import com.powsybl.dataframe.update.StringSeries;
 import com.powsybl.dataframe.update.UpdatingDataframe;
-import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.Identifiable;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.ReactiveLimitsHolder;
 
 import java.util.Collections;
 import java.util.List;
 
+import static com.powsybl.dataframe.network.adders.NetworkUtils.getIdentifiableOrThrow;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.getRequiredDoubles;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.getRequiredStrings;
 
@@ -73,7 +76,7 @@ public class MinMaxReactiveLimitsDataframeAdder implements NetworkElementAdder {
     }
 
     private static void createLimits(Network network, String elementId, double minQ, double maxQ) {
-        Identifiable identifiable = network.getIdentifiable(elementId);
+        Identifiable<?> identifiable = getIdentifiableOrThrow(network, elementId);
         if (identifiable instanceof ReactiveLimitsHolder) {
             ((ReactiveLimitsHolder) identifiable).newMinMaxReactiveLimits().setMinQ(minQ).setMaxQ(maxQ).add();
         } else {

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/NetworkElementAdders.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/NetworkElementAdders.java
@@ -29,7 +29,7 @@ public final class NetworkElementAdders {
             Map.entry(STATIC_VAR_COMPENSATOR, new SvcDataframeAdder()),
             Map.entry(TWO_WINDINGS_TRANSFORMER, new TwtDataframeAdder()),
             Map.entry(LOAD, new LoadDataframeAdder()),
-            Map.entry(VSC_CONVERTER_STATION, new VscDataframeAdder()),
+            Map.entry(VSC_CONVERTER_STATION, new VscStationDataframeAdder()),
             Map.entry(LCC_CONVERTER_STATION, new LccStationDataframeAdder()),
             Map.entry(BUSBAR_SECTION, new BusBarDataframeAdder()),
             Map.entry(DANGLING_LINE, new DanglingLineDataframeAdder()),

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/NetworkUtils.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/NetworkUtils.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.dataframe.network.adders;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.Identifiable;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.Substation;
+import com.powsybl.iidm.network.VoltageLevel;
+
+/**
+ * @author Sylvain Leclerc <sylvain.leclerc@rte-france.com>
+ */
+public final class NetworkUtils {
+
+    private NetworkUtils() {
+    }
+
+    public static VoltageLevel getVoltageLevelOrThrow(Network network, String id) {
+        VoltageLevel voltageLevel = network.getVoltageLevel(id);
+        if (voltageLevel == null) {
+            throw new PowsyblException("Voltage level " + id + " does not exist.");
+        }
+        return voltageLevel;
+    }
+
+    public static Substation getSubstationOrThrow(Network network, String id) {
+        Substation substation = network.getSubstation(id);
+        if (substation == null) {
+            throw new PowsyblException("Substation " + id + " does not exist.");
+        }
+        return substation;
+    }
+
+    public static Identifiable<?> getIdentifiableOrThrow(Network network, String id) {
+        Identifiable<?> identifiable = network.getIdentifiable(id);
+        if (identifiable == null) {
+            throw new PowsyblException("Network element " + id + " does not exist.");
+        }
+        return identifiable;
+    }
+}

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/ShuntDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/ShuntDataframeAdder.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.powsybl.dataframe.network.adders.NetworkUtils.getVoltageLevelOrThrow;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
 
 /**
@@ -127,7 +128,7 @@ public class ShuntDataframeAdder implements NetworkElementAdder {
             String voltageLevelId = voltageLevels.get(row);
             String shuntId = ids.get(row);
 
-            ShuntCompensatorAdder adder = network.getVoltageLevel(voltageLevelId)
+            ShuntCompensatorAdder adder = getVoltageLevelOrThrow(network, voltageLevelId)
                     .newShuntCompensator();
             setInjectionAttributes(adder, row);
             applyIfPresent(sectionCount, row, adder::setSectionCount);

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/SvcDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/SvcDataframeAdder.java
@@ -16,6 +16,7 @@ import com.powsybl.iidm.network.*;
 import java.util.Collections;
 import java.util.List;
 
+import static com.powsybl.dataframe.network.adders.NetworkUtils.getVoltageLevelOrThrow;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
 
 /**
@@ -67,7 +68,7 @@ public class SvcDataframeAdder extends AbstractSimpleAdder {
         }
 
         void create(Network network, int row) {
-            StaticVarCompensatorAdder adder = network.getVoltageLevel(voltageLevels.get(row))
+            StaticVarCompensatorAdder adder = getVoltageLevelOrThrow(network, voltageLevels.get(row))
                     .newStaticVarCompensator();
             setInjectionAttributes(adder, row);
             applyIfPresent(bMin, row, adder::setBmin);

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/SwitchDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/SwitchDataframeAdder.java
@@ -16,6 +16,7 @@ import com.powsybl.iidm.network.*;
 import java.util.Collections;
 import java.util.List;
 
+import static com.powsybl.dataframe.network.adders.NetworkUtils.getVoltageLevelOrThrow;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyBooleanIfPresent;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
 
@@ -74,7 +75,7 @@ public class SwitchDataframeAdder extends AbstractSimpleAdder {
         }
 
         void create(Network network, int row) {
-            VoltageLevel vl = network.getVoltageLevel(voltageLevels.get(row));
+            VoltageLevel vl = getVoltageLevelOrThrow(network, voltageLevels.get(row));
             TopologyKind kind = vl.getTopologyKind();
             if (kind == TopologyKind.NODE_BREAKER) {
                 VoltageLevel.NodeBreakerView.SwitchAdder adder = vl.getNodeBreakerView().newSwitch();

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/VoltageLevelDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/VoltageLevelDataframeAdder.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.dataframe.network.adders;
 
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.dataframe.SeriesMetadata;
 import com.powsybl.dataframe.update.DoubleSeries;
 import com.powsybl.dataframe.update.StringSeries;
@@ -53,9 +52,6 @@ public class VoltageLevelDataframeAdder extends AbstractSimpleAdder {
         VoltageLevelSeries(UpdatingDataframe dataframe) {
             super(dataframe);
             this.substations = dataframe.getStrings("substation_id");
-            if (this.substations == null) {
-                throw new PowsyblException("substation_id is missing");
-            }
             this.topologyKind = dataframe.getStrings("topology_kind");
             this.nominalV = dataframe.getDoubles("nominal_v");
             this.lowVoltageLimit = dataframe.getDoubles("low_voltage_limit");
@@ -63,8 +59,13 @@ public class VoltageLevelDataframeAdder extends AbstractSimpleAdder {
         }
 
         void create(Network network, int row) {
-            VoltageLevelAdder adder = network.getSubstation(substations.get(row))
-                    .newVoltageLevel();
+            VoltageLevelAdder adder;
+            if (this.substations != null) {
+                adder = network.getSubstation(substations.get(row))
+                        .newVoltageLevel();
+            } else {
+                adder = network.newVoltageLevel();
+            }
             setIdentifiableAttributes(adder, row);
             applyIfPresent(topologyKind, row, TopologyKind.class, adder::setTopologyKind);
             applyIfPresent(nominalV, row, adder::setNominalV);

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/VoltageLevelDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/VoltageLevelDataframeAdder.java
@@ -61,7 +61,7 @@ public class VoltageLevelDataframeAdder extends AbstractSimpleAdder {
         void create(Network network, int row) {
             VoltageLevelAdder adder;
             if (this.substations != null) {
-                adder = network.getSubstation(substations.get(row))
+                adder = NetworkUtils.getSubstationOrThrow(network, substations.get(row))
                         .newVoltageLevel();
             } else {
                 adder = network.newVoltageLevel();

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/VscStationDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/VscStationDataframeAdder.java
@@ -18,6 +18,7 @@ import com.powsybl.iidm.network.VscConverterStationAdder;
 import java.util.Collections;
 import java.util.List;
 
+import static com.powsybl.dataframe.network.adders.NetworkUtils.getVoltageLevelOrThrow;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyBooleanIfPresent;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
 
@@ -26,7 +27,7 @@ import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
  * @author Etienne Lesot <etienne.lesot at rte-france.com>
  * @author Sylvain Leclerc <sylvain.leclerc@rte-france.com>
  */
-public class VscDataframeAdder extends AbstractSimpleAdder {
+public class VscStationDataframeAdder extends AbstractSimpleAdder {
 
     private static final List<SeriesMetadata> METADATA = List.of(
             SeriesMetadata.stringIndex("id"),
@@ -67,7 +68,7 @@ public class VscDataframeAdder extends AbstractSimpleAdder {
         }
 
         void create(Network network, int row) {
-            VscConverterStationAdder adder = network.getVoltageLevel(voltageLevels.get(row))
+            VscConverterStationAdder adder = getVoltageLevelOrThrow(network, voltageLevels.get(row))
                     .newVscConverterStation();
             setInjectionAttributes(adder, row);
             applyIfPresent(lossFactors, row, f -> adder.setLossFactor((float) f));

--- a/pypowsybl/network.py
+++ b/pypowsybl/network.py
@@ -3628,7 +3628,7 @@ class Network:  # pylint: disable=too-many-public-methods
 
             - **id**: the identifier of the new voltage level
             - **substation_id**: the identifier of the substation which the new voltage level belongs to.
-              It must already exist. Can be null
+              Optional. If defined, the substation must already exist.
             - **name**: an optional human-readable name
             - **topology_kind**: the topology kind, BUS_BREAKER or NODE_BREAKER
             - **nominal_v**: the nominal voltage, in kV

--- a/pypowsybl/network.py
+++ b/pypowsybl/network.py
@@ -3628,7 +3628,7 @@ class Network:  # pylint: disable=too-many-public-methods
 
             - **id**: the identifier of the new voltage level
             - **substation_id**: the identifier of the substation which the new voltage level belongs to.
-              It must already exist.
+              It must already exist. Can be null
             - **name**: an optional human-readable name
             - **topology_kind**: the topology kind, BUS_BREAKER or NODE_BREAKER
             - **nominal_v**: the nominal voltage, in kV

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 #Change those options to get logs
-log_cli=true
-log_level=1
+log_cli=false
+log_level=ERROR

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 #Change those options to get logs
-log_cli=false
-log_level=ERROR
+log_cli=true
+log_level=1

--- a/tests/test_network_elements_creation.py
+++ b/tests/test_network_elements_creation.py
@@ -788,5 +788,24 @@ def test_creating_vl_without_substation():
     assert 'VLTEST2' in net.get_voltage_levels().index and 'VLTEST' in net.get_voltage_levels().index
 
 
+def check_unknown_voltage_level_error_message(fn):
+    with pytest.raises(PyPowsyblError) as exc:
+        fn(voltage_level_id='UNKNOWN', id='S')
+    assert exc.match('Voltage level UNKNOWN does not exist')
+
+
 def test_error_messages():
-    pass
+    network = pn.create_eurostag_tutorial_example1_network()
+    with pytest.raises(PyPowsyblError) as exc:
+        network.create_voltage_levels(id='VL', substation_id='UNKNOWN', nominal_v=400)
+    assert exc.match('Substation UNKNOWN does not exist')
+
+    check_unknown_voltage_level_error_message(network.create_loads)
+    check_unknown_voltage_level_error_message(network.create_generators)
+    check_unknown_voltage_level_error_message(network.create_switches)
+    check_unknown_voltage_level_error_message(network.create_static_var_compensators)
+    check_unknown_voltage_level_error_message(network.create_dangling_lines)
+    check_unknown_voltage_level_error_message(network.create_lcc_converter_stations)
+    check_unknown_voltage_level_error_message(network.create_vsc_converter_stations)
+
+

--- a/tests/test_network_elements_creation.py
+++ b/tests/test_network_elements_creation.py
@@ -786,3 +786,7 @@ def test_creating_vl_without_substation():
                               nominal_v=[225, 225],
                               topology_kind=['BUS_BREAKER', 'BUS_BREAKER'])
     assert 'VLTEST2' in net.get_voltage_levels().index and 'VLTEST' in net.get_voltage_levels().index
+
+
+def test_error_messages():
+    pass

--- a/tests/test_network_elements_creation.py
+++ b/tests/test_network_elements_creation.py
@@ -756,5 +756,33 @@ def test_remove_elements_switches():
     assert 'S1VL1_LD1_BREAKER' not in net.get_switches().index
     assert 'HVDC1' not in net.get_hvdc_lines().index
     assert 'TWT' not in net.get_2_windings_transformers().index
-    #assert 'S1' not in net.get_substations().index
-    #assert 'S1VL1' not in net.get_voltage_levels().index
+    # assert 'S1' not in net.get_substations().index
+    # assert 'S1VL1' not in net.get_voltage_levels().index
+
+
+def test_creating_vl_without_substation():
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+    logging.getLogger('powsybl').setLevel(1)
+    net = pypowsybl.network.create_four_substations_node_breaker_network()
+    df = pd.DataFrame.from_records(index='id', data=[{
+        'id': 'VLTEST',
+        'high_voltage_limit': 250,
+        'low_voltage_limit': 200,
+        'nominal_v': 225,
+        'topology_kind': 'BUS_BREAKER'
+    }])
+    net.create_voltage_levels(df)
+    assert 'VLTEST' in net.get_voltage_levels().index
+    net.create_voltage_levels(id='VLTEST2', high_voltage_limit=250,
+                              low_voltage_limit=200,
+                              nominal_v=225,
+                              topology_kind='BUS_BREAKER')
+    assert 'VLTEST2' in net.get_voltage_levels().index
+    net.remove_elements(['VLTEST', 'VLTEST2'])
+    assert 'VLTEST2' not in net.get_voltage_levels().index and 'VLTEST' not in net.get_voltage_levels().index
+    net.create_voltage_levels(id=['VLTEST', 'VLTEST2'], high_voltage_limit=[250, 250],
+                              low_voltage_limit=[200, 200],
+                              nominal_v=[225, 225],
+                              topology_kind=['BUS_BREAKER', 'BUS_BREAKER'])
+    assert 'VLTEST2' in net.get_voltage_levels().index and 'VLTEST' in net.get_voltage_levels().index


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Ambiguous bug/feature

**What is the current behavior?** *(You can also link to an open issue here)*

Using a non-existing container ID in network element creation raises an error with no message (null pointer on java side).

**What is the new behavior (if this is a feature change)?**

We get an explicit message such as:
```
Voltage level VL-2 does not exist.
```
