### PR TITLE
[Network modifications] Fix: no exception should be thrown if boolean throwException is false

### DIFF
--- a/java/src/main/java/com/powsybl/dataframe/network/adders/AbstractBranchSeries.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/AbstractBranchSeries.java
@@ -58,6 +58,6 @@ abstract class AbstractBranchSeries extends IdentifiableSeries {
         applyIfPresent(nodes2, row, adder::setNode2);
     }
 
-    abstract BranchAdder create(Network network, int row);
+    abstract BranchAdder create(Network network, int row, boolean throwException);
 
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/AbstractBranchSeries.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/AbstractBranchSeries.java
@@ -12,6 +12,8 @@ import com.powsybl.dataframe.update.UpdatingDataframe;
 import com.powsybl.iidm.network.BranchAdder;
 import com.powsybl.iidm.network.Network;
 
+import java.util.Optional;
+
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
 
 /**
@@ -58,6 +60,10 @@ abstract class AbstractBranchSeries extends IdentifiableSeries {
         applyIfPresent(nodes2, row, adder::setNode2);
     }
 
-    abstract BranchAdder create(Network network, int row, boolean throwException);
+    BranchAdder create(Network network, int row) {
+        return create(network, row, true).orElseThrow();
+    }
+
+    abstract Optional<BranchAdder> create(Network network, int row, boolean throwException);
 
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/AbstractFeederBaysSeries.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/AbstractFeederBaysSeries.java
@@ -19,10 +19,10 @@ public abstract class AbstractFeederBaysSeries {
 
     abstract AbstractBranchSeries createTypedSeries(UpdatingDataframe dataframe);
 
-    public CreateBranchFeederBaysBuilder createBuilder(Network n, UpdatingDataframe dataframe, int row) {
+    public CreateBranchFeederBaysBuilder createBuilder(Network n, UpdatingDataframe dataframe, int row, boolean throwException) {
         AbstractBranchSeries series = createTypedSeries(dataframe);
         CreateBranchFeederBaysBuilder builder = new CreateBranchFeederBaysBuilder();
-        BranchAdder<?, ?> lAdder = series.create(n, row);
+        BranchAdder<?, ?> lAdder = series.create(n, row, throwException);
         builder.withBranchAdder(lAdder);
         applyIfPresent(dataframe.getStrings("bus_or_busbar_section_id_1"), row, builder::withBusOrBusbarSectionId1);
         applyIfPresent(dataframe.getStrings("bus_or_busbar_section_id_2"), row, builder::withBusOrBusbarSectionId2);

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/AbstractFeederBaysSeries.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/AbstractFeederBaysSeries.java
@@ -13,27 +13,28 @@ import com.powsybl.iidm.network.BranchAdder;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.extensions.ConnectablePosition;
 
+import java.util.Optional;
+
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
 
 public abstract class AbstractFeederBaysSeries {
 
     abstract AbstractBranchSeries createTypedSeries(UpdatingDataframe dataframe);
 
-    public CreateBranchFeederBaysBuilder createBuilder(Network n, UpdatingDataframe dataframe, int row, boolean throwException) {
+    public Optional<CreateBranchFeederBaysBuilder> createBuilder(Network n, UpdatingDataframe dataframe, int row, boolean throwException) {
         AbstractBranchSeries series = createTypedSeries(dataframe);
         CreateBranchFeederBaysBuilder builder = new CreateBranchFeederBaysBuilder();
-        BranchAdder<?, ?> lAdder = series.create(n, row, throwException);
-        if (lAdder != null) {
-            builder.withBranchAdder(lAdder);
+        Optional<BranchAdder> lineAdder = series.create(n, row, throwException);
+        if (lineAdder.isPresent()) {
+            builder.withBranchAdder(lineAdder.get());
             applyIfPresent(dataframe.getStrings("bus_or_busbar_section_id_1"), row, builder::withBusOrBusbarSectionId1);
             applyIfPresent(dataframe.getStrings("bus_or_busbar_section_id_2"), row, builder::withBusOrBusbarSectionId2);
             applyIfPresent(dataframe.getInts("position_order_1"), row, builder::withPositionOrder1);
             applyIfPresent(dataframe.getInts("position_order_2"), row, builder::withPositionOrder2);
             applyIfPresent(dataframe.getStrings("direction_1"), row, ConnectablePosition.Direction.class, builder::withDirection1);
             applyIfPresent(dataframe.getStrings("direction_2"), row, ConnectablePosition.Direction.class, builder::withDirection2);
-            return builder;
-        } else {
-            return null;
+            return Optional.of(builder);
         }
+        return Optional.empty();
     }
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/AbstractFeederBaysSeries.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/AbstractFeederBaysSeries.java
@@ -23,13 +23,17 @@ public abstract class AbstractFeederBaysSeries {
         AbstractBranchSeries series = createTypedSeries(dataframe);
         CreateBranchFeederBaysBuilder builder = new CreateBranchFeederBaysBuilder();
         BranchAdder<?, ?> lAdder = series.create(n, row, throwException);
-        builder.withBranchAdder(lAdder);
-        applyIfPresent(dataframe.getStrings("bus_or_busbar_section_id_1"), row, builder::withBusOrBusbarSectionId1);
-        applyIfPresent(dataframe.getStrings("bus_or_busbar_section_id_2"), row, builder::withBusOrBusbarSectionId2);
-        applyIfPresent(dataframe.getInts("position_order_1"), row, builder::withPositionOrder1);
-        applyIfPresent(dataframe.getInts("position_order_2"), row, builder::withPositionOrder2);
-        applyIfPresent(dataframe.getStrings("direction_1"), row, ConnectablePosition.Direction.class, builder::withDirection1);
-        applyIfPresent(dataframe.getStrings("direction_2"), row, ConnectablePosition.Direction.class, builder::withDirection2);
-        return builder;
+        if (lAdder != null) {
+            builder.withBranchAdder(lAdder);
+            applyIfPresent(dataframe.getStrings("bus_or_busbar_section_id_1"), row, builder::withBusOrBusbarSectionId1);
+            applyIfPresent(dataframe.getStrings("bus_or_busbar_section_id_2"), row, builder::withBusOrBusbarSectionId2);
+            applyIfPresent(dataframe.getInts("position_order_1"), row, builder::withPositionOrder1);
+            applyIfPresent(dataframe.getInts("position_order_2"), row, builder::withPositionOrder2);
+            applyIfPresent(dataframe.getStrings("direction_1"), row, ConnectablePosition.Direction.class, builder::withDirection1);
+            applyIfPresent(dataframe.getStrings("direction_2"), row, ConnectablePosition.Direction.class, builder::withDirection2);
+            return builder;
+        } else {
+            return null;
+        }
     }
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/AbstractSimpleAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/AbstractSimpleAdder.java
@@ -38,7 +38,7 @@ public abstract class AbstractSimpleAdder implements NetworkElementAdder {
     }
 
     public void addElements(Network network, UpdatingDataframe dataframe) {
-        addElements(network, dataframe, (n, df, adder, row, throwException, reporter) -> add(adder), false, Reporter.NO_OP);
+        addElements(network, dataframe, (n, df, adder, row, throwException, reporter) -> add(adder), true, Reporter.NO_OP);
     }
 
     void addElements(Network network, UpdatingDataframe dataframe, AbstractSimpleAdder.AdditionStrategy addition, boolean throwException, Reporter reporter) {
@@ -46,22 +46,22 @@ public abstract class AbstractSimpleAdder implements NetworkElementAdder {
     }
 
     private void add(InjectionAdder<?, ?> injectionAdder) {
-        if (injectionAdder instanceof LoadAdder) {
-            ((LoadAdder) injectionAdder).add();
-        } else if (injectionAdder instanceof BatteryAdder) {
-            ((BatteryAdder) injectionAdder).add();
-        } else if (injectionAdder instanceof DanglingLineAdder) {
-            ((DanglingLineAdder) injectionAdder).add();
-        } else if (injectionAdder instanceof GeneratorAdder) {
-            ((GeneratorAdder) injectionAdder).add();
-        } else if (injectionAdder instanceof ShuntCompensatorAdder) {
-            ((ShuntCompensatorAdder) injectionAdder).add();
-        } else if (injectionAdder instanceof StaticVarCompensatorAdder) {
-            ((StaticVarCompensatorAdder) injectionAdder).add();
-        } else if (injectionAdder instanceof LccConverterStationAdder) {
-            ((LccConverterStationAdder) injectionAdder).add();
-        } else if (injectionAdder instanceof VscConverterStationAdder) {
-            ((VscConverterStationAdder) injectionAdder).add();
+        if (injectionAdder instanceof LoadAdder loadAdder) {
+            loadAdder.add();
+        } else if (injectionAdder instanceof BatteryAdder batteryAdder) {
+            batteryAdder.add();
+        } else if (injectionAdder instanceof DanglingLineAdder danglingLineAdder) {
+            danglingLineAdder.add();
+        } else if (injectionAdder instanceof GeneratorAdder generatorAdder) {
+            generatorAdder.add();
+        } else if (injectionAdder instanceof ShuntCompensatorAdder shuntCompensatorAdder) {
+            shuntCompensatorAdder.add();
+        } else if (injectionAdder instanceof StaticVarCompensatorAdder staticVarCompensatorAdder) {
+            staticVarCompensatorAdder.add();
+        } else if (injectionAdder instanceof LccConverterStationAdder lccConverterStationAdder) {
+            lccConverterStationAdder.add();
+        } else if (injectionAdder instanceof VscConverterStationAdder vscConverterStationAdder) {
+            vscConverterStationAdder.add();
         } else {
             throw new AssertionError("Given InjectionAdder not supported: " + injectionAdder.getClass().getName());
         }

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/LccStationDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/LccStationDataframeAdder.java
@@ -13,6 +13,7 @@ import com.powsybl.dataframe.update.StringSeries;
 import com.powsybl.dataframe.update.UpdatingDataframe;
 import com.powsybl.iidm.network.LccConverterStationAdder;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.VoltageLevel;
 
 import java.util.Collections;
 import java.util.List;
@@ -58,13 +59,17 @@ public class LccStationDataframeAdder extends AbstractSimpleAdder {
             this.busOrBusbarSections = dataframe.getStrings("bus_or_busbar_section_id");
         }
 
-        LccConverterStationAdder createAdder(Network network, int row) {
-            LccConverterStationAdder adder = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels, busOrBusbarSections)
-                    .newLccConverterStation();
-            setInjectionAttributes(adder, row);
-            applyIfPresent(lossFactors, row, f -> adder.setLossFactor((float) f));
-            applyIfPresent(powerFactors, row, f -> adder.setPowerFactor((float) f));
-            return adder;
+        LccConverterStationAdder createAdder(Network network, int row, boolean throwException) {
+            VoltageLevel vl = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels, busOrBusbarSections, throwException);
+            if (vl != null) {
+                LccConverterStationAdder adder = vl.newLccConverterStation();
+                setInjectionAttributes(adder, row);
+                applyIfPresent(lossFactors, row, f -> adder.setLossFactor((float) f));
+                applyIfPresent(powerFactors, row, f -> adder.setPowerFactor((float) f));
+                return adder;
+            } else {
+                return null;
+            }
         }
     }
 
@@ -72,8 +77,10 @@ public class LccStationDataframeAdder extends AbstractSimpleAdder {
     public void addElements(Network network, UpdatingDataframe dataframe, AdditionStrategy additionStrategy, boolean throwException, Reporter reporter) {
         LccStationSeries series = new LccStationSeries(dataframe);
         for (int row = 0; row < dataframe.getRowCount(); row++) {
-            LccConverterStationAdder adder = series.createAdder(network, row);
-            additionStrategy.add(network, dataframe, adder, row, throwException, reporter);
+            LccConverterStationAdder adder = series.createAdder(network, row, throwException);
+            if (adder != null) {
+                additionStrategy.add(network, dataframe, adder, row, throwException, reporter);
+            }
         }
     }
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/LineDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/LineDataframeAdder.java
@@ -48,7 +48,7 @@ public class LineDataframeAdder extends AbstractSimpleAdder {
     public void addElements(Network network, UpdatingDataframe dataframe) {
         LineSeries series = new LineSeries(dataframe);
         for (int row = 0; row < dataframe.getRowCount(); row++) {
-            series.create(network, row).add();
+            series.create(network, row, true).add();
         }
     }
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/LineDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/LineDataframeAdder.java
@@ -48,7 +48,7 @@ public class LineDataframeAdder extends AbstractSimpleAdder {
     public void addElements(Network network, UpdatingDataframe dataframe) {
         LineSeries series = new LineSeries(dataframe);
         for (int row = 0; row < dataframe.getRowCount(); row++) {
-            series.create(network, row, true).add();
+            series.create(network, row).add();
         }
     }
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/LineSeries.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/LineSeries.java
@@ -2,8 +2,11 @@ package com.powsybl.dataframe.network.adders;
 
 import com.powsybl.dataframe.update.DoubleSeries;
 import com.powsybl.dataframe.update.UpdatingDataframe;
+import com.powsybl.iidm.network.BranchAdder;
 import com.powsybl.iidm.network.LineAdder;
 import com.powsybl.iidm.network.Network;
+
+import java.util.Optional;
 
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
 
@@ -26,7 +29,7 @@ public class LineSeries extends AbstractBranchSeries {
         this.x = dataframe.getDoubles("x");
     }
 
-    LineAdder create(Network network, int row, boolean throwException) {
+    Optional<BranchAdder> create(Network network, int row, boolean throwException) {
         LineAdder adder = network.newLine();
         setBranchAttributes(adder, row);
         applyIfPresent(b1, row, adder::setB1);
@@ -35,6 +38,6 @@ public class LineSeries extends AbstractBranchSeries {
         applyIfPresent(g2, row, adder::setG2);
         applyIfPresent(r, row, adder::setR);
         applyIfPresent(x, row, adder::setX);
-        return adder;
+        return Optional.of(adder);
     }
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/LineSeries.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/LineSeries.java
@@ -26,7 +26,7 @@ public class LineSeries extends AbstractBranchSeries {
         this.x = dataframe.getDoubles("x");
     }
 
-    LineAdder create(Network network, int row) {
+    LineAdder create(Network network, int row, boolean throwException) {
         LineAdder adder = network.newLine();
         setBranchAttributes(adder, row);
         applyIfPresent(b1, row, adder::setB1);

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/LoadDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/LoadDataframeAdder.java
@@ -18,6 +18,7 @@ import com.powsybl.iidm.network.VoltageLevel;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static com.powsybl.dataframe.network.adders.NetworkUtils.getVoltageLevelOrThrowWithBusOrBusbarSectionId;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
@@ -63,17 +64,17 @@ public class LoadDataframeAdder extends AbstractSimpleAdder {
             this.busOrBusbarSections = dataframe.getStrings("bus_or_busbar_section_id");
         }
 
-        LoadAdder createAdder(Network network, int row, boolean throwException) {
-            VoltageLevel vl = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels, busOrBusbarSections, throwException);
-            if (vl != null) {
-                LoadAdder adder = vl.newLoad();
+        Optional<LoadAdder> createAdder(Network network, int row, boolean throwException) {
+            Optional<VoltageLevel> vl = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels, busOrBusbarSections, throwException);
+            if (vl.isPresent()) {
+                LoadAdder adder = vl.get().newLoad();
                 setInjectionAttributes(adder, row);
                 applyIfPresent(p0, row, adder::setP0);
                 applyIfPresent(q0, row, adder::setQ0);
                 applyIfPresent(type, row, LoadType.class, adder::setLoadType);
-                return adder;
+                return Optional.of(adder);
             }
-            return null;
+            return Optional.empty();
         }
     }
 
@@ -81,9 +82,9 @@ public class LoadDataframeAdder extends AbstractSimpleAdder {
     public void addElements(Network network, UpdatingDataframe dataframe, AdditionStrategy addition, boolean throwException, Reporter reporter) {
         LoadSeries series = new LoadSeries(dataframe);
         for (int row = 0; row < dataframe.getRowCount(); row++) {
-            LoadAdder adder = series.createAdder(network, row, throwException);
-            if (adder != null) {
-                addition.add(network, dataframe, adder, row, throwException, reporter);
+            Optional<LoadAdder> adder = series.createAdder(network, row, throwException);
+            if (adder.isPresent()) {
+                addition.add(network, dataframe, adder.get(), row, throwException, reporter);
             }
         }
     }

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/NetworkUtils.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/NetworkUtils.java
@@ -15,43 +15,51 @@ import com.powsybl.iidm.network.*;
  */
 public final class NetworkUtils {
 
+    private static final String DOES_NOT_EXIST = " does not exist.";
+
     private NetworkUtils() {
     }
 
     public static VoltageLevel getVoltageLevelOrThrow(Network network, String id) {
         VoltageLevel voltageLevel = network.getVoltageLevel(id);
         if (voltageLevel == null) {
-            throw new PowsyblException("Voltage level " + id + " does not exist.");
+            throw new PowsyblException("Voltage level " + id + DOES_NOT_EXIST);
         }
         return voltageLevel;
     }
 
-    public static VoltageLevel getVoltageLevelOrThrowWithBusOrBusbarSectionId(Network network, int row, StringSeries voltageLevels, StringSeries busOrBusbarSections) {
+    public static VoltageLevel getVoltageLevelOrThrowWithBusOrBusbarSectionId(Network network, int row, StringSeries voltageLevels, StringSeries busOrBusbarSections, boolean throwException) {
         if (voltageLevels == null) {
             if (busOrBusbarSections != null) {
                 Identifiable<?> busOrBusbarSection = network.getIdentifiable(busOrBusbarSections.get(row));
-                if (busOrBusbarSection == null) {
+                if (busOrBusbarSection == null && throwException) {
                     throw new PowsyblException(String.format("Bus or busbar section %s not found.", busOrBusbarSections.get(row)));
+
                 }
-                if (busOrBusbarSection instanceof BusbarSection) {
-                    return ((BusbarSection) busOrBusbarSection).getTerminal().getVoltageLevel();
-                } else if (busOrBusbarSection instanceof Bus) {
-                    return ((Bus) busOrBusbarSection).getVoltageLevel();
+                if (busOrBusbarSection instanceof BusbarSection bbs) {
+                    return bbs.getTerminal().getVoltageLevel();
+                } else if (busOrBusbarSection instanceof Bus bus) {
+                    return bus.getVoltageLevel();
                 } else {
-                    throw new PowsyblException(String.format("Unsupported type %s for identifiable %s", busOrBusbarSection.getType(), busOrBusbarSection.getId()));
+                    if (throwException) {
+                        throw new PowsyblException(String.format("Unsupported type %s for identifiable %s", busOrBusbarSection.getType(), busOrBusbarSection.getId()));
+                    }
                 }
             } else {
-                throw new PowsyblException("Voltage level id and bus or busbar section id missing.");
+                if (throwException) {
+                    throw new PowsyblException("Voltage level id and bus or busbar section id missing.");
+                }
             }
         } else {
             return getVoltageLevelOrThrow(network, voltageLevels.get(row));
         }
+        return null;
     }
 
     public static Substation getSubstationOrThrow(Network network, String id) {
         Substation substation = network.getSubstation(id);
         if (substation == null) {
-            throw new PowsyblException("Substation " + id + " does not exist.");
+            throw new PowsyblException("Substation " + id + DOES_NOT_EXIST);
         }
         return substation;
     }
@@ -59,7 +67,7 @@ public final class NetworkUtils {
     public static Identifiable<?> getIdentifiableOrThrow(Network network, String id) {
         Identifiable<?> identifiable = network.getIdentifiable(id);
         if (identifiable == null) {
-            throw new PowsyblException("Network element " + id + " does not exist.");
+            throw new PowsyblException("Network element " + id + DOES_NOT_EXIST);
         }
         return identifiable;
     }

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/NetworkUtils.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/NetworkUtils.java
@@ -10,6 +10,8 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.dataframe.update.StringSeries;
 import com.powsybl.iidm.network.*;
 
+import java.util.Optional;
+
 /**
  * @author Sylvain Leclerc <sylvain.leclerc@rte-france.com>
  */
@@ -28,7 +30,7 @@ public final class NetworkUtils {
         return voltageLevel;
     }
 
-    public static VoltageLevel getVoltageLevelOrThrowWithBusOrBusbarSectionId(Network network, int row, StringSeries voltageLevels, StringSeries busOrBusbarSections, boolean throwException) {
+    public static Optional<VoltageLevel> getVoltageLevelOrThrowWithBusOrBusbarSectionId(Network network, int row, StringSeries voltageLevels, StringSeries busOrBusbarSections, boolean throwException) {
         if (voltageLevels == null) {
             if (busOrBusbarSections != null) {
                 Identifiable<?> busOrBusbarSection = network.getIdentifiable(busOrBusbarSections.get(row));
@@ -36,9 +38,9 @@ public final class NetworkUtils {
                     throw new PowsyblException(String.format("Bus or busbar section %s not found.", busOrBusbarSections.get(row)));
                 }
                 if (busOrBusbarSection instanceof BusbarSection bbs) {
-                    return bbs.getTerminal().getVoltageLevel();
+                    return Optional.of(bbs.getTerminal().getVoltageLevel());
                 } else if (busOrBusbarSection instanceof Bus bus) {
-                    return bus.getVoltageLevel();
+                    return Optional.of(bus.getVoltageLevel());
                 } else {
                     if (throwException) {
                         throw new PowsyblException(String.format("Unsupported type %s for identifiable %s", busOrBusbarSection.getType(), busOrBusbarSection.getId()));
@@ -50,9 +52,9 @@ public final class NetworkUtils {
                 }
             }
         } else {
-            return getVoltageLevelOrThrow(network, voltageLevels.get(row));
+            return Optional.of(getVoltageLevelOrThrow(network, voltageLevels.get(row)));
         }
-        return null;
+        return Optional.empty();
     }
 
     public static Substation getSubstationOrThrow(Network network, String id) {

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/NetworkUtils.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/NetworkUtils.java
@@ -34,7 +34,6 @@ public final class NetworkUtils {
                 Identifiable<?> busOrBusbarSection = network.getIdentifiable(busOrBusbarSections.get(row));
                 if (busOrBusbarSection == null && throwException) {
                     throw new PowsyblException(String.format("Bus or busbar section %s not found.", busOrBusbarSections.get(row)));
-
                 }
                 if (busOrBusbarSection instanceof BusbarSection bbs) {
                     return bbs.getTerminal().getVoltageLevel();

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/ShuntDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/ShuntDataframeAdder.java
@@ -74,7 +74,7 @@ public class ShuntDataframeAdder implements NetworkElementAdder {
         UpdatingDataframe sectionsDf = dataframes.get(2);
         ShuntCompensatorSeries series = new ShuntCompensatorSeries(shuntsDf, linearModelsDf, sectionsDf);
         for (int row = 0; row < shuntsDf.getRowCount(); row++) {
-            series.create(network, row);
+            series.create(network, row, true);
         }
     }
 
@@ -85,19 +85,21 @@ public class ShuntDataframeAdder implements NetworkElementAdder {
         UpdatingDataframe sectionsDf = dataframes.get(2);
         ShuntCompensatorSeries series = new ShuntCompensatorSeries(shuntsDf, linearModelsDf, sectionsDf);
         for (int row = 0; row < shuntsDf.getRowCount(); row++) {
-            ShuntCompensatorAdder adder = series.createAdder(network, row);
-            String busOrBusbarSectionId = shuntsDf.getStrings("bus_or_busbar_section_id").get(row);
-            OptionalInt injectionPositionOrder = shuntsDf.getIntValue("position_order", row);
-            ConnectablePosition.Direction direction = ConnectablePosition.Direction.valueOf(shuntsDf.getStringValue("direction", row).orElse("BOTTOM"));
-            CreateFeederBayBuilder builder = new CreateFeederBayBuilder()
-                    .withInjectionAdder(adder)
-                    .withBusOrBusbarSectionId(busOrBusbarSectionId)
-                    .withInjectionDirection(direction);
-            if (injectionPositionOrder.isPresent()) {
-                builder.withInjectionPositionOrder(injectionPositionOrder.getAsInt());
+            ShuntCompensatorAdder adder = series.createAdder(network, row, throwException);
+            if (adder != null) {
+                String busOrBusbarSectionId = shuntsDf.getStrings("bus_or_busbar_section_id").get(row);
+                OptionalInt injectionPositionOrder = shuntsDf.getIntValue("position_order", row);
+                ConnectablePosition.Direction direction = ConnectablePosition.Direction.valueOf(shuntsDf.getStringValue("direction", row).orElse("BOTTOM"));
+                CreateFeederBayBuilder builder = new CreateFeederBayBuilder()
+                        .withInjectionAdder(adder)
+                        .withBusOrBusbarSectionId(busOrBusbarSectionId)
+                        .withInjectionDirection(direction);
+                if (injectionPositionOrder.isPresent()) {
+                    builder.withInjectionPositionOrder(injectionPositionOrder.getAsInt());
+                }
+                NetworkModification modification = builder.build();
+                modification.apply(network, throwException, reporter == null ? Reporter.NO_OP : reporter);
             }
-            NetworkModification modification = builder.build();
-            modification.apply(network, throwException, reporter == null ? Reporter.NO_OP : reporter);
         }
     }
 
@@ -151,83 +153,89 @@ public class ShuntDataframeAdder implements NetworkElementAdder {
             }
         }
 
-        ShuntCompensatorAdder createAdder(Network network, int row) {
+        ShuntCompensatorAdder createAdder(Network network, int row, boolean throwException) {
             String shuntId = ids.get(row);
-            ShuntCompensatorAdder adder = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels, busOrBusbarSections)
-                    .newShuntCompensator();
-            setInjectionAttributes(adder, row);
-            applyIfPresent(sectionCount, row, adder::setSectionCount);
-            applyIfPresent(targetDeadband, row, adder::setTargetDeadband);
-            applyIfPresent(targetV, row, adder::setTargetV);
+            VoltageLevel vl = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels, busOrBusbarSections, throwException);
+            if (vl != null) {
+                ShuntCompensatorAdder adder = vl.newShuntCompensator();
+                setInjectionAttributes(adder, row);
+                applyIfPresent(sectionCount, row, adder::setSectionCount);
+                applyIfPresent(targetDeadband, row, adder::setTargetDeadband);
+                applyIfPresent(targetV, row, adder::setTargetV);
 
-            ShuntCompensatorModelType modelType = ShuntCompensatorModelType.valueOf(modelTypes.get(row));
+                ShuntCompensatorModelType modelType = ShuntCompensatorModelType.valueOf(modelTypes.get(row));
 
-            if (modelType == ShuntCompensatorModelType.LINEAR) {
-                ShuntCompensatorLinearModelAdder linearModelAdder = adder.newLinearModel();
-                int index = linearModelsIndexes.get(shuntId);
-                if (index == -1) {
-                    throw new PowsyblException("one section must be defined for a linear shunt");
+                if (modelType == ShuntCompensatorModelType.LINEAR) {
+                    ShuntCompensatorLinearModelAdder linearModelAdder = adder.newLinearModel();
+                    int index = linearModelsIndexes.get(shuntId);
+                    if (index == -1) {
+                        throw new PowsyblException("one section must be defined for a linear shunt");
+                    }
+                    applyIfPresent(bPerSection, index, linearModelAdder::setBPerSection);
+                    applyIfPresent(gPerSection, index, linearModelAdder::setGPerSection);
+                    applyIfPresent(maxSectionCount, index, linearModelAdder::setMaximumSectionCount);
+                    linearModelAdder.add();
+                } else if (modelType == ShuntCompensatorModelType.NON_LINEAR) {
+                    ShuntCompensatorNonLinearModelAdder nonLinearAdder = adder.newNonLinearModel();
+                    TIntArrayList sections = sectionsIndexes.get(shuntId);
+                    if (sections == null) {
+                        throw new PowsyblException("At least one section must be defined for a non linear shunt.");
+                    }
+                    sections.forEach(i -> {
+                        ShuntCompensatorNonLinearModelAdder.SectionAdder section = nonLinearAdder.beginSection();
+                        applyIfPresent(g, i, section::setG);
+                        applyIfPresent(b, i, section::setB);
+                        section.endSection();
+                        return true;
+                    });
+                    nonLinearAdder.add();
+                } else {
+                    throw new PowsyblException("shunt model type non valid");
                 }
-                applyIfPresent(bPerSection, index, linearModelAdder::setBPerSection);
-                applyIfPresent(gPerSection, index, linearModelAdder::setGPerSection);
-                applyIfPresent(maxSectionCount, index, linearModelAdder::setMaximumSectionCount);
-                linearModelAdder.add();
-            } else if (modelType == ShuntCompensatorModelType.NON_LINEAR) {
-                ShuntCompensatorNonLinearModelAdder nonLinearAdder = adder.newNonLinearModel();
-                TIntArrayList sections = sectionsIndexes.get(shuntId);
-                if (sections == null) {
-                    throw new PowsyblException("At least one section must be defined for a non linear shunt.");
-                }
-                sections.forEach(i -> {
-                    ShuntCompensatorNonLinearModelAdder.SectionAdder section = nonLinearAdder.beginSection();
-                    applyIfPresent(g, i, section::setG);
-                    applyIfPresent(b, i, section::setB);
-                    section.endSection();
-                    return true;
-                });
-                nonLinearAdder.add();
+                return adder;
             } else {
-                throw new PowsyblException("shunt model type non valid");
+                return null;
             }
-            return adder;
         }
 
-        void create(Network network, int row) {
-            ShuntCompensatorAdder adder = createAdder(network, row);
-            adder.add();
+        void create(Network network, int row, boolean throwException) {
+            ShuntCompensatorAdder adder = createAdder(network, row, throwException);
+            if (adder != null) {
+                adder.add();
+            }
         }
-    }
 
-    /**
-     * Mapping shunt ID --> index of line in dataframe
-     */
-    private static TObjectIntMap<String> getLinearModelsIndexes(UpdatingDataframe linearModelsDf) {
-        StringSeries ids = linearModelsDf.getStrings("id");
-        if (ids == null) {
-            throw new PowsyblException("Linear models dataframe: id is not set");
+        /**
+         * Mapping shunt ID --> index of line in dataframe
+         */
+        private static TObjectIntMap<String> getLinearModelsIndexes(UpdatingDataframe linearModelsDf) {
+            StringSeries ids = linearModelsDf.getStrings("id");
+            if (ids == null) {
+                throw new PowsyblException("Linear models dataframe: id is not set");
+            }
+            TObjectIntMap<String> indexes = new TObjectIntHashMap<>(10, 0.5f, -1);
+            for (int modelIndex = 0; modelIndex < linearModelsDf.getRowCount(); modelIndex++) {
+                String shuntId = ids.get(modelIndex);
+                indexes.put(shuntId, modelIndex);
+            }
+            return indexes;
         }
-        TObjectIntMap<String> indexes = new TObjectIntHashMap<>(10, 0.5f, -1);
-        for (int modelIndex = 0; modelIndex < linearModelsDf.getRowCount(); modelIndex++) {
-            String shuntId = ids.get(modelIndex);
-            indexes.put(shuntId, modelIndex);
-        }
-        return indexes;
-    }
 
-    /**
-     * Mapping shunt ID --> index of lines in dataframe
-     */
-    private static Map<String, TIntArrayList> getSectionsIndexes(UpdatingDataframe sectionsDf) {
-        StringSeries ids = sectionsDf.getStrings("id");
-        if (ids == null) {
-            throw new PowsyblException("Shunt sections dataframe: id is not set");
+        /**
+         * Mapping shunt ID --> index of lines in dataframe
+         */
+        private static Map<String, TIntArrayList> getSectionsIndexes(UpdatingDataframe sectionsDf) {
+            StringSeries ids = sectionsDf.getStrings("id");
+            if (ids == null) {
+                throw new PowsyblException("Shunt sections dataframe: id is not set");
+            }
+            Map<String, TIntArrayList> sectionsIndexes = new HashMap<>();
+            for (int sectionIndex = 0; sectionIndex < sectionsDf.getRowCount(); sectionIndex++) {
+                String shuntId = ids.get(sectionIndex);
+                sectionsIndexes.computeIfAbsent(shuntId, k -> new TIntArrayList())
+                        .add(sectionIndex);
+            }
+            return sectionsIndexes;
         }
-        Map<String, TIntArrayList> sectionsIndexes = new HashMap<>();
-        for (int sectionIndex = 0; sectionIndex < sectionsDf.getRowCount(); sectionIndex++) {
-            String shuntId = ids.get(sectionIndex);
-            sectionsIndexes.computeIfAbsent(shuntId, k -> new TIntArrayList())
-                    .add(sectionIndex);
-        }
-        return sectionsIndexes;
     }
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/SvcDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/SvcDataframeAdder.java
@@ -70,18 +70,22 @@ public class SvcDataframeAdder extends AbstractSimpleAdder {
             this.regulatingElements = dataframe.getStrings("regulating_element_id");
         }
 
-        StaticVarCompensatorAdder createAdder(Network network, int row) {
-            StaticVarCompensatorAdder adder = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels, busOrBusbarSections)
-                    .newStaticVarCompensator();
-            setInjectionAttributes(adder, row);
-            applyIfPresent(bMin, row, adder::setBmin);
-            applyIfPresent(bMax, row, adder::setBmax);
-            applyIfPresent(targetQ, row, adder::setReactivePowerSetpoint);
-            applyIfPresent(targetV, row, adder::setVoltageSetpoint);
-            applyIfPresent(regulationModes, row, StaticVarCompensator.RegulationMode.class, adder::setRegulationMode);
-            applyIfPresent(regulatingElements, row, elementId -> NetworkUtil
-                    .setRegulatingTerminal(adder::setRegulatingTerminal, network, elementId));
-            return adder;
+        StaticVarCompensatorAdder createAdder(Network network, int row, boolean throwException) {
+            VoltageLevel vl = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels, busOrBusbarSections, throwException);
+            if (vl != null) {
+                StaticVarCompensatorAdder adder = vl.newStaticVarCompensator();
+                setInjectionAttributes(adder, row);
+                applyIfPresent(bMin, row, adder::setBmin);
+                applyIfPresent(bMax, row, adder::setBmax);
+                applyIfPresent(targetQ, row, adder::setReactivePowerSetpoint);
+                applyIfPresent(targetV, row, adder::setVoltageSetpoint);
+                applyIfPresent(regulationModes, row, StaticVarCompensator.RegulationMode.class, adder::setRegulationMode);
+                applyIfPresent(regulatingElements, row, elementId -> NetworkUtil
+                        .setRegulatingTerminal(adder::setRegulatingTerminal, network, elementId));
+                return adder;
+            } else {
+                return null;
+            }
         }
     }
 
@@ -89,8 +93,10 @@ public class SvcDataframeAdder extends AbstractSimpleAdder {
     public void addElements(Network network, UpdatingDataframe dataframe, AdditionStrategy addition, boolean throwException, Reporter reporter) {
         StaticVarCompensatorSeries series = new StaticVarCompensatorSeries(dataframe);
         for (int row = 0; row < dataframe.getRowCount(); row++) {
-            StaticVarCompensatorAdder adder = series.createAdder(network, row);
-            addition.add(network, dataframe, adder, row, throwException, reporter);
+            StaticVarCompensatorAdder adder = series.createAdder(network, row, throwException);
+            if (adder != null) {
+                addition.add(network, dataframe, adder, row, throwException, reporter);
+            }
         }
     }
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/SvcDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/SvcDataframeAdder.java
@@ -16,6 +16,7 @@ import com.powsybl.python.network.NetworkUtil;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static com.powsybl.dataframe.network.adders.NetworkUtils.getVoltageLevelOrThrowWithBusOrBusbarSectionId;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
@@ -70,10 +71,10 @@ public class SvcDataframeAdder extends AbstractSimpleAdder {
             this.regulatingElements = dataframe.getStrings("regulating_element_id");
         }
 
-        StaticVarCompensatorAdder createAdder(Network network, int row, boolean throwException) {
-            VoltageLevel vl = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels, busOrBusbarSections, throwException);
-            if (vl != null) {
-                StaticVarCompensatorAdder adder = vl.newStaticVarCompensator();
+        Optional<StaticVarCompensatorAdder> createAdder(Network network, int row, boolean throwException) {
+            Optional<VoltageLevel> vl = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels, busOrBusbarSections, throwException);
+            if (vl.isPresent()) {
+                StaticVarCompensatorAdder adder = vl.get().newStaticVarCompensator();
                 setInjectionAttributes(adder, row);
                 applyIfPresent(bMin, row, adder::setBmin);
                 applyIfPresent(bMax, row, adder::setBmax);
@@ -82,10 +83,9 @@ public class SvcDataframeAdder extends AbstractSimpleAdder {
                 applyIfPresent(regulationModes, row, StaticVarCompensator.RegulationMode.class, adder::setRegulationMode);
                 applyIfPresent(regulatingElements, row, elementId -> NetworkUtil
                         .setRegulatingTerminal(adder::setRegulatingTerminal, network, elementId));
-                return adder;
-            } else {
-                return null;
+                return Optional.of(adder);
             }
+            return Optional.empty();
         }
     }
 
@@ -93,9 +93,9 @@ public class SvcDataframeAdder extends AbstractSimpleAdder {
     public void addElements(Network network, UpdatingDataframe dataframe, AdditionStrategy addition, boolean throwException, Reporter reporter) {
         StaticVarCompensatorSeries series = new StaticVarCompensatorSeries(dataframe);
         for (int row = 0; row < dataframe.getRowCount(); row++) {
-            StaticVarCompensatorAdder adder = series.createAdder(network, row, throwException);
-            if (adder != null) {
-                addition.add(network, dataframe, adder, row, throwException, reporter);
+            Optional<StaticVarCompensatorAdder> adder = series.createAdder(network, row, throwException);
+            if (adder.isPresent()) {
+                addition.add(network, dataframe, adder.get(), row, throwException, reporter);
             }
         }
     }

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/TwoWindingsTransformerSeries.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/TwoWindingsTransformerSeries.java
@@ -20,6 +20,8 @@ import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
 
 public class TwoWindingsTransformerSeries extends AbstractBranchSeries {
 
+    private static final String COULD_NOT_CREATE_TRANSFORMER = "Could not create transformer ";
+
     private final DoubleSeries ratedU1;
     private final DoubleSeries ratedU2;
     private final DoubleSeries ratedS;
@@ -39,14 +41,14 @@ public class TwoWindingsTransformerSeries extends AbstractBranchSeries {
         this.x = dataframe.getDoubles("x");
     }
 
-    TwoWindingsTransformerAdder create(Network network, int row) {
+    TwoWindingsTransformerAdder create(Network network, int row, boolean throwException) {
         String id = ids.get(row);
-        VoltageLevel vl1 = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels1, busOrBusbarSections1);
-        VoltageLevel vl2 = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels2, busOrBusbarSections2);
-        Substation s1 = vl1.getSubstation().orElseThrow(() -> new PowsyblException("Could not create transformer " + id + ": no substation."));
-        Substation s2 = vl2.getSubstation().orElseThrow(() -> new PowsyblException("Could not create transformer " + id + ": no substation."));
+        VoltageLevel vl1 = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels1, busOrBusbarSections1, throwException);
+        VoltageLevel vl2 = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels2, busOrBusbarSections2, throwException);
+        Substation s1 = vl1.getSubstation().orElseThrow(() -> new PowsyblException(COULD_NOT_CREATE_TRANSFORMER + id + ": no substation."));
+        Substation s2 = vl2.getSubstation().orElseThrow(() -> new PowsyblException(COULD_NOT_CREATE_TRANSFORMER + id + ": no substation."));
         if (s1 != s2) {
-            throw new PowsyblException("Could not create transformer " + id + ": both voltage ids must be on the same substation");
+            throw new PowsyblException(COULD_NOT_CREATE_TRANSFORMER + id + ": both voltage ids must be on the same substation");
         }
 
         var adder = s1.newTwoWindingsTransformer();

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/TwoWindingsTransformerSeries.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/TwoWindingsTransformerSeries.java
@@ -45,21 +45,25 @@ public class TwoWindingsTransformerSeries extends AbstractBranchSeries {
         String id = ids.get(row);
         VoltageLevel vl1 = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels1, busOrBusbarSections1, throwException);
         VoltageLevel vl2 = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels2, busOrBusbarSections2, throwException);
-        Substation s1 = vl1.getSubstation().orElseThrow(() -> new PowsyblException(COULD_NOT_CREATE_TRANSFORMER + id + ": no substation."));
-        Substation s2 = vl2.getSubstation().orElseThrow(() -> new PowsyblException(COULD_NOT_CREATE_TRANSFORMER + id + ": no substation."));
-        if (s1 != s2) {
-            throw new PowsyblException(COULD_NOT_CREATE_TRANSFORMER + id + ": both voltage ids must be on the same substation");
-        }
+        if (vl1 != null && vl2 != null) {
+            Substation s1 = vl1.getSubstation().orElseThrow(() -> new PowsyblException(COULD_NOT_CREATE_TRANSFORMER + id + ": no substation."));
+            Substation s2 = vl2.getSubstation().orElseThrow(() -> new PowsyblException(COULD_NOT_CREATE_TRANSFORMER + id + ": no substation."));
+            if (s1 != s2) {
+                throw new PowsyblException(COULD_NOT_CREATE_TRANSFORMER + id + ": both voltage ids must be on the same substation");
+            }
 
-        var adder = s1.newTwoWindingsTransformer();
-        setBranchAttributes(adder, row);
-        applyIfPresent(ratedU1, row, adder::setRatedU1);
-        applyIfPresent(ratedU2, row, adder::setRatedU2);
-        applyIfPresent(ratedS, row, adder::setRatedS);
-        applyIfPresent(b, row, adder::setB);
-        applyIfPresent(g, row, adder::setG);
-        applyIfPresent(r, row, adder::setR);
-        applyIfPresent(x, row, adder::setX);
-        return adder;
+            var adder = s1.newTwoWindingsTransformer();
+            setBranchAttributes(adder, row);
+            applyIfPresent(ratedU1, row, adder::setRatedU1);
+            applyIfPresent(ratedU2, row, adder::setRatedU2);
+            applyIfPresent(ratedS, row, adder::setRatedS);
+            applyIfPresent(b, row, adder::setB);
+            applyIfPresent(g, row, adder::setG);
+            applyIfPresent(r, row, adder::setR);
+            applyIfPresent(x, row, adder::setX);
+            return adder;
+        } else {
+            return null;
+        }
     }
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/TwoWindingsTransformerSeries.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/TwoWindingsTransformerSeries.java
@@ -10,10 +10,9 @@ package com.powsybl.dataframe.network.adders;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.dataframe.update.DoubleSeries;
 import com.powsybl.dataframe.update.UpdatingDataframe;
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.Substation;
-import com.powsybl.iidm.network.TwoWindingsTransformerAdder;
-import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.iidm.network.*;
+
+import java.util.Optional;
 
 import static com.powsybl.dataframe.network.adders.NetworkUtils.getVoltageLevelOrThrowWithBusOrBusbarSectionId;
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
@@ -41,13 +40,13 @@ public class TwoWindingsTransformerSeries extends AbstractBranchSeries {
         this.x = dataframe.getDoubles("x");
     }
 
-    TwoWindingsTransformerAdder create(Network network, int row, boolean throwException) {
+    Optional<BranchAdder> create(Network network, int row, boolean throwException) {
         String id = ids.get(row);
-        VoltageLevel vl1 = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels1, busOrBusbarSections1, throwException);
-        VoltageLevel vl2 = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels2, busOrBusbarSections2, throwException);
-        if (vl1 != null && vl2 != null) {
-            Substation s1 = vl1.getSubstation().orElseThrow(() -> new PowsyblException(COULD_NOT_CREATE_TRANSFORMER + id + ": no substation."));
-            Substation s2 = vl2.getSubstation().orElseThrow(() -> new PowsyblException(COULD_NOT_CREATE_TRANSFORMER + id + ": no substation."));
+        Optional<VoltageLevel> vl1 = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels1, busOrBusbarSections1, throwException);
+        Optional<VoltageLevel> vl2 = getVoltageLevelOrThrowWithBusOrBusbarSectionId(network, row, voltageLevels2, busOrBusbarSections2, throwException);
+        if (vl1.isPresent() && vl2.isPresent()) {
+            Substation s1 = vl1.get().getSubstation().orElseThrow(() -> new PowsyblException(COULD_NOT_CREATE_TRANSFORMER + id + ": no substation."));
+            Substation s2 = vl2.get().getSubstation().orElseThrow(() -> new PowsyblException(COULD_NOT_CREATE_TRANSFORMER + id + ": no substation."));
             if (s1 != s2) {
                 throw new PowsyblException(COULD_NOT_CREATE_TRANSFORMER + id + ": both voltage ids must be on the same substation");
             }
@@ -61,9 +60,8 @@ public class TwoWindingsTransformerSeries extends AbstractBranchSeries {
             applyIfPresent(g, row, adder::setG);
             applyIfPresent(r, row, adder::setR);
             applyIfPresent(x, row, adder::setX);
-            return adder;
-        } else {
-            return null;
+            return Optional.of(adder);
         }
+        return Optional.empty();
     }
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/TwtDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/TwtDataframeAdder.java
@@ -49,7 +49,7 @@ public class TwtDataframeAdder extends AbstractSimpleAdder {
     public void addElements(Network network, UpdatingDataframe dataframe) {
         TwoWindingsTransformerSeries series = new TwoWindingsTransformerSeries(dataframe);
         for (int row = 0; row < dataframe.getRowCount(); row++) {
-            series.create(network, row, true).add();
+            series.create(network, row).add();
         }
     }
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/adders/TwtDataframeAdder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/TwtDataframeAdder.java
@@ -49,7 +49,7 @@ public class TwtDataframeAdder extends AbstractSimpleAdder {
     public void addElements(Network network, UpdatingDataframe dataframe) {
         TwoWindingsTransformerSeries series = new TwoWindingsTransformerSeries(dataframe);
         for (int row = 0; row < dataframe.getRowCount(); row++) {
-            series.create(network, row).add();
+            series.create(network, row, true).add();
         }
     }
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/modifications/CreateLineFeeder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/modifications/CreateLineFeeder.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.dataframe.network.modifications;
 
+import com.powsybl.commons.reporter.Reporter;
 import com.powsybl.commons.reporter.ReporterModel;
 import com.powsybl.dataframe.DataframeElementType;
 import com.powsybl.dataframe.SeriesMetadata;
@@ -35,9 +36,11 @@ public class CreateLineFeeder implements NetworkModification {
         }
         for (int i = 0; i < dataframes.get(0).getRowCount(); i++) {
             FeederBaysLineSeries fbLineSeries = new FeederBaysLineSeries();
-            CreateBranchFeederBaysBuilder builder = fbLineSeries.createBuilder(network, dataframes.get(0), i);
-            com.powsybl.iidm.modification.NetworkModification modification = builder.build();
-            modification.apply(network);
+            CreateBranchFeederBaysBuilder builder = fbLineSeries.createBuilder(network, dataframes.get(0), i, throwException);
+            if (builder != null) {
+                com.powsybl.iidm.modification.NetworkModification modification = builder.build();
+                modification.apply(network, throwException, reporter == null ? Reporter.NO_OP : reporter);
+            }
         }
     }
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/modifications/CreateLineFeeder.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/modifications/CreateLineFeeder.java
@@ -18,6 +18,7 @@ import com.powsybl.iidm.network.Network;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * @author Coline Piloquet <coline.piloquet at rte-france.com>
@@ -36,9 +37,9 @@ public class CreateLineFeeder implements NetworkModification {
         }
         for (int i = 0; i < dataframes.get(0).getRowCount(); i++) {
             FeederBaysLineSeries fbLineSeries = new FeederBaysLineSeries();
-            CreateBranchFeederBaysBuilder builder = fbLineSeries.createBuilder(network, dataframes.get(0), i, throwException);
-            if (builder != null) {
-                com.powsybl.iidm.modification.NetworkModification modification = builder.build();
+            Optional<CreateBranchFeederBaysBuilder> builder = fbLineSeries.createBuilder(network, dataframes.get(0), i, throwException);
+            if (builder.isPresent()) {
+                com.powsybl.iidm.modification.NetworkModification modification = builder.get().build();
                 modification.apply(network, throwException, reporter == null ? Reporter.NO_OP : reporter);
             }
         }

--- a/java/src/main/java/com/powsybl/dataframe/network/modifications/CreateTwoWindingsTransformer.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/modifications/CreateTwoWindingsTransformer.java
@@ -18,6 +18,7 @@ import com.powsybl.iidm.network.Network;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * @author Coline Piloquet <coline.piloquet at rte-france.com>
@@ -35,9 +36,9 @@ public class CreateTwoWindingsTransformer implements NetworkModification {
         }
         for (int i = 0; i < dataframes.get(0).getRowCount(); i++) {
             FeederBaysTwtSeries fbTwtSeries = new FeederBaysTwtSeries();
-            CreateBranchFeederBaysBuilder builder = fbTwtSeries.createBuilder(network, dataframes.get(0), i, throwException);
-            if (builder != null) {
-                com.powsybl.iidm.modification.NetworkModification modification = builder.build();
+            Optional<CreateBranchFeederBaysBuilder> builder = fbTwtSeries.createBuilder(network, dataframes.get(0), i, throwException);
+            if (builder.isPresent()) {
+                com.powsybl.iidm.modification.NetworkModification modification = builder.get().build();
                 modification.apply(network, throwException, reporter == null ? Reporter.NO_OP : reporter);
             }
         }

--- a/java/src/main/java/com/powsybl/dataframe/network/modifications/CreateTwoWindingsTransformer.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/modifications/CreateTwoWindingsTransformer.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.dataframe.network.modifications;
 
+import com.powsybl.commons.reporter.Reporter;
 import com.powsybl.commons.reporter.ReporterModel;
 import com.powsybl.dataframe.DataframeElementType;
 import com.powsybl.dataframe.SeriesMetadata;
@@ -34,9 +35,9 @@ public class CreateTwoWindingsTransformer implements NetworkModification {
         }
         for (int i = 0; i < dataframes.get(0).getRowCount(); i++) {
             FeederBaysTwtSeries fbTwtSeries = new FeederBaysTwtSeries();
-            CreateBranchFeederBaysBuilder builder = fbTwtSeries.createBuilder(network, dataframes.get(0), i);
+            CreateBranchFeederBaysBuilder builder = fbTwtSeries.createBuilder(network, dataframes.get(0), i, throwException);
             com.powsybl.iidm.modification.NetworkModification modification = builder.build();
-            modification.apply(network);
+            modification.apply(network, throwException, reporter == null ? Reporter.NO_OP : reporter);
         }
     }
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/modifications/CreateTwoWindingsTransformer.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/modifications/CreateTwoWindingsTransformer.java
@@ -36,8 +36,10 @@ public class CreateTwoWindingsTransformer implements NetworkModification {
         for (int i = 0; i < dataframes.get(0).getRowCount(); i++) {
             FeederBaysTwtSeries fbTwtSeries = new FeederBaysTwtSeries();
             CreateBranchFeederBaysBuilder builder = fbTwtSeries.createBuilder(network, dataframes.get(0), i, throwException);
-            com.powsybl.iidm.modification.NetworkModification modification = builder.build();
-            modification.apply(network, throwException, reporter == null ? Reporter.NO_OP : reporter);
+            if (builder != null) {
+                com.powsybl.iidm.modification.NetworkModification modification = builder.build();
+                modification.apply(network, throwException, reporter == null ? Reporter.NO_OP : reporter);
+            }
         }
     }
 }

--- a/java/src/main/java/com/powsybl/dataframe/network/modifications/ReplaceTeePointByVoltageLevelOnLine.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/modifications/ReplaceTeePointByVoltageLevelOnLine.java
@@ -23,15 +23,20 @@ import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
  */
 public class ReplaceTeePointByVoltageLevelOnLine implements NetworkModification {
 
+    private static final String NEW_LINE1_ID = "new_line1_id";
+    private static final String NEW_LINE2_ID = "new_line2_id";
+    private static final String NEW_LINE1_NAME = "new_line1_name";
+    private static final String NEW_LINE2_NAME = "new_line2_name";
+
     private static final List<SeriesMetadata> METADATA = List.of(
             SeriesMetadata.stringIndex("tee_point_line1"),
             SeriesMetadata.strings("tee_point_line2"),
             SeriesMetadata.strings("tee_point_line_to_remove"),
             SeriesMetadata.strings("bbs_or_bus_id"),
-            SeriesMetadata.strings("new_line1_id"),
-            SeriesMetadata.strings("new_line2_id"),
-            SeriesMetadata.strings("new_line1_name"),
-            SeriesMetadata.strings("new_line2_name")
+            SeriesMetadata.strings(NEW_LINE1_ID),
+            SeriesMetadata.strings(NEW_LINE2_ID),
+            SeriesMetadata.strings(NEW_LINE1_NAME),
+            SeriesMetadata.strings(NEW_LINE2_NAME)
     );
 
     @Override
@@ -45,15 +50,15 @@ public class ReplaceTeePointByVoltageLevelOnLine implements NetworkModification 
         applyIfPresent(dataframe.getStrings("tee_point_line2"), row, builder::withTeePointLine2);
         applyIfPresent(dataframe.getStrings("tee_point_line_to_remove"), row, builder::withTeePointLineToRemove);
         applyIfPresent(dataframe.getStrings("bbs_or_bus_id"), row, builder::withBbsOrBusId);
-        applyIfPresent(dataframe.getStrings("new_line1_id"), row, builder::withNewLine1Id);
-        applyIfPresent(dataframe.getStrings("new_line2_id"), row, builder::withNewLine2Id);
-        applyIfPresent(dataframe.getStrings("new_line1_name"), row, builder::withNewLine1Name);
-        applyIfPresent(dataframe.getStrings("new_line2_name"), row, builder::withNewLine2Id);
-        if (dataframe.getStringValue("new_line1_name", row).isEmpty()) {
-            applyIfPresent(dataframe.getStrings("new_line1_id"), row, builder::withNewLine1Name);
+        applyIfPresent(dataframe.getStrings(NEW_LINE1_ID), row, builder::withNewLine1Id);
+        applyIfPresent(dataframe.getStrings(NEW_LINE2_ID), row, builder::withNewLine2Id);
+        applyIfPresent(dataframe.getStrings(NEW_LINE1_NAME), row, builder::withNewLine1Name);
+        applyIfPresent(dataframe.getStrings(NEW_LINE2_NAME), row, builder::withNewLine2Id);
+        if (dataframe.getStringValue(NEW_LINE1_NAME, row).isEmpty()) {
+            applyIfPresent(dataframe.getStrings(NEW_LINE1_ID), row, builder::withNewLine1Name);
         }
-        if (dataframe.getStringValue("new_line2_name", row).isEmpty()) {
-            applyIfPresent(dataframe.getStrings("new_line2_id"), row, builder::withNewLine2Name);
+        if (dataframe.getStringValue(NEW_LINE2_NAME, row).isEmpty()) {
+            applyIfPresent(dataframe.getStrings(NEW_LINE2_ID), row, builder::withNewLine2Name);
         }
         return builder;
     }

--- a/java/src/main/java/com/powsybl/dataframe/network/modifications/RevertConnectVoltageLevelOnLine.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/modifications/RevertConnectVoltageLevelOnLine.java
@@ -24,11 +24,14 @@ import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
  */
 public class RevertConnectVoltageLevelOnLine implements NetworkModification {
 
+    private static final String LINE_ID = "line_id";
+    private static final String LINE_NAME = "line_name";
+
     private static final List<SeriesMetadata> METADATA = List.of(
             SeriesMetadata.stringIndex("line1_id"),
             SeriesMetadata.strings("line2_id"),
-            SeriesMetadata.strings("line_id"),
-            SeriesMetadata.strings("line_name")
+            SeriesMetadata.strings(LINE_ID),
+            SeriesMetadata.strings(LINE_NAME)
     );
 
     @Override
@@ -40,11 +43,11 @@ public class RevertConnectVoltageLevelOnLine implements NetworkModification {
         RevertConnectVoltageLevelOnLineBuilder builder = new RevertConnectVoltageLevelOnLineBuilder();
         applyIfPresent(dataframe.getStrings("line1_id"), row, builder::withLine1Id);
         applyIfPresent(dataframe.getStrings("line2_id"), row, builder::withLine2Id);
-        applyIfPresent(dataframe.getStrings("line_name"), row, builder::withLineName);
-        applyIfPresent(dataframe.getStrings("line_id"), row, builder::withLineId);
-        Optional<String> lineName = dataframe.getStringValue("line_name", row);
+        applyIfPresent(dataframe.getStrings(LINE_NAME), row, builder::withLineName);
+        applyIfPresent(dataframe.getStrings(LINE_ID), row, builder::withLineId);
+        Optional<String> lineName = dataframe.getStringValue(LINE_NAME, row);
         if (lineName.isEmpty()) {
-            applyIfPresent(dataframe.getStrings("line_id"), row, builder::withLineName);
+            applyIfPresent(dataframe.getStrings(LINE_ID), row, builder::withLineName);
         }
         return builder;
     }

--- a/java/src/main/java/com/powsybl/dataframe/network/modifications/RevertCreateLineOnLine.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/modifications/RevertCreateLineOnLine.java
@@ -24,11 +24,13 @@ import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
  */
 public class RevertCreateLineOnLine implements NetworkModification {
 
+    private static final String MERGED_LINE_ID = "merged_line_id";
+
     private static final List<SeriesMetadata> METADATA = List.of(
             SeriesMetadata.stringIndex("line_to_be_merged1_id"),
             SeriesMetadata.strings("line_to_be_merged2_id"),
             SeriesMetadata.strings("line_to_be_deleted"),
-            SeriesMetadata.strings("merged_line_id"),
+            SeriesMetadata.strings(MERGED_LINE_ID),
             SeriesMetadata.strings("merged_line_name")
     );
 
@@ -42,10 +44,10 @@ public class RevertCreateLineOnLine implements NetworkModification {
         applyIfPresent(dataframe.getStrings("line_to_be_merged1_id"), row, builder::withLineToBeMerged1Id);
         applyIfPresent(dataframe.getStrings("line_to_be_merged2_id"), row, builder::withLineToBeMerged2Id);
         applyIfPresent(dataframe.getStrings("line_to_be_deleted"), row, builder::withLineToBeDeletedId);
-        applyIfPresent(dataframe.getStrings("merged_line_id"), row, builder::withMergedLineId);
+        applyIfPresent(dataframe.getStrings(MERGED_LINE_ID), row, builder::withMergedLineId);
         Optional<String> mergedLineName = dataframe.getStringValue("merged_line_name", row);
         if (mergedLineName.isEmpty()) {
-            applyIfPresent(dataframe.getStrings("merged_line_id"), row, builder::withMergedLineName);
+            applyIfPresent(dataframe.getStrings(MERGED_LINE_ID), row, builder::withMergedLineName);
         } else {
             builder.withMergedLineName(mergedLineName.get());
         }

--- a/java/src/main/java/com/powsybl/dataframe/network/modifications/VoltageLevelTopologyCreation.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/modifications/VoltageLevelTopologyCreation.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.stream.Collectors;
 
 import static com.powsybl.dataframe.network.adders.SeriesUtils.applyIfPresent;
 
@@ -51,7 +50,7 @@ public class VoltageLevelTopologyCreation implements NetworkModification {
                 switchKindOptionalStr.get();
         List<SwitchKind> switchKindList = Arrays.stream(switchKindStr.split(","))
                 .map(SwitchKind::valueOf)
-                .collect(Collectors.toList());
+                .toList();
         applyIfPresent(dataframe.getStrings("id"), row, builder::withVoltageLevelId);
         applyIfPresent(dataframe.getInts("low_bus_or_busbar_index"), row, builder::withLowBusOrBusbarIndex);
         applyIfPresent(dataframe.getInts("aligned_buses_or_busbar_count"), row, builder::withAlignedBusesOrBusbarCount);

--- a/java/src/main/java/com/powsybl/python/network/NetworkModificationsCFunctions.java
+++ b/java/src/main/java/com/powsybl/python/network/NetworkModificationsCFunctions.java
@@ -20,7 +20,6 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.iidm.network.extensions.ConnectablePosition;
 import com.powsybl.python.commons.CTypeUtil;
-import com.powsybl.python.commons.CommonCFunctions;
 import com.powsybl.python.commons.Directives;
 import com.powsybl.python.commons.PyPowsyblApiHeader;
 import org.apache.commons.lang3.Range;
@@ -32,8 +31,6 @@ import org.graalvm.nativeimage.c.function.CEntryPoint;
 import org.graalvm.nativeimage.c.type.CCharPointer;
 import org.graalvm.nativeimage.c.type.CCharPointerPointer;
 import org.graalvm.nativeimage.c.type.CIntPointer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -104,13 +101,8 @@ public final class NetworkModificationsCFunctions {
                 dfs.add(createDataframe(cDataframes.getDataframes().addressOf(i)));
             }
             DataframeNetworkModificationType type = convert(networkModificationType);
-            logger().debug("throwException in createNetworkModification {}", throwException);
             NetworkModifications.applyModification(type, network, dfs, throwException, reporter);
         });
-    }
-
-    private static Logger logger() {
-        return LoggerFactory.getLogger(CommonCFunctions.class);
     }
 
     @CEntryPoint(name = "getModificationMetadata")

--- a/java/src/main/java/com/powsybl/python/security/SecurityAnalysisCFunctions.java
+++ b/java/src/main/java/com/powsybl/python/security/SecurityAnalysisCFunctions.java
@@ -65,14 +65,13 @@ public final class SecurityAnalysisCFunctions {
     @CEntryPoint(name = "getSecurityAnalysisProviderNames")
     public static PyPowsyblApiHeader.ArrayPointer<CCharPointerPointer> getSecurityAnalysisProviderNames(IsolateThread thread, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
         return doCatch(exceptionHandlerPtr, () -> createCharPtrArray(SecurityAnalysisProvider.findAll()
-                .stream().map(SecurityAnalysisProvider::getName).collect(Collectors.toList())));
+                .stream().map(SecurityAnalysisProvider::getName).toList()));
     }
 
     @CEntryPoint(name = "setDefaultSecurityAnalysisProvider")
     public static void setDefaultSecurityAnalysisProvider(IsolateThread thread, CCharPointer provider, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
-        doCatch(exceptionHandlerPtr, () -> {
-            PyPowsyblConfiguration.setDefaultSecurityAnalysisProvider(CTypeUtil.toString(provider));
-        });
+        doCatch(exceptionHandlerPtr, () ->
+            PyPowsyblConfiguration.setDefaultSecurityAnalysisProvider(CTypeUtil.toString(provider)));
     }
 
     @CEntryPoint(name = "getDefaultSecurityAnalysisProvider")
@@ -90,11 +89,9 @@ public final class SecurityAnalysisCFunctions {
         doCatch(exceptionHandlerPtr, () -> {
             SecurityAnalysisContext analysisContext = ObjectHandles.getGlobal().get(securityAnalysisContextHandle);
             List<String> contingencies = toStringList(contingencyIds, contingencyIdsCount);
-            contingencies.forEach(contingency -> {
-                analysisContext.addMonitor(new StateMonitor(new ContingencyContext(contingency.isEmpty() ? null : contingency, convert(contingencyContextType)),
-                        Set.copyOf(toStringList(branchIds, branchIdsCount)), Set.copyOf(toStringList(voltageLevelIds, voltageLevelIdCount)),
-                        Set.copyOf(toStringList(threeWindingsTransformerIds, threeWindingsTransformerIdsCount))));
-            });
+            contingencies.forEach(contingency -> analysisContext.addMonitor(new StateMonitor(new ContingencyContext(contingency.isEmpty() ? null : contingency, convert(contingencyContextType)),
+                    Set.copyOf(toStringList(branchIds, branchIdsCount)), Set.copyOf(toStringList(voltageLevelIds, voltageLevelIdCount)),
+                    Set.copyOf(toStringList(threeWindingsTransformerIds, threeWindingsTransformerIdsCount)))));
         });
     }
 

--- a/tests/test_network_modification.py
+++ b/tests/test_network_modification.py
@@ -1179,7 +1179,7 @@ def test_exception_create_element_with_bay():
                       data=[['new_line', 'S1VL2_BBS', 'S2VL1_BBS', 115, 121, 'TOP', 'TOP', 5.0, 50.0, 20.0, 30.0, 40.0,
                              50.0]])
     with pytest.raises(PyPowsyblError) as exc:
-        pp.network.create_line_bays(n, df_line_wrong_bbs)
+        pp.network.create_line_bays(n, df_line_wrong_bbs, raise_exception=True)
     assert exc.match('Bus or busbar section S1VL2_BBS not found')
 
     pp.network.create_line_bays(network=n, df=df_line_wrong_bbs, raise_exception=False)

--- a/tests/test_network_modification.py
+++ b/tests/test_network_modification.py
@@ -3,6 +3,7 @@ import pytest
 import pypowsybl as pp
 import pandas as pd
 import pathlib
+from pypowsybl import PyPowsyblError
 
 TEST_DIR = pathlib.Path(__file__).parent
 
@@ -1157,3 +1158,44 @@ def test_remove_hvdc():
 
     assert 'HVDC1' not in n.get_hvdc_lines().index
     assert n.get_vsc_converter_stations().empty
+
+
+def test_exception_create_element_with_bay():
+    #load (works the same for every injection)
+    n = pp.network.create_four_substations_node_breaker_network()
+    df_load_wrong_bbs = pd.DataFrame(index=["new_load"], columns=["id", "p0", "q0", "bus_or_busbar_section_id", "position_order"],
+                                     data=[["new_load", 10.0, 3.0, "S1VL1_BB", 0]])
+    with pytest.raises(PyPowsyblError) as exc:
+        pp.network.create_load_bay(network=n, df=df_load_wrong_bbs, raise_exception=True)
+    assert exc.match('Bus or busbar section S1VL1_BB not found.')
+
+    pp.network.create_load_bay(network=n, df=df_load_wrong_bbs, raise_exception=False)
+    assert 'new_load' not in n.get_loads().index
+
+    #line
+    df_line_wrong_bbs = pd.DataFrame(index=['new_line'],
+                      columns=['id', 'bus_or_busbar_section_id_1', 'bus_or_busbar_section_id_2', 'position_order_1',
+                               'position_order_2', 'direction_1', 'direction_2', 'r', 'x', 'g1', 'g2', 'b1', 'b2'],
+                      data=[['new_line', 'S1VL2_BBS', 'S2VL1_BBS', 115, 121, 'TOP', 'TOP', 5.0, 50.0, 20.0, 30.0, 40.0,
+                             50.0]])
+    with pytest.raises(PyPowsyblError) as exc:
+        pp.network.create_line_bays(n, df_line_wrong_bbs)
+    assert exc.match('Bus or busbar section S1VL2_BBS not found')
+
+    pp.network.create_line_bays(network=n, df=df_line_wrong_bbs, raise_exception=False)
+    assert 'new_line' not in n.get_loads().index
+
+    #two winding transformer
+    df_twt_wrong_bbs = pd.DataFrame(index=['new_twt'],
+                      columns=['id', 'bus_or_busbar_section_id_1', 'bus_or_busbar_section_id_2', 'position_order_1',
+                               'position_order_2', 'direction_1', 'direction_2', 'r', 'x', 'g', 'b', 'rated_u1',
+                               'rated_u2', 'rated_s'],
+                      data=[['new_twt', 'S1VL1_BBS', 'S1VL2_BBS', 115, 121, 'TOP', 'TOP', 5.0, 50.0, 2.0, 4.0, 225.0,
+                             400.0, 1.0]])
+    with pytest.raises(PyPowsyblError) as exc:
+        pp.network.create_2_windings_transformer_bays(n, df_twt_wrong_bbs, raise_exception=True)
+    assert exc.match('Bus or busbar section S1VL2_BBS not found.')
+
+    pp.network.create_2_windings_transformer_bays(n, df_twt_wrong_bbs, raise_exception=False)
+    assert 'new_twt' not in n.get_2_windings_transformers().index
+


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The boolean raise_exception is ignored when using network modifications.


**What is the new behavior (if this is a feature change)?**
When creating a feeder bay, if the boolean is true, an exception will be thrown, same for the creation of a line or a two windings transformer.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No