### PR TITLE
[Shortcircuits] Units of currents are in A and not kA

### DIFF
--- a/pypowsybl/shortcircuit/impl/parameters.py
+++ b/pypowsybl/shortcircuit/impl/parameters.py
@@ -17,7 +17,7 @@ class Parameters:  # pylint: disable=too-few-public-methods
     """
     Parameters for a short-circuit analysis execution.
 
-    Please check the Powsybl's short-circuit APIs documentation, for detailed information.
+    Please check the PowSyBl short-circuit APIs documentation, for detailed information.
 
     .. currentmodule:: pypowsybl.shortcircuit
 
@@ -25,16 +25,16 @@ class Parameters:  # pylint: disable=too-few-public-methods
         with_fortescue_result: indicates whether the currents and voltages are to be given in three-phase magnitude or
             detailed with magnitude and angle on each phase. This parameter also applies to the feeder results and
             voltage results.
-        with_feeder_result: indicates whether the contributions of each feeder to the short circuit current at the fault
+        with_feeder_result: indicates whether the contributions of each feeder to the short-circuit current at the fault
             node should be calculated.
         with_limit_violations: indicates whether limit violations should be returned after the calculation. If true, a
-        list of buses where the calculated shortcircuit current is higher than the maximum admissible current (stored in
+        list of buses where the calculated short-circuit current is higher than the maximum admissible current (stored in
         ip_max in the identifiableShortCircuit extension) or lower than the minimum admissible current (stored in ip_min
         in the identifiableShortCircuit extension).
         with_voltage_result: indicates whether the voltage profile should be calculated on every node of the network
         min_voltage_drop_proportional_threshold: specifies a threshold for filtering the voltage results.
             Only nodes where the voltage drop due to the short circuit is greater than this property are retained.
-        study_type: specifies the type of short circuit study. It can be SUB_TRANSIENT, TRANSIENT or STEADY_STATE.
+        study_type: specifies the type of short-circuit study. It can be SUB_TRANSIENT, TRANSIENT or STEADY_STATE.
     """
 
     def __init__(self,

--- a/pypowsybl/shortcircuit/impl/short_circuit_analysis.py
+++ b/pypowsybl/shortcircuit/impl/short_circuit_analysis.py
@@ -77,7 +77,7 @@ class ShortCircuitAnalysis:
 
     def run(self, network: Network, parameters: Parameters = None,
             provider: str = '', reporter: Reporter = None) -> ShortCircuitAnalysisResult:
-        """ Runs an short-circuit analysis.
+        """ Runs a short-circuit analysis.
 
         Args:
             network:    Network on which the short-circuit analysis will be computed

--- a/pypowsybl/shortcircuit/impl/short_circuit_analysis_result.py
+++ b/pypowsybl/shortcircuit/impl/short_circuit_analysis_result.py
@@ -22,12 +22,12 @@ class ShortCircuitAnalysisResult:
     def fault_results(self) -> pd.DataFrame:
         """
         contains the results, for each fault, in a dataframe representation. The rows are fault ids and the columns are:
-        - status: the status of the computation, can be SUCCESS, NO_SHORTCIRCUIT_DATA (in case that the reactances of
+        - status: the status of the computation, can be SUCCESS, NO_SHORTCIRCUIT_DATA (in case the reactances of
         generators are missing), SOLVER_FAILURE or FAILURE
         - short_circuit_power: the value of the shortcircuit power (in MVA)
         - time_constant: the duration before reaching the permanent shortcircuit current
         - current: the current at the fault, either only the three-phase magnitude or detailed with magnitudes and
-        angles on each phase (in kA)
+        angles on each phase (in A)
         - voltage: the voltage at the fault, either only the three-phase magnitude or detailed with magnitudes and
         angles on each phase (in kV)
 
@@ -38,9 +38,9 @@ class ShortCircuitAnalysisResult:
     def feeder_results(self) -> pd.DataFrame:
         """
         contains the contributions of each feeder to the short circuit current, in a dataframe representation. The rows
-        are the ids of contributing connectable ids sorted by faults and the columns is just the current, either in
-        three-phase magnitude or detailed with magnitude and angle for each phase. The currents are in kV.
-        It should be empty when the parameter with_feeder_result is set to false
+        are the ids of contributing connectable ids sorted by faults and the columns is the current, either in
+        three-phase magnitude or detailed with magnitude and angle for each phase. The magnitude of the currents are in
+        A. It should be empty when the parameter with_feeder_result is set to false
         """
         return create_data_frame_from_series_array(_pypowsybl.get_feeder_results(self._handle, self._with_fortescue_result))
 
@@ -52,10 +52,10 @@ class ShortCircuitAnalysisResult:
         - subject_name: the name of the equipment where the violation occurs
         - limit_type: the type of limit violation, can be LOW_SHORT_CIRCUIT_CURRENT or HIGH_SHORT_CIRCUIT_CURRENT
         - limit_name
-        - limit: the value of the limit that is violated (maximum or minimum admissible short-circuit current) in kV
+        - limit: the value of the limit that is violated (maximum or minimum admissible short-circuit current) in A
         - acceptable_duration
         - limit_reduction
-        - value: the calculated short-circuit current that is too high or too low (in kV)
+        - value: the calculated short-circuit current that is too high or too low (in A)
         - side: in case of a limit on a branch, the side where the violation has been detected
         It should be empty when the parameter with_limit_violations is set to false
         """

--- a/pypowsybl/shortcircuit/impl/short_circuit_analysis_result.py
+++ b/pypowsybl/shortcircuit/impl/short_circuit_analysis_result.py
@@ -22,10 +22,10 @@ class ShortCircuitAnalysisResult:
     def fault_results(self) -> pd.DataFrame:
         """
         contains the results, for each fault, in a dataframe representation. The rows are fault ids and the columns are:
-        - status: the status of the computation, can be SUCCESS, NO_SHORTCIRCUIT_DATA (in case the reactances of
+        - status: the status of the computation, can be SUCCESS, NO_SHORT_CIRCUIT_DATA (in case the reactances of
         generators are missing), SOLVER_FAILURE or FAILURE
-        - short_circuit_power: the value of the shortcircuit power (in MVA)
-        - time_constant: the duration before reaching the permanent shortcircuit current
+        - short_circuit_power: the value of the short-circuit power (in MVA)
+        - time_constant: the duration before reaching the permanent short-circuit current
         - current: the current at the fault, either only the three-phase magnitude or detailed with magnitudes and
         angles on each phase (in A)
         - voltage: the voltage at the fault, either only the three-phase magnitude or detailed with magnitudes and
@@ -37,7 +37,7 @@ class ShortCircuitAnalysisResult:
     @property
     def feeder_results(self) -> pd.DataFrame:
         """
-        contains the contributions of each feeder to the short circuit current, in a dataframe representation. The rows
+        contains the contributions of each feeder to the short-circuit current, in a dataframe representation. The rows
         are the ids of contributing connectable ids sorted by faults and the columns is the current, either in
         three-phase magnitude or detailed with magnitude and angle for each phase. The magnitude of the currents are in
         A. It should be empty when the parameter with_feeder_result is set to false
@@ -64,7 +64,7 @@ class ShortCircuitAnalysisResult:
     @property
     def voltage_bus_results(self) -> pd.DataFrame:
         """
-        contains a list of all the short circuit voltage bus results, in a dataframe representation.
+        contains a list of all the short-circuit voltage bus results, in a dataframe representation.
         The rows are for each fault the IDs of the buses sorted by voltage level ID and the columns are:
         - initial_voltage_magnitude: the initial voltage at the bus in kV
         - voltage_drop_proportional: the voltage drop in percent


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update, the currents in the short-circuit results are given in A.