### PR TITLE
fixing the copy of properties of Network class

### DIFF
--- a/pypowsybl/network.py
+++ b/pypowsybl/network.py
@@ -226,12 +226,7 @@ class Network:  # pylint: disable=too-many-public-methods
 
     def __init__(self, handle: _pp.JavaHandle):
         self._handle = handle
-        att = _pp.get_network_metadata(self._handle)
-        self._id = att.id
-        self._name = att.name
-        self._source_format = att.source_format
-        self._forecast_distance = _datetime.timedelta(minutes=att.forecast_distance)
-        self._case_date = _datetime.datetime.fromtimestamp(att.case_date, _timezone.utc)
+        self.__init_from_handle()
 
     @property
     def id(self) -> str:
@@ -281,6 +276,15 @@ class Network:  # pylint: disable=too-many-public-methods
     def __setstate__(self, state: _Dict[str, str]) -> None:
         xml = state['xml']
         self._handle = _pp.load_network_from_string('tmp.xiidm', xml, {}, None)
+        self.__init_from_handle()
+
+    def __init_from_handle(self) -> None:
+        att = _pp.get_network_metadata(self._handle)
+        self._id = att.id
+        self._name = att.name
+        self._source_format = att.source_format
+        self._forecast_distance = _datetime.timedelta(minutes=att.forecast_distance)
+        self._case_date = _datetime.datetime.fromtimestamp(att.case_date, _timezone.utc)
 
     def open_switch(self, id: str) -> bool:
         return _pp.update_switch_position(self._handle, id, True)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -736,6 +736,7 @@ def test_current_limits():
 def test_deep_copy():
     n = pp.network.create_eurostag_tutorial_example1_network()
     copy_n = copy.deepcopy(n)
+    assert copy_n.id == "sim1"
     assert ['NGEN_NHV1', 'NHV2_NLOAD'] == copy_n.get_elements_ids(pp.network.ElementType.TWO_WINDINGS_TRANSFORMER)
 
 


### PR DESCRIPTION
adding a test to check the right behaviour

Signed-off-by: HugoKulesza <hugo.kulesza@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
After copying a network, the new one has some properties that are lost (e.g. network.id). 


