### PR TITLE
Fix multi substation sld svg

### DIFF
--- a/java/src/main/java/com/powsybl/python/commons/CTypeUtil.java
+++ b/java/src/main/java/com/powsybl/python/commons/CTypeUtil.java
@@ -75,7 +75,7 @@ public final class CTypeUtil {
 
     public static String[][] toString2DArray(CCharPointerPointer charPtrPtr, int length, int rows) {
         int cols = length / rows;
-        String[][] string2DArray = new String[rows][length / cols];
+        String[][] string2DArray = new String[rows][cols];
         int index = 0;
         for (int i = 0; i < rows; i++) {
             for (int j = 0; j < cols; j++) {

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -846,6 +846,14 @@ def test_sld_svg():
     assert re.search('.*<svg.*', sld_multi_substation2.svg)
     assert len(sld_multi_substation2.metadata) > 0
 
+    sld_multi_substation3 = n.get_matrix_multi_substation_single_line_diagram([['S1'],['S2']])
+    assert re.search('.*<svg.*', sld_multi_substation3.svg)
+    assert len(sld_multi_substation3.metadata) > 0   
+    
+    sld_multi_substation4 = n.get_matrix_multi_substation_single_line_diagram([['S1', 'S2']])
+    assert re.search('.*<svg.*', sld_multi_substation4.svg)
+    assert len(sld_multi_substation4.metadata) > 0    
+
 def test_sld_svg_backward_compatibility():
     n = pp.network.create_four_substations_node_breaker_network()
     sld = n.get_single_line_diagram('S1VL1', LayoutParameters(use_name=True, center_name=True, diagonal_label=True,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) --> no need.

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix

**What is the current behavior?**

` write_matrix_multi_substation_single_line_diagram_svg `and `get_matrix_multi_substation_single_line_diagram`:  errors are raised depending on the matrix_ids parameter (the 2D list of substation ids);  
Tests were added to demonstrate the issue in a couple of cases. 
On the java side the matrix's size, decoded from the python parameter, does not seem to be  computed correctly.  

**What is the new behavior (if this is a feature change)?**
The matrix's size on the Java side is computed correctly.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
