### PR TITLE
add topology kind attribute for voltage levels

### DIFF
--- a/java/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -712,6 +712,7 @@ public final class NetworkDataframes {
                 .doubles("high_voltage_limit", VoltageLevel::getHighVoltageLimit, VoltageLevel::setHighVoltageLimit)
                 .doubles("low_voltage_limit", VoltageLevel::getLowVoltageLimit, VoltageLevel::setLowVoltageLimit)
                 .booleans("fictitious", Identifiable::isFictitious, Identifiable::setFictitious, false)
+                .strings("topology_kind", vl -> vl.getTopologyKind().toString(), false)
                 .addProperties()
                 .build();
     }

--- a/java/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
+++ b/java/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
@@ -441,6 +441,14 @@ class NetworkDataframesTest {
         assertThat(series)
                 .extracting(Series::getName)
                 .containsExactly("id", "name", "substation_id", "nominal_v", "high_voltage_limit", "low_voltage_limit");
+
+        List<Series> allAttributesSeries = createDataFrame(VOLTAGE_LEVEL, network,
+                new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()));
+
+        assertThat(allAttributesSeries)
+                .extracting(Series::getName)
+                .containsExactly("id", "name", "substation_id", "nominal_v", "high_voltage_limit", "low_voltage_limit",
+                "fictitious", "topology_kind");
     }
 
     @Test

--- a/pypowsybl/network.py
+++ b/pypowsybl/network.py
@@ -1495,7 +1495,7 @@ class Network:  # pylint: disable=too-many-public-methods
               - **high_voltage_limit**: the high voltage limit
               - **low_voltage_limit**: the low voltage limit
               - **fictitious** (optional): ``True`` if the voltage level is part of the model and not of the actual network
-
+              - **topology_kind** (optional): the voltage level topology kind (NODE_BREAKER or BUS_BREAKER)
             This dataframe is indexed by the id of the voltage levels
 
         Examples:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -574,8 +574,10 @@ def test_update_2_windings_transformers_data_frame():
 
 def test_voltage_levels_data_frame():
     n = pp.network.create_eurostag_tutorial_example1_network()
-    voltage_levels = n.get_voltage_levels()
-    assert 24.0 == voltage_levels['nominal_v']['VLGEN']
+    voltage_levels = n.get_voltage_levels(all_attributes=True)
+    vlgen = voltage_levels.loc['VLGEN']
+    assert 24.0 == vlgen['nominal_v']
+    assert 'BUS_BREAKER' == vlgen['topology_kind']
 
 
 def test_substations_data_frame():


### PR DESCRIPTION
Signed-off-by: Etienne LESOT <etienne.lesot@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature

**What is the new behavior (if this is a feature change)?**
add a new attribute in voltage levels dataframe that gives the topology kind
