### PR TITLE
Fix Windows CI : set matplotlib to 3.9.0 for python > 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ pandas==2.2.2; python_version >= "3.9"
 pandas==2.0.3; python_version <= "3.8"
 prettytable==2.0.0
 networkx
-matplotlib
+matplotlib==3.9.0; python_version >= "3.9"
+matplotlib; python_version <= "3.8"
 
 # documentation dependencies
 sphinx==7.1.2


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
If no version is specified, the CI uses new matplotlib version 3.9.1 for python > 3.8.
It breaks the CI at the tests of the package built.
The true underlying cause has not been identified, this PR only set the version of matplotlib to have a working CI.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
