### PR TITLE
add default value for side in connectable position extension

### DIFF
--- a/java/src/main/java/com/powsybl/dataframe/network/extensions/ConnectablePositionDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/extensions/ConnectablePositionDataframeAdder.java
@@ -73,7 +73,7 @@ public class ConnectablePositionDataframeAdder extends AbstractSimpleAdder {
                 adder = (ConnectablePositionAdder) connectable.newExtension(ConnectablePositionAdder.class);
                 adderMap.put(this.id.get(row), adder);
             }
-            if (this.side.get(row).equals("")) {
+            if (this.side == null || this.side.get(row).equals("")) {
                 createFeeder(adder.newFeeder(), row);
             } else {
                 switch (SideEnum.valueOf(this.side.get(row))) {

--- a/java/src/main/java/com/powsybl/dataframe/network/extensions/ConnectablePositionDataframeProvider.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/extensions/ConnectablePositionDataframeProvider.java
@@ -37,7 +37,7 @@ public class ConnectablePositionDataframeProvider implements NetworkExtensionDat
         String id = dataframe.getStringValue("id", index)
                 .orElseThrow(() -> new IllegalArgumentException("id column is missing"));
         String side = dataframe.getStringValue("side", index)
-                .orElseThrow(() -> new IllegalArgumentException("side column is missing"));
+                .orElse("");
         Identifiable identifiable = network.getIdentifiable(id);
         Connectable connectable;
         if (identifiable instanceof Connectable) {

--- a/tests/test_network_extensions.py
+++ b/tests/test_network_extensions.py
@@ -296,6 +296,8 @@ def test_branch_observability():
 def test_connectable_position():
     n = pn.create_four_substations_node_breaker_network()
     extension_name = 'position'
+
+    # twt
     element_id = 'TWT'
     extensions = n.get_extensions(extension_name)
     assert extensions.empty
@@ -309,6 +311,14 @@ def test_connectable_position():
 
     n.remove_extensions(extension_name, [element_id])
     assert n.get_extensions(extension_name).empty
+
+    # load
+    n.create_extensions(extension_name, id="LD1", order=3, feeder_name='test', direction='UNDEFINED')
+    e = n.get_extensions(extension_name).loc["LD1"]
+    assert e.order == 3
+    assert e.feeder_name == 'test'
+    assert e.direction == 'UNDEFINED'
+    assert e.side == ''
 
 
 def test_busbar_section_position():


### PR DESCRIPTION
Signed-off-by: Etienne LESOT <etienne.lesot@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
side must be provided when creating a connectable position extension


**What is the new behavior (if this is a feature change)?**
side by default is none