### PR TITLE
add perunit module

### DIFF
--- a/pypowsybl/__init__.py
+++ b/pypowsybl/__init__.py
@@ -17,6 +17,7 @@ from pypowsybl import (
     sensitivity,
     glsk,
     flowdecomposition,
+    perunit
 )
 
 __version__ = '0.20.0.dev1'
@@ -34,7 +35,8 @@ __all__ = [
     "security",
     "sensitivity",
     "glsk",
-    "flowdecomposition"
+    "flowdecomposition",
+    "perunit"
 ]
 
 


### PR DESCRIPTION
Signed-off-by: Etienne LESOT <etienne.lesot@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
no


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix

**What is the current behavior?** *(You can also link to an open issue here)*
it is difficult to import perunit module

**What is the new behavior (if this is a feature change)?**
perunit can now be used as a module 
```python
import pypowsybl as pp
net = pp.network.create_eurostag_tutorial_example1_network()
net_per_unit = pp.perunit.per_unit_view(net, 100)
```
