### PR TITLE
Fix Pandas dependency version for MacOS ARM64

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # actual dependencies
-pandas==1.3.5
+pandas==1.4.4; sys_platform == "darwin" and platform_machine == "arm64"
+pandas==1.3.5; sys_platform != "darwin" or platform_machine != "arm64"
 prettytable==2.0.0
 networkx
 matplotlib


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Build fails on MacOS ARM64 (M1 or M2) because Pandas only support this platform for version >= 1.4.0.
On the other end, Pandas >= 1.4.0 do not support Python 3.7 anymore.

**What is the new behavior (if this is a feature change)?**
We use Pandas 1.4.4 for MacOS ARM64 and Pandas 1.3.5 for other platforms.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
