### PR TITLE
Avoid using call triggering c++ call execution in default parameters init

### DIFF
--- a/pypowsybl/voltage_initializer/impl/voltage_initializer.py
+++ b/pypowsybl/voltage_initializer/impl/voltage_initializer.py
@@ -10,7 +10,7 @@ from .voltage_initializer_parameters import VoltageInitializerParameters
 from .voltage_initializer_results import VoltageInitializerResults
 
 
-def run(network: Network, params: VoltageInitializerParameters = VoltageInitializerParameters(), debug: bool = False) \
+def run(network: Network, params: VoltageInitializerParameters, debug: bool = False) \
         -> VoltageInitializerResults:
     """
     Run voltage initializer on the network with the given params.
@@ -20,5 +20,7 @@ def run(network: Network, params: VoltageInitializerParameters = VoltageInitiali
         params: The parameters used to customize the run
         debug: if true, the tmp directory of the voltage initializer run will not be erased.
     """
+    if params is None:
+        params = VoltageInitializerParameters()
     result_handle = run_voltage_initializer(debug, network._handle, params._handle)
     return VoltageInitializerResults(result_handle)


### PR DESCRIPTION
Do not use a constructor triggering a c++ call from within a default parameters list, it is evaluated at declaration and can trigger a call before proper pypowsybl init.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
