### PR TITLE
Remove python 3.7 compatibility

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -16,11 +16,6 @@ jobs:
       matrix:
         python:
           - {
-            name: cp37,
-            abi: cp37m,
-            version: '3.7',
-          }
-          - {
             name: cp38,
             abi: cp38,
             version: '3.8',
@@ -130,10 +125,6 @@ jobs:
             os: windows-2022,
           }
         python:
-          - {
-            name: cp37,
-            version: '3.7',
-          }
           - {
             name: cp38,
             version: '3.8',

--- a/README.md
+++ b/README.md
@@ -89,8 +89,7 @@ Requirements:
 - Maven >= 3.1
 - Cmake >= 3.14
 - C++11 compiler
-- Python >= 3.7 for Linux, Windows and MacOS amd64
-- Python >= 3.8 for MacOS arm64
+- Python >= 3.8 for Linux, Windows and MacOS amd64
 - [Oracle GraalVM Java 17](https://www.graalvm.org/downloads/)
 
 To build from sources and install PyPowSyBl package:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 # actual dependencies
-pandas==1.5.3; python_version == "3.11"
-pandas==1.5.3; python_version != "3.11" and sys_platform == "darwin" and platform_machine == "arm64"
-pandas==1.3.5; python_version != "3.11" and (sys_platform != "darwin" or platform_machine != "arm64")
+pandas==1.5.3
 prettytable==2.0.0
 networkx
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # actual dependencies
-pandas==1.5.3
+pandas==2.0.3
 prettytable==2.0.0
 networkx
 matplotlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifiers =
     Development Status :: 4 - Beta
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -26,7 +25,7 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     prettytable
     numpy>=1.20.0

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,4 +8,4 @@ sonar.sources=pypowsybl
 sonar.tests=tests
 
 # to get specific analysis for those versions
-sonar.python.version=3.7,3.8,3.9,3.10
+sonar.python.version=3.8,3.9,3.10,3.11


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Technical debt


**What is the current behavior?**
<!-- You can also link to an open issue here -->
We support python 3.7 BUT the consequence is to have so old version of Pandas for 3.7 different of the one for newer versions.


**What is the new behavior (if this is a feature change)?**
We do not support python 3.7 anymore.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
