### PR TITLE
Fix image in documentation

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -90,6 +90,7 @@ This will produce the following SVG image, which will just display if you run
 inside a notebook:
 
 .. image:: _static/images/getting-started-sld.svg
+   :class: forced-white-background
 
 
 Going further


### PR DESCRIPTION
Documentation: fix background of an image for dark mode (forgot it in https://github.com/powsybl/pypowsybl/pull/727)