### PR TITLE
Avoid releasing null_ptr Java handle

### DIFF
--- a/cpp/src/pypowsybl.cpp
+++ b/cpp/src/pypowsybl.cpp
@@ -109,7 +109,9 @@ T callJava(F f, ARGS... args) {
 //Destruction of java object when the shared_ptr has no more references
 JavaHandle::JavaHandle(void* handle):
     handle_(handle, [](void* to_be_deleted) {
-        callJava<>(::destroyObjectHandle, to_be_deleted);
+        if (to_be_deleted) {
+            callJava<>(::destroyObjectHandle, to_be_deleted);
+        }
     })
 {
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Optimization


**What is the current behavior?** *(You can also link to an open issue here)*
Even if it seems to be correctly supported on Java side by GraalVM SDK, we  should avoid releasing `JavaHandle` built from a `null_ptr`. We have this case many times because of reporter java handle built from `null_ptr`.


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
