### PR TITLE
Fix CI : regain compatibility with node16 for the CI

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -12,6 +12,8 @@ jobs:
     name: Build linux ${{ matrix.python.name }} wheel
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64:2024-07-01-8dac23b
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     strategy:
       matrix:
         python:

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -12,6 +12,8 @@ jobs:
     name: Build linux ${{ matrix.python.name }} wheel
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64:2024-07-01-8dac23b
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     strategy:
       matrix:
         python:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Github actions have changed the default version of node to node20 for all runners. It is not compatible with the base image used to build pypowsybl in the CI. 

**What is the new behavior (if this is a feature change)?**
An environment variable is used to reset the version of node to node16 in the CI files.

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
This workaround will only work until October, when Github intend to definitively block the use of node16.
