### PR TITLE
Fix per uniting of lines with not same nominal voltage at both side

### DIFF
--- a/pypowsybl/network/impl/perunit.py
+++ b/pypowsybl/network/impl/perunit.py
@@ -4,7 +4,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # SPDX-License-Identifier: MPL-2.0
 #
-from typing import List, Union
+from typing import List
 import math
 import pandas as pd
 import numpy as np

--- a/pypowsybl/network/impl/perunit.py
+++ b/pypowsybl/network/impl/perunit.py
@@ -77,10 +77,28 @@ class PerUnitView:  # pylint: disable=too-many-public-methods
         for col in columns:
             df[col] /= factor
 
+    def _per_unit_r_not_same_nom_v(self, df: pd.DataFrame, columns: List[str], nominal_v1: pd.Series, nominal_v2: pd.Series) -> None:
+        factor = nominal_v1 * nominal_v2 / self.sn
+        for col in columns:
+            df[col] /= factor
+
     def _per_unit_g(self, df: pd.DataFrame, columns: List[str], nominal_v: pd.Series) -> None:
         factor = nominal_v ** 2 / self.sn
         for col in columns:
             df[col] *= factor
+
+    def y(self, df: pd.DataFrame, r_col: str, x_col: str):
+        return df.apply(lambda row: np.reciprocal(np.complex128(row[r_col] + row[x_col] * 1j)), axis=1)
+
+    def _per_unit_g_not_same_nom_v(self, df: pd.DataFrame, columns: List[str], r_col: str, x_col: str, nominal_v1: pd.Series, nominal_v2: pd.Series) -> None:
+        for col in columns:
+            ytr = self.y(df, r_col, x_col)
+            df[col] = (df[col] * nominal_v1 * nominal_v1 + (nominal_v1 - nominal_v2) * nominal_v1 * ytr.apply(lambda row: row.real)) / self.sn
+
+    def _per_unit_b_not_same_nom_v(self, df: pd.DataFrame, columns: List[str], r_col: str, x_col: str, nominal_v1: pd.Series, nominal_v2: pd.Series) -> None:
+        for col in columns:
+            ytr = self.y(df, r_col, x_col)
+            df[col] = (df[col] * nominal_v1 * nominal_v1 + (nominal_v1 - nominal_v2) * nominal_v1 * ytr.apply(lambda row: row.imag)) / self.sn
 
     def _per_unit_i(self, df: pd.DataFrame, columns: List[str], nominal_v: pd.Series) -> None:
         factor = self.sn * 10 ** 3 / (self.sqrt3 * nominal_v)
