### PR TITLE
Fix GraalVM CI issue

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -11,7 +11,7 @@ jobs:
   manylinux_build:
     name: Build linux ${{ matrix.python.name }} wheel
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux_2_24_x86_64:2022-12-26-0d38463
+    container: quay.io/pypa/manylinux_2_28_x86_64:2024-01-08-eb135ed
     strategy:
       matrix:
         python:

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -22,8 +22,7 @@ jobs:
           }
 
     steps:
-      - name: Install Linux packages (Alma Linux)
-        if: matrix.python.version == '3.12'
+      - name: Install Linux packages
         run: dnf install -y wget
 
       - name: Install Maven

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -22,11 +22,9 @@ jobs:
           }
 
     steps:
-      - name: Install Linux packages
-        run: |
-          echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list
-          apt-get update
-          apt install -y wget
+      - name: Install Linux packages (Alma Linux)
+        if: matrix.python.version == '3.12'
+        run: dnf install -y wget
 
       - name: Install Maven
         run: |

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -11,51 +11,38 @@ jobs:
   manylinux_build:
     name: Build linux ${{ matrix.python.name }} wheel
     runs-on: ubuntu-latest
-    container: ${{ matrix.python.container }}
+    container: quay.io/pypa/manylinux_2_28_x86_64:2024-01-08-eb135ed
     strategy:
       matrix:
         python:
           - {
             name: cp38,
             abi: cp38,
-            version: '3.8',
-            container: 'quay.io/pypa/manylinux_2_24_x86_64:2022-12-26-0d38463'
+            version: '3.8'
           }
           - {
             name: cp39,
             abi: cp39,
-            version: '3.9',
-            container: 'quay.io/pypa/manylinux_2_24_x86_64:2022-12-26-0d38463'
+            version: '3.9'
           }
           - {
             name: cp310,
             abi: cp310,
-            version: '3.10',
-            container: 'quay.io/pypa/manylinux_2_24_x86_64:2022-12-26-0d38463'
+            version: '3.10'
           }
           - {
             name: cp311,
             abi: cp311,
-            version: '3.11',
-            container: 'quay.io/pypa/manylinux_2_24_x86_64:2022-12-26-0d38463'
+            version: '3.11'
           }
           - {
             name: cp312,
             abi: cp312,
-            version: '3.12',
-            container: 'quay.io/pypa/manylinux_2_28_x86_64:2024-01-08-eb135ed'
+            version: '3.12'
           }
 
     steps:
-      - name: Install Linux packages (Debian)
-        if: matrix.python.version != '3.12'
-        run: |
-          echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list
-          apt-get update
-          apt install -y wget
-
-      - name: Install Linux packages (Alma Linux)
-        if: matrix.python.version == '3.12'
+      - name: Install Linux packages
         run: dnf install -y wget
 
       - name: Install Maven


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
CI fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
CI is failing because new version of GraalVM now requires glic >= 2.25


**What is the new behavior (if this is a feature change)?**
We need to use manylinux_2_28_x86_64 container for all python versions.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
