### PR TITLE
fix optional attributes for creation and docstring

### DIFF
--- a/pypowsybl/network.py
+++ b/pypowsybl/network.py
@@ -3713,8 +3713,7 @@ class Network:  # pylint: disable=too-many-public-methods
 
     def create_shunt_compensators(self, shunt_df: _DataFrame,
                                   linear_model_df: _Optional[_DataFrame] = None,
-                                  non_linear_model_df: _Optional[_DataFrame] = None,
-                                  **kwargs: _ArrayLike) -> None:
+                                  non_linear_model_df: _Optional[_DataFrame] = None) -> None:
         """
         Create shunt compensators.
 
@@ -3810,7 +3809,7 @@ class Network:  # pylint: disable=too-many-public-methods
         if non_linear_model_df is None:
             non_linear_model_df = pd.DataFrame()
         dfs: _List[_Optional[_DataFrame]] = [shunt_df, linear_model_df, non_linear_model_df]
-        return self._create_elements(ElementType.SHUNT_COMPENSATOR, dfs, **kwargs)
+        return self._create_elements(ElementType.SHUNT_COMPENSATOR, dfs)
 
     def create_switches(self, df: _DataFrame = None, **kwargs: _ArrayLike) -> None:
         """
@@ -3893,13 +3892,15 @@ class Network:  # pylint: disable=too-many-public-methods
         """
         return self._create_elements(ElementType.VOLTAGE_LEVEL, [df], **kwargs)
 
-    def create_ratio_tap_changers(self, rtc_df: _DataFrame, steps_df: _DataFrame = None, **kwargs: _ArrayLike) -> None:
+    def create_ratio_tap_changers(self, rtc_df: _DataFrame, steps_df: _DataFrame) -> None:
         """
         Create ratio tap changers on transformers.
 
         Tap changers data must be provided in 2 separate dataframes:
         one for the tap changers attributes, and another one for tap changers steps attributes.
         The latter one will generally have multiple lines for one transformer ID.
+        The steps are created in order of the dataframe order meaning (for a transformer) first line of the steps
+        dataframe will create step one of the steps of these transformer.
 
         Args:
             rtc_df: dataframe of tap changers data
@@ -3940,18 +3941,21 @@ class Network:  # pylint: disable=too-many-public-methods
                     index='id',
                     columns=['id', 'b', 'g', 'r', 'x', 'rho'],
                     data=[('NGEN_NHV1', 2, 2, 1, 1, 0.5),
-                          ('NGEN_NHV1', 2, 2, 1, 1, 0.5)])
+                          ('NGEN_NHV1', 2, 2, 1, 1, 0.5),
+                          ('NGEN_NHV1', 2, 2, 1, 1, 0.8)])
                 network.create_ratio_tap_changers(rtc_df, steps_df)
         """
-        return self._create_elements(ElementType.RATIO_TAP_CHANGER, [rtc_df, steps_df], **kwargs)
+        return self._create_elements(ElementType.RATIO_TAP_CHANGER, [rtc_df, steps_df])
 
-    def create_phase_tap_changers(self, ptc_df: _DataFrame, steps_df: _DataFrame = None, **kwargs: _ArrayLike) -> None:
+    def create_phase_tap_changers(self, ptc_df: _DataFrame, steps_df: _DataFrame) -> None:
         """
         Create phase tap changers on transformers.
 
         Tap changers data must be provided in 2 separate dataframes:
         one for the tap changers attributes, and another one for tap changers steps attributes.
         The latter one will generally have multiple lines for one transformer ID.
+        The steps are created in order of the dataframe order meaning (for a transformer) first line of the steps
+        dataframe will create step one of the steps of these transformer.
 
         Args:
             ptc_df: dataframe of tap changers data
@@ -3990,12 +3994,13 @@ class Network:  # pylint: disable=too-many-public-methods
                 steps_df = pd.DataFrame.from_records(
                     index='id', columns=['id', 'b', 'g', 'r', 'x', 'rho', 'alpha'],
                     data=[('TWT_TEST', 2, 2, 1, 1, 0.5, 0.1),
+                          ('TWT_TEST', 2, 2, 1, 1, 0.4, 0.2),
                           ('TWT_TEST', 2, 2, 1, 1, 0.5, 0.1)])
                 n.create_phase_tap_changers(ptc_df, steps_df)
         """
-        return self._create_elements(ElementType.PHASE_TAP_CHANGER, [ptc_df, steps_df], **kwargs)
+        return self._create_elements(ElementType.PHASE_TAP_CHANGER, [ptc_df, steps_df])
 
-    def create_hvdc_lines(self, df: _DataFrame, **kwargs: _ArrayLike) -> None:
+    def create_hvdc_lines(self, df: _DataFrame = None, **kwargs: _ArrayLike) -> None:
         """
         Creates HVDC lines.
 
@@ -4033,7 +4038,7 @@ class Network:  # pylint: disable=too-many-public-methods
         """
         return self._create_elements(ElementType.HVDC_LINE, [df], **kwargs)
 
-    def create_operational_limits(self, df: _DataFrame, **kwargs: _ArrayLike) -> None:
+    def create_operational_limits(self, df: _DataFrame = None, **kwargs: _ArrayLike) -> None:
         """
         Creates operational limits.
 
