### PR TITLE
Exclude MacOS Python 3.7 build

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -150,6 +150,15 @@ jobs:
             name: cp311,
             version: '3.11',
           }
+        exclude:
+          - config: {
+              name: darwin,
+              os: macos-11,
+            }
+            python: {
+              name: cp37,
+              version: '3.7',
+            }
 
     steps:
       - name: Setup GraalVM

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -150,7 +150,7 @@ jobs:
             name: cp311,
             version: '3.11',
           }
-        exclude:
+        exclude: # exclude MacOS Python 3.7 because does not work anymore
           - config: {
               name: darwin,
               os: macos-11,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Last Python 3.7.17 for MacOS is buggy and build fails: https://github.com/actions/setup-python/issues/682
When reverting to 3.7.16, we have another issue apparently since last MacOS 11 update.
```
ERROR: pypowsybl-0.24.0.dev1-cp37-cp37m-macosx_11_0_x86_64.whl is not a supported wheel on this platform. 
```
It looks like MACOSX_DEPLOYMENT_TARGET is not taken into account anymore.


**What is the new behavior (if this is a feature change)?**
We just dot not build a wheel anymore for MacOs and Python 3.7


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
