### PR TITLE
fix bus breaker id for switches

### DIFF
--- a/java/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -635,20 +635,20 @@ public final class NetworkDataframes {
                 .build();
     }
 
-    private static String getBus1Id(Switch s) {
+    private static String getBusBreakerBus1Id(Switch s) {
         VoltageLevel vl = s.getVoltageLevel();
-        if (vl.getTopologyKind() != TopologyKind.BUS_BREAKER) {
+        if (!s.isRetained()) {
             return "";
         }
-        return vl.getBusBreakerView().getBus1(s.getId()).getId();
+        return vl.getBusBreakerView().getBus1(s.getId()) != null ? vl.getBusBreakerView().getBus1(s.getId()).getId() : "";
     }
 
-    private static String getBus2Id(Switch s) {
+    private static String getBusBreakerBus2Id(Switch s) {
         VoltageLevel vl = s.getVoltageLevel();
-        if (vl.getTopologyKind() != TopologyKind.BUS_BREAKER) {
+        if (!s.isRetained()) {
             return "";
         }
-        return vl.getBusBreakerView().getBus2(s.getId()).getId();
+        return vl.getBusBreakerView().getBus2(s.getId()) != null ? vl.getBusBreakerView().getBus2(s.getId()).getId() : "";
     }
 
     private static int getNode1(Switch s) {
@@ -675,8 +675,8 @@ public final class NetworkDataframes {
                 .booleans("open", Switch::isOpen, Switch::setOpen)
                 .booleans("retained", Switch::isRetained, Switch::setRetained)
                 .strings("voltage_level_id", s -> s.getVoltageLevel().getId())
-                .strings("bus_breaker_bus1_id", NetworkDataframes::getBus1Id, false)
-                .strings("bus_breaker_bus2_id", NetworkDataframes::getBus2Id, false)
+                .strings("bus_breaker_bus1_id", NetworkDataframes::getBusBreakerBus1Id, false)
+                .strings("bus_breaker_bus2_id", NetworkDataframes::getBusBreakerBus2Id, false)
                 .ints("node1", NetworkDataframes::getNode1, false)
                 .ints("node2", NetworkDataframes::getNode2, false)
                 .addProperties()

--- a/java/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -640,7 +640,8 @@ public final class NetworkDataframes {
         if (!s.isRetained()) {
             return "";
         }
-        return vl.getBusBreakerView().getBus1(s.getId()) != null ? vl.getBusBreakerView().getBus1(s.getId()).getId() : "";
+        Bus bus = vl.getBusBreakerView().getBus1(s.getId());
+        return bus != null ? bus.getId() : "";
     }
 
     private static String getBusBreakerBus2Id(Switch s) {
@@ -648,7 +649,8 @@ public final class NetworkDataframes {
         if (!s.isRetained()) {
             return "";
         }
-        return vl.getBusBreakerView().getBus2(s.getId()) != null ? vl.getBusBreakerView().getBus2(s.getId()).getId() : "";
+        Bus bus = vl.getBusBreakerView().getBus2(s.getId());
+        return bus != null ? bus.getId() : "";
     }
 
     private static int getNode1(Switch s) {

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1355,13 +1355,16 @@ def test_validate():
 def test_switches_node_breaker_connection_info():
     n = pp.network.create_four_substations_node_breaker_network()
     switches = n.get_switches(attributes=['bus_breaker_bus1_id', 'bus_breaker_bus2_id', 'node1', 'node2'])
-    assert (switches['bus_breaker_bus1_id'] == '').all()
-    assert (switches['bus_breaker_bus2_id'] == '').all()
     assert (switches['node1'] >= 0).all()
     assert (switches['node2'] >= 0).all()
     disc = switches.loc['S1VL1_BBS_LD1_DISCONNECTOR']
     assert disc.node1 == 0
     assert disc.node2 == 1
+    breaker = switches.loc['S1VL1_LD1_BREAKER']
+    assert breaker.bus_breaker_bus1_id == 'S1VL1_0'
+    assert breaker.bus_breaker_bus2_id == 'S1VL1_2'
+    assert breaker.node1 == 1
+    assert breaker.node2 == 2
 
 
 def test_switches_bus_breaker_connection_info():


### PR DESCRIPTION
Signed-off-by: Etienne LESOT <etienne.lesot@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
for node breaker view the bus breaker bus id is missing


**What is the new behavior (if this is a feature change)?**
fix it
