### PR TITLE
Fix crash when creating a feeder bay using an empty dataframe

### DIFF
--- a/java/src/main/java/com/powsybl/dataframe/network/modifications/CreateFeederBay.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/modifications/CreateFeederBay.java
@@ -47,8 +47,11 @@ public class CreateFeederBay implements NetworkModification {
 
     @Override
     public void applyModification(Network network, List<UpdatingDataframe> dataframes, boolean throwException, ReportNode reportNode) {
-        PyPowsyblApiHeader.ElementType elementType = PyPowsyblApiHeader.ElementType.valueOf(dataframes.get(0).getStrings("feeder_type").get(0));
-        DataframeElementType type = convert(elementType);
-        NetworkElementAdders.addElementsWithBay(type, network, dataframes, throwException, reportNode);
+        UpdatingDataframe firstUpdatingDataframe = dataframes.get(0);
+        if (firstUpdatingDataframe.getRowCount() > 0) {
+            PyPowsyblApiHeader.ElementType elementType = PyPowsyblApiHeader.ElementType.valueOf(firstUpdatingDataframe.getStrings("feeder_type").get(0));
+            DataframeElementType type = convert(elementType);
+            NetworkElementAdders.addElementsWithBay(type, network, dataframes, throwException, reportNode);
+        }
     }
 }

--- a/tests/test_network_modification.py
+++ b/tests/test_network_modification.py
@@ -1771,6 +1771,10 @@ def test_exception_create_element_with_bay():
     assert exc.match('Bus or busbar section S1VL2_BBS not found')
 
 
-
-
-
+def test_empty_load_bay_segv():
+    n = pp.network.create_four_substations_node_breaker_network()
+    assert len(n.get_loads()) == 6
+    df = pd.DataFrame(index=[], columns=["id", "p0", "q0", "bus_or_busbar_section_id", "position_order"],
+                      data=[])
+    pp.network.create_load_bay(network=n, df=df, raise_exception=True)
+    assert len(n.get_loads()) == 6 # no crash and no network change


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When creating for instance a load feeder bay with an empty load dataframe, we get a crash (segv).


**What is the new behavior (if this is a feature change)?**
A check has been added to avoir the crash.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
