### PR TITLE
Fix MSVC runtime binaries incompatibility issues

### DIFF
--- a/cpp/powsybl-cpp/CMakeLists.txt
+++ b/cpp/powsybl-cpp/CMakeLists.txt
@@ -7,6 +7,12 @@
 cmake_minimum_required(VERSION 3.14)
 project(powsybl-cpp)
 
+# Enable static linkage to prevent any future runtime binary compatibility issue
+if(MSVC)
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+endif()
+
 include(ExternalProject)
 
 set(POWSYBL_CPP_LIB ${CMAKE_SHARED_LIBRARY_PREFIX}powsybl-cpp${CMAKE_SHARED_LIBRARY_SUFFIX})
@@ -94,5 +100,12 @@ add_dependencies(powsybl-cpp native-image)
 if(DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY)
     add_custom_command(TARGET powsybl-cpp POST_BUILD ${POWSYBL_CPP_INSTALL_EXTRA_COMMAND} COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:powsybl-cpp> ${PYPOWSYBL_JAVA_BIN_DIR}/${PYPOWSYBL_JAVA_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${POWSYBL_MATH_NATIVE_JAR_ENTRY_DIR}/${POWSYBL_MATH_NATIVE_LIB} ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 endif(DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+
+# Fix related to issue describred here https://github.com/actions/runner-images/issues/10004#issuecomment-2156109231
+# Should fix incompatibility between MSVC runtime 14.40.XXX and previous version
+if(MSVC)
+   target_compile_definitions(powsybl-cpp
+     PRIVATE _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+endif()
 
 target_link_libraries(powsybl-cpp PUBLIC ${PYPOWSYBL_JAVA_LIB})

--- a/cpp/pypowsybl-cpp/CMakeLists.txt
+++ b/cpp/pypowsybl-cpp/CMakeLists.txt
@@ -7,6 +7,12 @@
 cmake_minimum_required(VERSION 3.14)
 project(pypowsybl-cpp)
 
+# Enable static linkage to prevent any future runtime binary compatibility issue
+if(MSVC)
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+endif()
+
 set(POWSYBL_CPP_SOURCE_DIR "../powsybl-cpp")
 set(PYPOWSYBL_JAVA_BIN_DIR ${CMAKE_CURRENT_BINARY_DIR}/../java)
 include_directories(${POWSYBL_CPP_SOURCE_DIR} ${PYPOWSYBL_JAVA_BIN_DIR})
@@ -16,4 +22,12 @@ pybind11_add_module(_pypowsybl pylogging.cpp bindings.cpp)
 
 add_dependencies(_pypowsybl native-image math-native)
 add_dependencies(math-native native-image) # because mvn command also copy math native jar
+
+# Fix related to issue describred here https://github.com/actions/runner-images/issues/10004#issuecomment-2156109231
+# Should fix incompatibility between MSVC runtime 14.40.XXX and previous version
+if(MSVC)
+   target_compile_definitions(powsybl-cpp
+     PRIVATE _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+endif()
+
 target_link_libraries(_pypowsybl PRIVATE powsybl-cpp)

--- a/cpp/pypowsybl-cpp/CMakeLists.txt
+++ b/cpp/pypowsybl-cpp/CMakeLists.txt
@@ -26,7 +26,7 @@ add_dependencies(math-native native-image) # because mvn command also copy math 
 # Fix related to issue describred here https://github.com/actions/runner-images/issues/10004#issuecomment-2156109231
 # Should fix incompatibility between MSVC runtime 14.40.XXX and previous version
 if(MSVC)
-   target_compile_definitions(powsybl-cpp
+   target_compile_definitions(_pypowsybl
      PRIVATE _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 endif()
 


### PR DESCRIPTION
Add MT flag and define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR as a failsafe.

See https://github.com/actions/runner-images/issues/10004#issuecomment-2156109231 for detailed information on issue.
and https://developercommunity.visualstudio.com/t/Access-violation-in-_Thrd_yield-after-up/10664660#T-N10669129-N10678728

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
