### PR TITLE
Add missing dangling line visitor function

### DIFF
--- a/java/src/main/java/com/powsybl/python/network/NetworkAreaDiagramUtil.java
+++ b/java/src/main/java/com/powsybl/python/network/NetworkAreaDiagramUtil.java
@@ -183,5 +183,11 @@ public final class NetworkAreaDiagramUtil {
             }
 
         }
+
+        public void visitDanglingLine(DanglingLine danglingLine) {
+            if (danglingLine.isPaired()) {
+                danglingLine.getTieLine().ifPresent(tieline -> visitBranch(tieline, tieline.getSide(danglingLine.getTerminal())));
+            }
+        }
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
Tie lines are not visited and crossed when filtering voltage levels according to their nominal voltages.


**What is the new behavior (if this is a feature change)?**
Tie lines are properly visited.

**Other information**:
This is a temporary fix. This piece of code should be transfered into powsybl-diagram (a PR has already be opened for that : https://github.com/powsybl/powsybl-diagram/pull/566)