### PR TITLE
Docstring for merge method, and sequence as argument

### DIFF
--- a/pypowsybl/network.py
+++ b/pypowsybl/network.py
@@ -11,6 +11,7 @@ import sys as _sys
 import datetime as _datetime
 import warnings
 from typing import (
+    Sequence as _Sequence,
     List as _List,
     Set as _Set,
     Dict as _Dict,
@@ -2946,8 +2947,25 @@ class Network:  # pylint: disable=too-many-public-methods
         """
         return BusBreakerTopology(self._handle, voltage_level_id)
 
-    def merge(self, *networks: Network) -> None:
-        return _pp.merge(self._handle, [net._handle for net in networks])
+    def merge(self, networks: _Union[Network, _Sequence[Network]]) -> None:
+        """
+        Merges networks into this one.
+
+        Args:
+            networks:  List of networks to be merged into this one.
+
+        Examples:
+            If you have 3 networks, you can merge this way:
+
+            .. code-block:: python
+
+                network1.merge([network2, network3])
+
+            Note that network1 is modified: it absorbs network2 and network3.
+        """
+        if isinstance(networks, Network):
+            networks = [networks]
+        return _pp.merge(self._handle, [n._handle for n in networks])
 
     def _get_c_dataframes(self, dfs: _List[_Optional[_DataFrame]], metadata: _List[_List[_pp.SeriesMetadata]], **kwargs: _ArrayLike) -> _List[_Optional[_pp.Dataframe]]:
         c_dfs: _List[_Optional[_pp.Dataframe]] = []


### PR DESCRIPTION

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Documentation, API improvement.

**What is the current behavior?** *(You can also link to an open issue here)*

`network.merge` is not documented.
Also, it uses a variable sized argument, which is not useful and could harm the possibilities of API evolution in the future.

**What is the new behavior (if this is a feature change)?**

The method is now documented, and accepts a single network or a sequence of networks as an argument.

This is a breaking change:
```python
# Before
network1.merge(network2, network3)

# After
network1.merge([network2, network3])
```
