### PR TITLE
Rename AMPL log related enum

### DIFF
--- a/cpp/powsybl-cpp/powsybl-api.h
+++ b/cpp/powsybl-cpp/powsybl-api.h
@@ -403,10 +403,10 @@ typedef enum {
 } VoltageInitializerObjective;
 
 typedef enum {
-    DEBUG = 0,
-    INFO,
-    WARNING,
-    ERROR,
+    LOG_AMPL_DEBUG = 0,
+    LOG_AMPL_INFO,
+    LOG_AMPL_WARNING,
+    LOG_AMPL_ERROR,
 } VoltageInitializerLogLevelAmpl;
 
 typedef enum {

--- a/cpp/pypowsybl-cpp/bindings.cpp
+++ b/cpp/pypowsybl-cpp/bindings.cpp
@@ -189,10 +189,10 @@ void voltageInitializerBinding(py::module_& m) {
         .value("SPECIFIC_VOLTAGE_PROFILE", VoltageInitializerObjective::SPECIFIC_VOLTAGE_PROFILE);
 
     py::enum_<VoltageInitializerLogLevelAmpl>(m, "VoltageInitializerLogLevelAmpl")
-        .value("DEBUG", VoltageInitializerLogLevelAmpl::DEBUG)
-        .value("INFO", VoltageInitializerLogLevelAmpl::INFO)
-        .value("WARNING", VoltageInitializerLogLevelAmpl::WARNING)
-        .value("ERROR", VoltageInitializerLogLevelAmpl::ERROR);
+        .value("DEBUG", VoltageInitializerLogLevelAmpl::LOG_AMPL_DEBUG)
+        .value("INFO", VoltageInitializerLogLevelAmpl::LOG_AMPL_INFO)
+        .value("WARNING", VoltageInitializerLogLevelAmpl::LOG_AMPL_WARNING)
+        .value("ERROR", VoltageInitializerLogLevelAmpl::LOG_AMPL_ERROR);
 
     py::enum_<VoltageInitializerLogLevelSolver>(m, "VoltageInitializerLogLevelSolver")
         .value("NOTHING", VoltageInitializerLogLevelSolver::NOTHING)

--- a/java/src/main/java/com/powsybl/python/commons/PyPowsyblApiHeader.java
+++ b/java/src/main/java/com/powsybl/python/commons/PyPowsyblApiHeader.java
@@ -1282,10 +1282,10 @@ public final class PyPowsyblApiHeader {
 
     @CEnum("VoltageInitializerLogLevelAmpl")
     public enum VoltageInitializerLogLevelAmpl {
-        DEBUG,
-        INFO,
-        WARNING,
-        ERROR;
+        LOG_AMPL_DEBUG,
+        LOG_AMPL_INFO,
+        LOG_AMPL_WARNING,
+        LOG_AMPL_ERROR;
 
         @CEnumValue
         public native int getCValue();

--- a/java/src/main/java/com/powsybl/python/commons/Util.java
+++ b/java/src/main/java/com/powsybl/python/commons/Util.java
@@ -346,10 +346,10 @@ public final class Util {
 
     public static OpenReacAmplLogLevel convert(VoltageInitializerLogLevelAmpl obj) {
         return switch (obj) {
-            case DEBUG -> OpenReacAmplLogLevel.DEBUG;
-            case INFO -> OpenReacAmplLogLevel.INFO;
-            case WARNING -> OpenReacAmplLogLevel.WARNING;
-            case ERROR -> OpenReacAmplLogLevel.ERROR;
+            case LOG_AMPL_DEBUG -> OpenReacAmplLogLevel.DEBUG;
+            case LOG_AMPL_INFO -> OpenReacAmplLogLevel.INFO;
+            case LOG_AMPL_WARNING -> OpenReacAmplLogLevel.WARNING;
+            case LOG_AMPL_ERROR -> OpenReacAmplLogLevel.ERROR;
         };
     }
 


### PR DESCRIPTION
Rename enum related to ampl logging, they are too common and some collision issue arise when reusing cpp part in powsybl julia.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