@@ -4064,10 +4069,11 @@ class Network:  # pylint: disable=too-many-public-methods
             df: Attributes as a dataframe.
             kwargs: Attributes as keyword arguments.
         """
-        df['acceptable_duration'] = df['acceptable_duration'].map(lambda x: -1 if x == Inf else int(x))
+        if df is not None:
+            df['acceptable_duration'] = df['acceptable_duration'].map(lambda x: -1 if x == Inf else int(x))
         return self._create_elements(ElementType.OPERATIONAL_LIMITS, [df], **kwargs)
 
-    def create_minmax_reactive_limits(self, df: _DataFrame, **kwargs: _ArrayLike) -> None:
+    def create_minmax_reactive_limits(self, df: _DataFrame = None, **kwargs: _ArrayLike) -> None:
         """
         Creates reactive limits of type min/max.
 
@@ -4101,7 +4107,7 @@ class Network:  # pylint: disable=too-many-public-methods
         """
         return self._create_elements(ElementType.MINMAX_REACTIVE_LIMITS, [df], **kwargs)
 
-    def create_curve_reactive_limits(self, df: _DataFrame, **kwargs: _ArrayLike) -> None:
+    def create_curve_reactive_limits(self, df: _DataFrame = None, **kwargs: _ArrayLike) -> None:
         """
         Creates reactive limits as "curves".
 

--- a/tests/test_network_elements_creation.py
+++ b/tests/test_network_elements_creation.py
@@ -19,6 +19,7 @@ import pathlib
 from numpy import NaN
 from pypowsybl import PyPowsyblError
 
+
 @pytest.fixture
 def this_dir():
     return pathlib.Path(__file__).parent
@@ -500,6 +501,19 @@ def test_hvdc_creation():
     assert hvdc.target_p == 100
     assert hvdc.max_p == 200
     assert hvdc.converters_mode == 'SIDE_1_RECTIFIER_SIDE_2_INVERTER'
+    # test inline arguments
+    n = pn.create_four_substations_node_breaker_network()
+    n.create_hvdc_lines(id='VSC_TEST', converter_station1_id='VSC1',
+                        converter_station2_id='VSC2', r=0.1, nominal_v=320, target_p=100,
+                        max_p=200, converters_mode='SIDE_1_RECTIFIER_SIDE_2_INVERTER')
+    hvdc = n.get_hvdc_lines().loc['VSC_TEST']
+    assert hvdc.converter_station1_id == 'VSC1'
+    assert hvdc.converter_station2_id == 'VSC2'
+    assert hvdc.r == 0.1
+    assert hvdc.nominal_v == 320
+    assert hvdc.target_p == 100
+    assert hvdc.max_p == 200
+    assert hvdc.converters_mode == 'SIDE_1_RECTIFIER_SIDE_2_INVERTER'
 
 
 def test_create_network_and_run_loadflow():
@@ -655,13 +669,15 @@ def test_create_minmax_reactive_limits():
         columns=['id', 'min_q', 'max_q'],
         data=[['GH1', -201.0, 201.0],
               ['GH2', -205.0, 205.0]])
-    pd.testing.assert_frame_equal(expected, network.get_generators(id=['GH1', 'GH2'], attributes=['min_q', 'max_q']), check_dtype=False)
+    pd.testing.assert_frame_equal(expected, network.get_generators(id=['GH1', 'GH2'], attributes=['min_q', 'max_q']),
+                                  check_dtype=False)
     expected = pd.DataFrame.from_records(
         index='id',
         columns=['id', 'min_q', 'max_q'],
         data=[['VSC1', -355.0, 405.0],
               ['VSC2', -405.0, 505.0]])
-    pd.testing.assert_frame_equal(expected, network.get_vsc_converter_stations(id=['VSC1', 'VSC2'], attributes=['min_q', 'max_q']),
+    pd.testing.assert_frame_equal(expected, network.get_vsc_converter_stations(id=['VSC1', 'VSC2'],
+                                                                               attributes=['min_q', 'max_q']),
                                   check_dtype=False)
     network = util.create_battery_network()
     network.create_minmax_reactive_limits(pd.DataFrame.from_records(index='id', data=[
@@ -702,7 +718,8 @@ num  p  min_q max_q
 0   50    -50   100
 1   60   -100    50
     """, index='num')
-    pd.testing.assert_frame_equal(expected, network.get_reactive_capability_curve_points().loc['BAT'], check_dtype=False)
+    pd.testing.assert_frame_equal(expected, network.get_reactive_capability_curve_points().loc['BAT'],
+                                  check_dtype=False)
 
     # VSCs
     network = pn.create_four_substations_node_breaker_network()
@@ -716,7 +733,8 @@ num p    min_q    max_q
 0   50    -50     100
 1   60  -100      50
 """, index='num')
-    pd.testing.assert_frame_equal(expected, network.get_reactive_capability_curve_points().loc['VSC1'], check_dtype=False)
+    pd.testing.assert_frame_equal(expected, network.get_reactive_capability_curve_points().loc['VSC1'],
+                                  check_dtype=False)
 
 
 def test_delete_elements_eurostag():
@@ -757,7 +775,7 @@ def test_remove_elements_switches():
     net = pypowsybl.network.create_four_substations_node_breaker_network()
     net.remove_elements(['S1VL1_BBS_LD1_DISCONNECTOR', 'S1VL1_LD1_BREAKER', 'TWT', 'HVDC1'])
     # TODO: restore it when bug fixed in powsybl-core
-    #net.remove_elements(['S1VL1', 'S1'])
+    # net.remove_elements(['S1VL1', 'S1'])
     assert 'S1VL1_BBS_LD1_DISCONNECTOR' not in net.get_switches().index
     assert 'S1VL1_LD1_BREAKER' not in net.get_switches().index
     assert 'HVDC1' not in net.get_hvdc_lines().index


### PR DESCRIPTION
Signed-off-by: Etienne LESOT <etienne.lesot@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
for some network element creation dataframe is required and it should not and conversely.