### PR TITLE
[WIP] Fix JavaHandle memory leak

### DIFF
--- a/cpp/src/pypowsybl.cpp
+++ b/cpp/src/pypowsybl.cpp
@@ -93,7 +93,7 @@ T callJava(F f, ARGS... args) {
 
     setLogLevelFromPythonLogger(&guard, &exc);
 
-    auto r = f(guard.thread(), args..., &exc);
+    T r = f(guard.thread(), args..., &exc);
     if (exc.message) {
         throw PyPowsyblError(toString(exc.message));
     }
@@ -469,7 +469,7 @@ std::string getVersionTable() {
 }
 
 JavaHandle createNetwork(const std::string& name, const std::string& id) {
-    return callJava<JavaHandle>(::createNetwork, (char*) name.data(), (char*) id.data());
+    return JavaHandle(callJava<void*>(::createNetwork, (char*) name.data(), (char*) id.data()));
 }
 
 void merge(JavaHandle network, std::vector<JavaHandle>& others) {
@@ -541,8 +541,8 @@ JavaHandle loadNetwork(const std::string& file, const std::map<std::string, std:
     }
     ToCharPtrPtr parameterNamesPtr(parameterNames);
     ToCharPtrPtr parameterValuesPtr(parameterValues);
-    return callJava<JavaHandle>(::loadNetwork, (char*) file.data(), parameterNamesPtr.get(), parameterNames.size(),
-                              parameterValuesPtr.get(), parameterValues.size(), (reporter == nullptr) ? nullptr : *reporter);
+    return JavaHandle(callJava<void*>(::loadNetwork, (char*) file.data(), parameterNamesPtr.get(), parameterNames.size(),
+                              parameterValuesPtr.get(), parameterValues.size(), (reporter == nullptr) ? nullptr : *reporter));
 }
 
 JavaHandle loadNetworkFromString(const std::string& fileName, const std::string& fileContent, const std::map<std::string, std::string>& parameters, JavaHandle* reporter) {
@@ -556,9 +556,9 @@ JavaHandle loadNetworkFromString(const std::string& fileName, const std::string&
     }
     ToCharPtrPtr parameterNamesPtr(parameterNames);
     ToCharPtrPtr parameterValuesPtr(parameterValues);
-    return callJava<JavaHandle>(::loadNetworkFromString, (char*) fileName.data(), (char*) fileContent.data(),
+    return JavaHandle(callJava<void*>(::loadNetworkFromString, (char*) fileName.data(), (char*) fileContent.data(),
                            parameterNamesPtr.get(), parameterNames.size(),
-                           parameterValuesPtr.get(), parameterValues.size(), (reporter == nullptr) ? nullptr : *reporter);
+                           parameterValuesPtr.get(), parameterValues.size(), (reporter == nullptr) ? nullptr : *reporter));
 }
 
 void dumpNetwork(const JavaHandle& network, const std::string& file, const std::string& format, const std::map<std::string, std::string>& parameters, JavaHandle* reporter) {
@@ -676,7 +676,7 @@ std::string getNetworkAreaDiagramSvg(const JavaHandle& network, const std::vecto
 }
 
 JavaHandle createSecurityAnalysis() {
-    return callJava<JavaHandle>(::createSecurityAnalysis);
+    return JavaHandle(callJava<void*>(::createSecurityAnalysis));
 }
 
 void addContingency(const JavaHandle& analysisContext, const std::string& contingencyId, const std::vector<std::string>& elementsIds) {
@@ -687,11 +687,11 @@ void addContingency(const JavaHandle& analysisContext, const std::string& contin
 JavaHandle runSecurityAnalysis(const JavaHandle& securityAnalysisContext, const JavaHandle& network, const SecurityAnalysisParameters& parameters,
                                const std::string& provider, bool dc, JavaHandle* reporter) {
     auto c_parameters = parameters.to_c_struct();
-    return callJava<JavaHandle>(::runSecurityAnalysis, securityAnalysisContext, network, c_parameters.get(), (char *) provider.data(), dc, (reporter == nullptr) ? nullptr : *reporter);
+    return JavaHandle(callJava<void*>(::runSecurityAnalysis, securityAnalysisContext, network, c_parameters.get(), (char *) provider.data(), dc, (reporter == nullptr) ? nullptr : *reporter));
 }
 
 JavaHandle createSensitivityAnalysis() {
-    return callJava<JavaHandle>(::createSensitivityAnalysis);
+    return JavaHandle(callJava<void*>(::createSensitivityAnalysis));
 }
 
 ::zone* createZone(const std::string& id, const std::vector<std::string>& injectionsIds, const std::vector<double>& injectionsShiftKeys) {
@@ -778,7 +778,7 @@ void setBusVoltageFactorMatrix(const JavaHandle& sensitivityAnalysisContext, con
 
 JavaHandle runSensitivityAnalysis(const JavaHandle& sensitivityAnalysisContext, const JavaHandle& network, bool dc, SensitivityAnalysisParameters& parameters, const std::string& provider, JavaHandle* reporter) {
     auto c_parameters = parameters.to_c_struct();
-    return callJava<JavaHandle>(::runSensitivityAnalysis, sensitivityAnalysisContext, network, dc, c_parameters.get(), (char *) provider.data(), (reporter == nullptr) ? nullptr : *reporter);
+    return JavaHandle(callJava<void*>(::runSensitivityAnalysis, sensitivityAnalysisContext, network, dc, c_parameters.get(), (char *) provider.data(), (reporter == nullptr) ? nullptr : *reporter));
 }
 
 matrix* getBranchFlowsSensitivityMatrix(const JavaHandle& sensitivityAnalysisResultContext, const std::string& matrixId, const std::string& contingencyId) {
@@ -1014,7 +1014,7 @@ void createExtensions(pypowsybl::JavaHandle network, dataframe_array* dataframes
 }
 
 JavaHandle createGLSKdocument(std::string& filename) {
-    return callJava<JavaHandle>(::createGLSKdocument, (char*) filename.c_str());
+    return JavaHandle(callJava<void*>(::createGLSKdocument, (char*) filename.c_str()));
 }
 
 std::vector<std::string> getGLSKinjectionkeys(pypowsybl::JavaHandle network, const JavaHandle& importer, std::string& country, long instant) {
@@ -1044,7 +1044,7 @@ long getInjectionFactorEndTimestamp(const JavaHandle& importer) {
 }
 
 JavaHandle createReporterModel(const std::string& taskKey, const std::string& defaultName) {
-    return callJava<JavaHandle>(::createReporterModel, (char*) taskKey.data(), (char*) defaultName.data());
+    return JavaHandle(callJava<void*>(::createReporterModel, (char*) taskKey.data(), (char*) defaultName.data()));
 }
 
 std::string printReport(const JavaHandle& reporterModel) {

--- a/cpp/src/pypowsybl.h
+++ b/cpp/src/pypowsybl.h
@@ -34,7 +34,7 @@ public:
 class JavaHandle {
 public:
     //Implicit constructor from void* returned by graalvm
-    explicit JavaHandle(void* handle);
+    JavaHandle(void* handle);
     ~JavaHandle() {}
 
     //Implicit conversion to void* for use as input to graalvm

--- a/cpp/src/pypowsybl.h
+++ b/cpp/src/pypowsybl.h
@@ -34,7 +34,7 @@ public:
 class JavaHandle {
 public:
     //Implicit constructor from void* returned by graalvm
-    JavaHandle(void* handle);
+    explicit JavaHandle(void* handle);
     ~JavaHandle() {}
 
     //Implicit conversion to void* for use as input to graalvm


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Loaded networks are never garbage collected on Java side even if python object has been deleted
```python
n = pp.network.load('<path>')
del n
```
Adding a log to `destroyObjectHandle` shows:
  - is is called just at pp.network.load so object handle is immediately released after allocation which sounds weird because ref is still usable (I have no explanation on why)
  - del n does not do anything

Looking at `callJava` code and adding some log to figure out what's happen:
  - An instance of `JavaHandle` is created at method start from a null_ptr (address 0x)
  - Another one is created at the end using constructor and void* operator is called from first one to get the java pointer
  - So first `JavaHandle` is destroyed at the end of `callJava` releasing the `shared_ptr` and so one Java instance (so a null_ptr is release on Java side, it should not do anything)
  - The second `JavaHandle` is created from previously release java void* pointer (how could it work???)
 
All these tests have been done on MacOS with clang 14. I have not tested with Linux and g++. Maybe the issue is specific to MacOS (to test).


**What is the new behavior (if this is a feature change)?**
 To fix this issue:
 - avoid implicit construction of `JavaHandle` by adding explicit to constructor
 - in `callJava`, construct T from return type of Java function

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