@@ -163,11 +181,16 @@ class PerUnitView:  # pylint: disable=too-many-public-methods
             a per-united dataframe of lines.
         """
         lines = self._network.get_lines()
-        nominal_v = self._get_indexed_nominal_v(lines, 'voltage_level2_id')
+        nominal_v1 = self._get_indexed_nominal_v(lines, 'voltage_level1_id')
+        nominal_v2 = self._get_indexed_nominal_v(lines, 'voltage_level2_id')
         self._per_unit_p(lines, ['p1', 'p2', 'q1', 'q2'])
-        self._per_unit_i(lines, ['i1', 'i2'], nominal_v)
-        self._per_unit_r(lines, ['r', 'x'], nominal_v)
-        self._per_unit_g(lines, ['g1', 'g2', 'b1', 'b2'], nominal_v)
+        self._per_unit_i(lines, ['i1'], nominal_v1)
+        self._per_unit_i(lines, ['i2'], nominal_v2)
+        self._per_unit_g_not_same_nom_v(lines, ['g1'], 'r', 'x', nominal_v1, nominal_v2)
+        self._per_unit_g_not_same_nom_v(lines, ['g2'], 'r', 'x', nominal_v2, nominal_v1)
+        self._per_unit_b_not_same_nom_v(lines, ['b1'], 'r', 'x', nominal_v1, nominal_v2)
+        self._per_unit_b_not_same_nom_v(lines, ['b2'], 'r', 'x', nominal_v2, nominal_v1)
+        self._per_unit_r_not_same_nom_v(lines, ['r', 'x'], nominal_v1, nominal_v2)
         return lines
 
     def get_2_windings_transformers(self) -> pd.DataFrame:

--- a/pypowsybl/network/impl/perunit.py
+++ b/pypowsybl/network/impl/perunit.py
@@ -90,15 +90,13 @@ class PerUnitView:  # pylint: disable=too-many-public-methods
     def y(self, df: pd.DataFrame, r_col: str, x_col: str):
         return df.apply(lambda row: np.reciprocal(np.complex128(row[r_col] + row[x_col] * 1j)), axis=1)
 
-    def _per_unit_g_not_same_nom_v(self, df: pd.DataFrame, columns: List[str], r_col: str, x_col: str, nominal_v1: pd.Series, nominal_v2: pd.Series) -> None:
-        for col in columns:
-            ytr = self.y(df, r_col, x_col)
-            df[col] = (df[col] * nominal_v1 * nominal_v1 + (nominal_v1 - nominal_v2) * nominal_v1 * ytr.apply(lambda row: row.real)) / self.sn
+    def _per_unit_g_not_same_nom_v(self, df: pd.DataFrame, column: str, r_col: str, x_col: str, nominal_v1: pd.Series, nominal_v2: pd.Series) -> None:
+        ytr = self.y(df, r_col, x_col)
+        df[column] = (df[column] * nominal_v1 * nominal_v1 + (nominal_v1 - nominal_v2) * nominal_v1 * ytr.apply(lambda row: row.real)) / self.sn
 
-    def _per_unit_b_not_same_nom_v(self, df: pd.DataFrame, columns: List[str], r_col: str, x_col: str, nominal_v1: pd.Series, nominal_v2: pd.Series) -> None:
-        for col in columns:
-            ytr = self.y(df, r_col, x_col)
-            df[col] = (df[col] * nominal_v1 * nominal_v1 + (nominal_v1 - nominal_v2) * nominal_v1 * ytr.apply(lambda row: row.imag)) / self.sn
+    def _per_unit_b_not_same_nom_v(self, df: pd.DataFrame, column: str, r_col: str, x_col: str, nominal_v1: pd.Series, nominal_v2: pd.Series) -> None:
+        ytr = self.y(df, r_col, x_col)
+        df[column] = (df[column] * nominal_v1 * nominal_v1 + (nominal_v1 - nominal_v2) * nominal_v1 * ytr.apply(lambda row: row.imag)) / self.sn
 
     def _per_unit_i(self, df: pd.DataFrame, columns: List[str], nominal_v: pd.Series) -> None:
         factor = self.sn * 10 ** 3 / (self.sqrt3 * nominal_v)
@@ -186,10 +184,10 @@ class PerUnitView:  # pylint: disable=too-many-public-methods
         self._per_unit_p(lines, ['p1', 'p2', 'q1', 'q2'])
         self._per_unit_i(lines, ['i1'], nominal_v1)
         self._per_unit_i(lines, ['i2'], nominal_v2)
-        self._per_unit_g_not_same_nom_v(lines, ['g1'], 'r', 'x', nominal_v1, nominal_v2)
-        self._per_unit_g_not_same_nom_v(lines, ['g2'], 'r', 'x', nominal_v2, nominal_v1)
-        self._per_unit_b_not_same_nom_v(lines, ['b1'], 'r', 'x', nominal_v1, nominal_v2)
-        self._per_unit_b_not_same_nom_v(lines, ['b2'], 'r', 'x', nominal_v2, nominal_v1)
+        self._per_unit_g_not_same_nom_v(lines, 'g1', 'r', 'x', nominal_v1, nominal_v2)
+        self._per_unit_g_not_same_nom_v(lines, 'g2', 'r', 'x', nominal_v2, nominal_v1)
+        self._per_unit_b_not_same_nom_v(lines, 'b1', 'r', 'x', nominal_v1, nominal_v2)
+        self._per_unit_b_not_same_nom_v(lines, 'b2', 'r', 'x', nominal_v2, nominal_v1)
         self._per_unit_r_not_same_nom_v(lines, ['r', 'x'], nominal_v1, nominal_v2)
         return lines
 

--- a/pypowsybl/network/impl/perunit.py
+++ b/pypowsybl/network/impl/perunit.py
@@ -87,15 +87,13 @@ class PerUnitView:  # pylint: disable=too-many-public-methods
         for col in columns:
             df[col] *= factor
 
-    def y(self, df: pd.DataFrame, r_col: str, x_col: str):
-        return df.apply(lambda row: np.reciprocal(np.complex128(row[r_col] + row[x_col] * 1j)), axis=1)
+    def y(self, df: pd.DataFrame, r_col: str, x_col: str) -> pd.Series:
+        return df.apply(lambda row: np.reciprocal(np.complex128(row[r_col] + row[x_col] * 1j)), axis = 1)
 
-    def _per_unit_g_not_same_nom_v(self, df: pd.DataFrame, column: str, r_col: str, x_col: str, nominal_v1: pd.Series, nominal_v2: pd.Series) -> None:
-        ytr = self.y(df, r_col, x_col)
+    def _per_unit_g_not_same_nom_v(self, df: pd.DataFrame, column: str, ytr: pd.Series, nominal_v1: pd.Series, nominal_v2: pd.Series) -> None:
         df[column] = (df[column] * nominal_v1 * nominal_v1 + (nominal_v1 - nominal_v2) * nominal_v1 * ytr.apply(lambda row: row.real)) / self.sn
 
-    def _per_unit_b_not_same_nom_v(self, df: pd.DataFrame, column: str, r_col: str, x_col: str, nominal_v1: pd.Series, nominal_v2: pd.Series) -> None:
-        ytr = self.y(df, r_col, x_col)
+    def _per_unit_b_not_same_nom_v(self, df: pd.DataFrame, column: str, ytr: pd.Series, nominal_v1: pd.Series, nominal_v2: pd.Series) -> None:
         df[column] = (df[column] * nominal_v1 * nominal_v1 + (nominal_v1 - nominal_v2) * nominal_v1 * ytr.apply(lambda row: row.imag)) / self.sn
 
     def _per_unit_i(self, df: pd.DataFrame, columns: List[str], nominal_v: pd.Series) -> None:
@@ -184,11 +182,12 @@ class PerUnitView:  # pylint: disable=too-many-public-methods
         self._per_unit_p(lines, ['p1', 'p2', 'q1', 'q2'])
         self._per_unit_i(lines, ['i1'], nominal_v1)
         self._per_unit_i(lines, ['i2'], nominal_v2)
-        self._per_unit_g_not_same_nom_v(lines, 'g1', 'r', 'x', nominal_v1, nominal_v2)
-        self._per_unit_g_not_same_nom_v(lines, 'g2', 'r', 'x', nominal_v2, nominal_v1)
-        self._per_unit_b_not_same_nom_v(lines, 'b1', 'r', 'x', nominal_v1, nominal_v2)
-        self._per_unit_b_not_same_nom_v(lines, 'b2', 'r', 'x', nominal_v2, nominal_v1)
+        ytr = self.y(lines, 'r', 'x')
         self._per_unit_r_not_same_nom_v(lines, ['r', 'x'], nominal_v1, nominal_v2)
+        self._per_unit_g_not_same_nom_v(lines, 'g1', ytr, nominal_v1, nominal_v2)
+        self._per_unit_g_not_same_nom_v(lines, 'g2', ytr, nominal_v2, nominal_v1)
+        self._per_unit_b_not_same_nom_v(lines, 'b1', ytr, nominal_v1, nominal_v2)
+        self._per_unit_b_not_same_nom_v(lines, 'b2', ytr, nominal_v2, nominal_v1)
         return lines
 
     def get_2_windings_transformers(self) -> pd.DataFrame:

--- a/pypowsybl/network/impl/perunit.py
+++ b/pypowsybl/network/impl/perunit.py
@@ -87,8 +87,8 @@ class PerUnitView:  # pylint: disable=too-many-public-methods
         for col in columns:
             df[col] *= factor
 
-    def y(self, df: pd.DataFrame, r_col: str, x_col: str) -> pd.Series:
-        return pd.Series(df.apply(lambda row: np.reciprocal(np.complex128(row[r_col] + row[x_col] * 1j)), axis = 1))
+    def _y(self, df: pd.DataFrame, r_col: str, x_col: str) -> pd.Series:
+        return pd.Series(df.apply(lambda row: np.reciprocal(np.complex128(row[r_col] + row[x_col] * 1j)), axis=1))
 
     def _per_unit_g_not_same_nom_v(self, df: pd.DataFrame, column: str, ytr: pd.Series, nominal_v1: pd.Series, nominal_v2: pd.Series) -> None:
         df[column] = (df[column] * nominal_v1 * nominal_v1 + (nominal_v1 - nominal_v2) * nominal_v1 * ytr.apply(lambda row: row.real)) / self.sn
@@ -182,7 +182,7 @@ class PerUnitView:  # pylint: disable=too-many-public-methods
         self._per_unit_p(lines, ['p1', 'p2', 'q1', 'q2'])
         self._per_unit_i(lines, ['i1'], nominal_v1)
         self._per_unit_i(lines, ['i2'], nominal_v2)
-        ytr = self.y(lines, 'r', 'x')
+        ytr = self._y(lines, 'r', 'x')
         self._per_unit_r_not_same_nom_v(lines, ['r', 'x'], nominal_v1, nominal_v2)
         self._per_unit_g_not_same_nom_v(lines, 'g1', ytr, nominal_v1, nominal_v2)
         self._per_unit_g_not_same_nom_v(lines, 'g2', ytr, nominal_v2, nominal_v1)

--- a/pypowsybl/network/impl/perunit.py
+++ b/pypowsybl/network/impl/perunit.py
@@ -87,8 +87,8 @@ class PerUnitView:  # pylint: disable=too-many-public-methods
         for col in columns:
             df[col] *= factor
 
-    def y(self, df: pd.DataFrame, r_col: str, x_col: str) -> Union[pd.DataFrame, pd.Series]:
-        return df.apply(lambda row: np.reciprocal(np.complex128(row[r_col] + row[x_col] * 1j)), axis = 1)
+    def y(self, df: pd.DataFrame, r_col: str, x_col: str) -> pd.Series:
+        return pd.Series(df.apply(lambda row: np.reciprocal(np.complex128(row[r_col] + row[x_col] * 1j)), axis = 1))
 
     def _per_unit_g_not_same_nom_v(self, df: pd.DataFrame, column: str, ytr: pd.Series, nominal_v1: pd.Series, nominal_v2: pd.Series) -> None:
         df[column] = (df[column] * nominal_v1 * nominal_v1 + (nominal_v1 - nominal_v2) * nominal_v1 * ytr.apply(lambda row: row.real)) / self.sn

--- a/pypowsybl/network/impl/perunit.py
+++ b/pypowsybl/network/impl/perunit.py
@@ -4,7 +4,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # SPDX-License-Identifier: MPL-2.0
 #
-from typing import List
+from typing import List, Union
 import math
 import pandas as pd
 import numpy as np
@@ -87,7 +87,7 @@ class PerUnitView:  # pylint: disable=too-many-public-methods
         for col in columns:
             df[col] *= factor
 
-    def y(self, df: pd.DataFrame, r_col: str, x_col: str) -> pd.Series:
+    def y(self, df: pd.DataFrame, r_col: str, x_col: str) -> Union[pd.DataFrame, pd.Series]:
         return df.apply(lambda row: np.reciprocal(np.complex128(row[r_col] + row[x_col] * 1j)), axis = 1)
 
     def _per_unit_g_not_same_nom_v(self, df: pd.DataFrame, column: str, ytr: pd.Series, nominal_v1: pd.Series, nominal_v2: pd.Series) -> None:

--- a/tests/test_per_unit.py
+++ b/tests/test_per_unit.py
@@ -9,6 +9,7 @@ import pypowsybl as pp
 import pandas as pd
 from numpy import NaN
 import util
+import pytest
 
 
 def test_bus_per_unit():
@@ -413,3 +414,14 @@ def test_ratio_tap_changers_per_unit():
                                      'alpha'],
                             data=[[1, 0, 2, 3, True, True, 158.0, 0.0, 'VLLOAD_0', 1.00, NaN]])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)
+
+def test_lines_not_same_nominal_voltage_per_unit():
+    n = pp.network.create_ieee14()
+    n = per_unit_view(n, 100)
+    lines = n.get_lines()
+    assert lines.loc['L7-8-1']['r'] == 0
+    assert lines.loc['L7-8-1']['x'] == pytest.approx(0.17615, rel=1e-5)
+    assert lines.loc['L7-8-1']['g1'] == pytest.approx(0, rel=1e-16)
+    assert lines.loc['L7-8-1']['g2'] == pytest.approx(0, rel=1e-16)
+    assert lines.loc['L7-8-1']['b1'] == pytest.approx(0, rel=1e-16)
+    assert lines.loc['L7-8-1']['b2'] == pytest.approx(0, rel=1e-16)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
#642 


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Per uniting is wrong for lines with different nominal voltage at both ends


**What is the new behavior (if this is a feature change)?**
Per uniting is correct for lines with different nominal voltage at both ends



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
