### PR TITLE
Loadflow parameters class in c++ layer

### DIFF
--- a/cpp/src/bindings.cpp
+++ b/cpp/src/bindings.cpp
@@ -6,7 +6,7 @@
  */
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include "pybind11/numpy.h"
+#include <pybind11/numpy.h>
 #include "pypowsybl.h"
 #include "pylogging.h"
 

--- a/cpp/src/bindings.cpp
+++ b/cpp/src/bindings.cpp
@@ -286,81 +286,21 @@ PYBIND11_MODULE(_pypowsybl, m) {
 
     py::class_<pypowsybl::LoadFlowParameters>(m, "LoadFlowParameters")
             .def(py::init(&pypowsybl::createLoadFlowParameters))
-            .def_property("voltage_init_mode", [](const pypowsybl::LoadFlowParameters& p) {
-                return static_cast<pypowsybl::VoltageInitMode>(p.voltage_init_mode);
-            }, [](pypowsybl::LoadFlowParameters& p, pypowsybl::VoltageInitMode voltageInitMode) {
-                p.voltage_init_mode = voltageInitMode;
-            })
-            .def_property("transformer_voltage_control_on", [](const pypowsybl::LoadFlowParameters& p) {
-                return p.transformer_voltage_control_on;
-            }, [](pypowsybl::LoadFlowParameters& p, bool transformerVoltageControlOn) {
-                p.transformer_voltage_control_on = transformerVoltageControlOn;
-            })
-            .def_property("no_generator_reactive_limits", [](const pypowsybl::LoadFlowParameters& p) {
-                return p.no_generator_reactive_limits;
-            }, [](pypowsybl::LoadFlowParameters& p, bool noGeneratorReactiveLimits) {
-                p.no_generator_reactive_limits = noGeneratorReactiveLimits;
-            })
-            .def_property("phase_shifter_regulation_on", [](const pypowsybl::LoadFlowParameters& p) {
-                return p.phase_shifter_regulation_on;
-            }, [](pypowsybl::LoadFlowParameters& p, bool phaseShifterRegulationOn) {
-                p.phase_shifter_regulation_on = phaseShifterRegulationOn;
-            })
-            .def_property("twt_split_shunt_admittance", [](const pypowsybl::LoadFlowParameters& p) {
-                return p.twt_split_shunt_admittance;
-            }, [](pypowsybl::LoadFlowParameters& p, bool twtSplitShuntAdmittance) {
-                p.twt_split_shunt_admittance = twtSplitShuntAdmittance;
-            })
-            .def_property("simul_shunt", [](const pypowsybl::LoadFlowParameters& p) {
-                return p.simul_shunt;
-            }, [](pypowsybl::LoadFlowParameters& p, bool simulShunt) {
-                p.simul_shunt = simulShunt;
-            })
-            .def_property("read_slack_bus", [](const pypowsybl::LoadFlowParameters& p) {
-                return p.read_slack_bus;
-            }, [](pypowsybl::LoadFlowParameters& p, bool readSlackBus) {
-                p.read_slack_bus = readSlackBus;
-            })
-            .def_property("write_slack_bus", [](const pypowsybl::LoadFlowParameters& p) {
-                return p.write_slack_bus;
-            }, [](pypowsybl::LoadFlowParameters& p, bool writeSlackBus) {
-                p.write_slack_bus = writeSlackBus;
-            })
-            .def_property("distributed_slack", [](const pypowsybl::LoadFlowParameters& p) {
-                return p.distributed_slack;
-            }, [](pypowsybl::LoadFlowParameters& p, bool distributedSlack) {
-                p.distributed_slack = distributedSlack;
-            })
-            .def_property("balance_type", [](const pypowsybl::LoadFlowParameters& p) {
-                return static_cast<pypowsybl::BalanceType>(p.balance_type);
-            }, [](pypowsybl::LoadFlowParameters& p, pypowsybl::BalanceType balanceType) {
-                p.balance_type = balanceType;
-            })
-            .def_property("dc_use_transformer_ratio", [](const pypowsybl::LoadFlowParameters& p) {
-                return p.dc_use_transformer_ratio;
-            }, [](pypowsybl::LoadFlowParameters& p, bool dcUseTransformerRatio) {
-                p.dc_use_transformer_ratio = dcUseTransformerRatio;
-            })
-            .def_property("countries_to_balance", [](const pypowsybl::LoadFlowParameters& p) {
-                return p.countries_to_balance;
-            }, [](pypowsybl::LoadFlowParameters& p, const std::vector<std::string>& countriesToBalance) {
-                p.countries_to_balance = countriesToBalance;
-            })
-            .def_property("connected_component_mode", [](const pypowsybl::LoadFlowParameters& p) {
-                return static_cast<pypowsybl::ConnectedComponentMode>(p.connected_component_mode);
-            }, [](pypowsybl::LoadFlowParameters& p, pypowsybl::ConnectedComponentMode connectedComponentMode) {
-                p.connected_component_mode = connectedComponentMode;
-            })
-            .def_property("provider_parameters_keys", [](const pypowsybl::LoadFlowParameters& p) {
-                return p.provider_parameters_keys;
-            }, [](pypowsybl::LoadFlowParameters& p, const std::vector<std::string>& providerParametersKeys) {
-                p.provider_parameters_keys = providerParametersKeys;
-            })
-            .def_property("provider_parameters_values", [](const pypowsybl::LoadFlowParameters& p) {
-                return p.provider_parameters_values;
-            }, [](pypowsybl::LoadFlowParameters& p, const std::vector<std::string>& providerParametersValues) {
-                p.provider_parameters_values = providerParametersValues;
-            });
+            .def_readwrite("voltage_init_mode", &pypowsybl::LoadFlowParameters::voltage_init_mode)
+            .def_readwrite("transformer_voltage_control_on", &pypowsybl::LoadFlowParameters::transformer_voltage_control_on)
+            .def_readwrite("no_generator_reactive_limits", &pypowsybl::LoadFlowParameters::no_generator_reactive_limits)
+            .def_readwrite("phase_shifter_regulation_on", &pypowsybl::LoadFlowParameters::phase_shifter_regulation_on)
+            .def_readwrite("twt_split_shunt_admittance", &pypowsybl::LoadFlowParameters::twt_split_shunt_admittance)
+            .def_readwrite("simul_shunt", &pypowsybl::LoadFlowParameters::simul_shunt)
+            .def_readwrite("read_slack_bus", &pypowsybl::LoadFlowParameters::read_slack_bus)
+            .def_readwrite("write_slack_bus", &pypowsybl::LoadFlowParameters::write_slack_bus)
+            .def_readwrite("distributed_slack", &pypowsybl::LoadFlowParameters::distributed_slack)
+            .def_readwrite("balance_type", &pypowsybl::LoadFlowParameters::balance_type)
+            .def_readwrite("dc_use_transformer_ratio", &pypowsybl::LoadFlowParameters::dc_use_transformer_ratio)
+            .def_readwrite("countries_to_balance", &pypowsybl::LoadFlowParameters::countries_to_balance)
+            .def_readwrite("connected_component_mode", &pypowsybl::LoadFlowParameters::connected_component_mode)
+            .def_readwrite("provider_parameters_keys", &pypowsybl::LoadFlowParameters::provider_parameters_keys)
+            .def_readwrite("provider_parameters_values", &pypowsybl::LoadFlowParameters::provider_parameters_values);
 
     m.def("run_load_flow", &pypowsybl::runLoadFlow, "Run a load flow", py::call_guard<py::gil_scoped_release>(),
           py::arg("network"), py::arg("dc"), py::arg("parameters"), py::arg("provider"), py::arg("reporter"));

--- a/cpp/src/pypowsybl.cpp
+++ b/cpp/src/pypowsybl.cpp
@@ -273,7 +273,7 @@ void deleteLoadFlowParameters(load_flow_parameters* ptr) {
 }
 
 LoadFlowParameters::LoadFlowParameters(load_flow_parameters* src) {
-    voltage_init_mode = src->voltage_init_mode;
+    voltage_init_mode = static_cast<VoltageInitMode>(src->voltage_init_mode);
     transformer_voltage_control_on = (bool) src->transformer_voltage_control_on;
     no_generator_reactive_limits = (bool) src->no_generator_reactive_limits;
     phase_shifter_regulation_on = (bool) src->phase_shifter_regulation_on;
@@ -281,9 +281,9 @@ LoadFlowParameters::LoadFlowParameters(load_flow_parameters* src) {
     simul_shunt = (bool) src->simul_shunt;
     read_slack_bus = (bool) src->read_slack_bus;
     distributed_slack = (bool) src->distributed_slack;
-    balance_type = src->balance_type;
+    balance_type = static_cast<BalanceType>(src->balance_type);
     dc_use_transformer_ratio = (bool) src->dc_use_transformer_ratio;
-    connected_component_mode = src->connected_component_mode;
+    connected_component_mode = static_cast<ConnectedComponentMode>(src->connected_component_mode);
     copyCharPtrPtrToVector(src->countries_to_balance, src->countries_to_balance_count, countries_to_balance);
     copyCharPtrPtrToVector(src->provider_parameters_keys, src->provider_parameters_keys_count, provider_parameters_keys);
     copyCharPtrPtrToVector(src->provider_parameters_values, src->provider_parameters_values_count, provider_parameters_values);

--- a/cpp/src/pypowsybl.cpp
+++ b/cpp/src/pypowsybl.cpp
@@ -308,6 +308,7 @@ std::shared_ptr<load_flow_parameters> LoadFlowParameters::to_c_struct() const {
     res->provider_parameters_keys_count = provider_parameters_keys.size();
     res->provider_parameters_values = pypowsybl::copyVectorStringToCharPtrPtr(provider_parameters_values);
     res->provider_parameters_values_count = provider_parameters_values.size();
+    //Memory has been allocated here on C side, we need to clean it up on C side (not java side)
     return std::shared_ptr<load_flow_parameters>(res, [](load_flow_parameters* ptr){
         deleteLoadFlowParameters(ptr);
         delete ptr;
@@ -509,7 +510,8 @@ std::vector<std::string> getNetworkElementsIds(const JavaHandle& network, elemen
 LoadFlowParameters* createLoadFlowParameters() {
     load_flow_parameters* parameters_ptr = callJava<load_flow_parameters*>(::createLoadFlowParameters);
     auto parameters = std::shared_ptr<load_flow_parameters>(parameters_ptr, [](load_flow_parameters* ptr){
-        callJava(::freeLoadFlowParameters, ptr);
+       //Memory has been allocated on java side, we need to clean it up on java side
+       callJava(::freeLoadFlowParameters, ptr);
     });
     return new LoadFlowParameters(parameters.get());
 }

--- a/cpp/src/pypowsybl.cpp
+++ b/cpp/src/pypowsybl.cpp
@@ -280,6 +280,7 @@ LoadFlowParameters::LoadFlowParameters(load_flow_parameters* src) {
     twt_split_shunt_admittance = (bool) src->twt_split_shunt_admittance;
     simul_shunt = (bool) src->simul_shunt;
     read_slack_bus = (bool) src->read_slack_bus;
+    write_slack_bus = (bool) src->write_slack_bus;
     distributed_slack = (bool) src->distributed_slack;
     balance_type = static_cast<BalanceType>(src->balance_type);
     dc_use_transformer_ratio = (bool) src->dc_use_transformer_ratio;
@@ -298,6 +299,7 @@ std::shared_ptr<load_flow_parameters> LoadFlowParameters::to_c_struct() const {
     res->twt_split_shunt_admittance = (unsigned char) twt_split_shunt_admittance;
     res->simul_shunt = (unsigned char) simul_shunt;
     res->read_slack_bus = (unsigned char) read_slack_bus;
+    res->write_slack_bus = (unsigned char) write_slack_bus;
     res->distributed_slack = (unsigned char) distributed_slack;
     res->balance_type = balance_type;
     res->dc_use_transformer_ratio = (unsigned char) dc_use_transformer_ratio;

--- a/cpp/src/pypowsybl.cpp
+++ b/cpp/src/pypowsybl.cpp
@@ -261,6 +261,59 @@ std::string toString(char* cstring) {
     return res;
 }
 
+void copyCharPtrPtrToVector(char** src, int count, std::vector<std::string>& dest) {
+    dest.clear();
+    std::copy(src, src + count, std::back_inserter(dest));
+}
+
+void deleteLoadFlowParameters(load_flow_parameters* ptr) {
+    pypowsybl::deleteCharPtrPtr(ptr->countries_to_balance, ptr->countries_to_balance_count);
+    pypowsybl::deleteCharPtrPtr(ptr->provider_parameters_keys, ptr->provider_parameters_keys_count);
+    pypowsybl::deleteCharPtrPtr(ptr->provider_parameters_values, ptr->provider_parameters_values_count);
+}
+
+LoadFlowParameters::LoadFlowParameters(load_flow_parameters* src) {
+    voltage_init_mode = src->voltage_init_mode;
+    transformer_voltage_control_on = (bool) src->transformer_voltage_control_on;
+    no_generator_reactive_limits = (bool) src->no_generator_reactive_limits;
+    phase_shifter_regulation_on = (bool) src->phase_shifter_regulation_on;
+    twt_split_shunt_admittance = (bool) src->twt_split_shunt_admittance;
+    simul_shunt = (bool) src->simul_shunt;
+    read_slack_bus = (bool) src->read_slack_bus;
+    distributed_slack = (bool) src->distributed_slack;
+    balance_type = src->balance_type;
+    dc_use_transformer_ratio = (bool) src->dc_use_transformer_ratio;
+    connected_component_mode = src->connected_component_mode;
+    copyCharPtrPtrToVector(src->countries_to_balance, src->countries_to_balance_count, countries_to_balance);
+    copyCharPtrPtrToVector(src->provider_parameters_keys, src->provider_parameters_keys_count, provider_parameters_keys);
+    copyCharPtrPtrToVector(src->provider_parameters_values, src->provider_parameters_values_count, provider_parameters_values);
+}
+
+std::shared_ptr<load_flow_parameters> LoadFlowParameters::to_c_struct() const {
+    load_flow_parameters* res = new load_flow_parameters();
+    res->voltage_init_mode = voltage_init_mode;
+    res->transformer_voltage_control_on = (unsigned char) transformer_voltage_control_on;
+    res->no_generator_reactive_limits = (unsigned char) no_generator_reactive_limits;
+    res->phase_shifter_regulation_on = (unsigned char) phase_shifter_regulation_on;
+    res->twt_split_shunt_admittance = (unsigned char) twt_split_shunt_admittance;
+    res->simul_shunt = (unsigned char) simul_shunt;
+    res->read_slack_bus = (unsigned char) read_slack_bus;
+    res->distributed_slack = (unsigned char) distributed_slack;
+    res->balance_type = balance_type;
+    res->dc_use_transformer_ratio = (unsigned char) dc_use_transformer_ratio;
+    res->connected_component_mode = connected_component_mode;
+    res->countries_to_balance = pypowsybl::copyVectorStringToCharPtrPtr(countries_to_balance);
+    res->countries_to_balance_count = countries_to_balance.size();
+    res->provider_parameters_keys = pypowsybl::copyVectorStringToCharPtrPtr(provider_parameters_keys);
+    res->provider_parameters_keys_count = provider_parameters_keys.size();
+    res->provider_parameters_values = pypowsybl::copyVectorStringToCharPtrPtr(provider_parameters_values);
+    res->provider_parameters_values_count = provider_parameters_values.size();
+    return std::shared_ptr<load_flow_parameters>(res, [](load_flow_parameters* ptr){
+        deleteLoadFlowParameters(ptr);
+        delete ptr;
+    });
+}
+
 void setJavaLibraryPath(const std::string& javaLibraryPath) {
     callJava<>(::setJavaLibraryPath, (char*) javaLibraryPath.data());
 }
@@ -453,17 +506,19 @@ std::vector<std::string> getNetworkElementsIds(const JavaHandle& network, elemen
     return elementsIds.get();
 }
 
-std::shared_ptr<load_flow_parameters> createLoadFlowParameters() {
-    load_flow_parameters* parameters = callJava<load_flow_parameters*>(::createLoadFlowParameters);
-    return std::shared_ptr<load_flow_parameters>(parameters, [](load_flow_parameters* ptr){
+LoadFlowParameters* createLoadFlowParameters() {
+    load_flow_parameters* parameters_ptr = callJava<load_flow_parameters*>(::createLoadFlowParameters);
+    auto parameters = std::shared_ptr<load_flow_parameters>(parameters_ptr, [](load_flow_parameters* ptr){
         callJava(::freeLoadFlowParameters, ptr);
     });
+    return new LoadFlowParameters(parameters.get());
 }
 
-LoadFlowComponentResultArray* runLoadFlow(const JavaHandle& network, bool dc, const std::shared_ptr<load_flow_parameters>& parameters,
+LoadFlowComponentResultArray* runLoadFlow(const JavaHandle& network, bool dc, const LoadFlowParameters& parameters,
                                           const std::string& provider, JavaHandle* reporter) {
+    auto c_parameters = parameters.to_c_struct();
     return new LoadFlowComponentResultArray(
-            callJava<array*>(::runLoadFlow, network, dc, parameters.get(), (char *) provider.data(), (reporter == nullptr) ? nullptr : *reporter));
+            callJava<array*>(::runLoadFlow, network, dc, c_parameters.get(), (char *) provider.data(), (reporter == nullptr) ? nullptr : *reporter));
 }
 
 SeriesArray* runLoadFlowValidation(const JavaHandle& network, validation_type validationType) {
@@ -497,9 +552,10 @@ void addContingency(const JavaHandle& analysisContext, const std::string& contin
     callJava(::addContingency, analysisContext, (char*) contingencyId.data(), elementIdPtr.get(), elementsIds.size());
 }
 
-JavaHandle runSecurityAnalysis(const JavaHandle& securityAnalysisContext, const JavaHandle& network, load_flow_parameters& parameters,
+JavaHandle runSecurityAnalysis(const JavaHandle& securityAnalysisContext, const JavaHandle& network, const LoadFlowParameters& parameters,
                                             const std::string& provider, bool dc, JavaHandle* reporter) {
-    return callJava<JavaHandle>(::runSecurityAnalysis, securityAnalysisContext, network, &parameters, (char *) provider.data(), dc, (reporter == nullptr) ? nullptr : *reporter);
+    auto c_parameters = parameters.to_c_struct();
+    return callJava<JavaHandle>(::runSecurityAnalysis, securityAnalysisContext, network, c_parameters.get(), (char *) provider.data(), dc, (reporter == nullptr) ? nullptr : *reporter);
 }
 
 JavaHandle createSensitivityAnalysis() {
@@ -588,10 +644,10 @@ void setBusVoltageFactorMatrix(const JavaHandle& sensitivityAnalysisContext, con
                 busIds.size(), targetVoltageIdPtr.get(), targetVoltageIds.size());
 }
 
-JavaHandle runSensitivityAnalysis(const JavaHandle& sensitivityAnalysisContext, const JavaHandle& network, bool dc, load_flow_parameters& parameters, const std::string& provider, JavaHandle* reporter) {
-    return callJava<JavaHandle>(::runSensitivityAnalysis, sensitivityAnalysisContext, network, dc, &parameters, (char *) provider.data(), (reporter == nullptr) ? nullptr : *reporter);
+JavaHandle runSensitivityAnalysis(const JavaHandle& sensitivityAnalysisContext, const JavaHandle& network, bool dc, const LoadFlowParameters& parameters, const std::string& provider, JavaHandle* reporter) {
+    auto c_parameters = parameters.to_c_struct();
+    return callJava<JavaHandle>(::runSensitivityAnalysis, sensitivityAnalysisContext, network, dc, c_parameters.get(), (char *) provider.data(), (reporter == nullptr) ? nullptr : *reporter);
 }
-
 
 matrix* getBranchFlowsSensitivityMatrix(const JavaHandle& sensitivityAnalysisResultContext, const std::string& matrixId, const std::string& contingencyId) {
     return callJava<matrix*>(::getBranchFlowsSensitivityMatrix, sensitivityAnalysisResultContext,

--- a/cpp/src/pypowsybl.h
+++ b/cpp/src/pypowsybl.h
@@ -157,7 +157,7 @@ public:
 
     std::shared_ptr<load_flow_parameters> to_c_struct() const;
 
-    int voltage_init_mode;
+    VoltageInitMode voltage_init_mode;
     bool transformer_voltage_control_on;
     bool no_generator_reactive_limits;
     bool phase_shifter_regulation_on;
@@ -166,10 +166,10 @@ public:
     bool read_slack_bus;
     bool write_slack_bus;
     bool distributed_slack;
-    int balance_type;
+    BalanceType balance_type;
     bool dc_use_transformer_ratio;
     std::vector<std::string> countries_to_balance;
-    int connected_component_mode;
+    ConnectedComponentMode connected_component_mode;
     std::vector<std::string> provider_parameters_keys;
     std::vector<std::string> provider_parameters_values;
 };

--- a/cpp/src/pypowsybl.h
+++ b/cpp/src/pypowsybl.h
@@ -149,6 +149,32 @@ private:
     bool isDefault_;
 };
 
+
+//c++ layer to facilitate memory management compared to C struct
+class LoadFlowParameters {
+public:
+    LoadFlowParameters(load_flow_parameters* src);
+
+    std::shared_ptr<load_flow_parameters> to_c_struct() const;
+
+    int voltage_init_mode;
+    bool transformer_voltage_control_on;
+    bool no_generator_reactive_limits;
+    bool phase_shifter_regulation_on;
+    bool twt_split_shunt_admittance;
+    bool simul_shunt;
+    bool read_slack_bus;
+    bool write_slack_bus;
+    bool distributed_slack;
+    int balance_type;
+    bool dc_use_transformer_ratio;
+    std::vector<std::string> countries_to_balance;
+    int connected_component_mode;
+    std::vector<std::string> provider_parameters_keys;
+    std::vector<std::string> provider_parameters_values;
+};
+
+
 char* copyStringToCharPtr(const std::string& str);
 char** copyVectorStringToCharPtrPtr(const std::vector<std::string>& strings);
 int* copyVectorInt(const std::vector<int>& ints);
@@ -214,13 +240,13 @@ JavaHandle loadNetworkFromString(const std::string& fileName, const std::string&
 
 void dumpNetwork(const JavaHandle& network, const std::string& file, const std::string& format, const std::map<std::string, std::string>& parameters, JavaHandle* reporter);
 
-std::shared_ptr<load_flow_parameters> createLoadFlowParameters();
+LoadFlowParameters* createLoadFlowParameters();
 
 std::string dumpNetworkToString(const JavaHandle& network, const std::string& format, const std::map<std::string, std::string>& parameters, JavaHandle* reporter);
 
 void reduceNetwork(const JavaHandle& network, const double v_min, const double v_max, const std::vector<std::string>& ids, const std::vector<std::string>& vls, const std::vector<int>& depths, bool withDangLingLines);
 
-LoadFlowComponentResultArray* runLoadFlow(const JavaHandle& network, bool dc, const std::shared_ptr<load_flow_parameters>& parameters, const std::string& provider, JavaHandle* reporter);
+LoadFlowComponentResultArray* runLoadFlow(const JavaHandle& network, bool dc, const LoadFlowParameters& parameters, const std::string& provider, JavaHandle* reporter);
 
 SeriesArray* runLoadFlowValidation(const JavaHandle& network, validation_type validationType);
 
@@ -236,7 +262,7 @@ JavaHandle createSecurityAnalysis();
 
 void addContingency(const JavaHandle& analysisContext, const std::string& contingencyId, const std::vector<std::string>& elementsIds);
 
-JavaHandle runSecurityAnalysis(const JavaHandle& securityAnalysisContext, const JavaHandle& network, load_flow_parameters& parameters, const std::string& provider, bool dc, JavaHandle* reporter);
+JavaHandle runSecurityAnalysis(const JavaHandle& securityAnalysisContext, const JavaHandle& network, const LoadFlowParameters& parameters, const std::string& provider, bool dc, JavaHandle* reporter);
 
 JavaHandle createSensitivityAnalysis();
 
@@ -253,7 +279,7 @@ void addPostContingencyBranchFlowFactorMatrix(const JavaHandle& sensitivityAnaly
 
 void setBusVoltageFactorMatrix(const JavaHandle& sensitivityAnalysisContext, const std::vector<std::string>& busIds, const std::vector<std::string>& targetVoltageIds);
 
-JavaHandle runSensitivityAnalysis(const JavaHandle& sensitivityAnalysisContext, const JavaHandle& network, bool dc, load_flow_parameters& parameters, const std::string& provider, JavaHandle* reporter);
+JavaHandle runSensitivityAnalysis(const JavaHandle& sensitivityAnalysisContext, const JavaHandle& network, bool dc, const LoadFlowParameters& parameters, const std::string& provider, JavaHandle* reporter);
 
 matrix* getBranchFlowsSensitivityMatrix(const JavaHandle& sensitivityAnalysisResultContext, const std::string& matrixId, const std::string &contingencyId);
 

--- a/cpp/src/pypowsybl.h
+++ b/cpp/src/pypowsybl.h
@@ -150,11 +150,9 @@ private:
 };
 
 
-//c++ layer to facilitate memory management compared to C struct
 class LoadFlowParameters {
 public:
     LoadFlowParameters(load_flow_parameters* src);
-
     std::shared_ptr<load_flow_parameters> to_c_struct() const;
 
     VoltageInitMode voltage_init_mode;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Refactoring.

**What is the current behavior?** *(You can also link to an open issue here)*

LF parameters do not have a representation in the c++ layer, which breaks a little
the separation between c and c++ layers.
Also, handling the memory management of the C struct is difficult because
of this unclear separation.

**What is the new behavior (if this is a feature change)?**

We add a c++ representation of parameters, this allows to have a cleaner separation between layers
(c, c++, python bindings), and to have a more simple and robust memory management.

