### PR TITLE
[Documentation] Add redirection from the logo to the main documentation website

### DIFF
--- a/docs/_templates/sidebar/brand.html
+++ b/docs/_templates/sidebar/brand.html
@@ -1,0 +1,25 @@
+{#-
+Overrides furo brand.html to customize links:
+- The logo links to a custom page (set sidebar_logo_href option in html_context)
+- The title links to the subproject's main page
+-#}
+<a class="sidebar-brand{% if logo %} centered{% endif %}" href="{% if sidebar_logo_href %} {{ sidebar_logo_href }} {% else %} {{ pathto(master_doc) }} {% endif %}">
+    {% block brand_content %}
+    {%- if logo_url %}
+    <div class="sidebar-logo-container">
+        <img class="sidebar-logo" src="{{ logo_url }}" alt="Logo"/>
+    </div>
+    {%- endif %}
+    {%- if theme_light_logo and theme_dark_logo %}
+    <div class="sidebar-logo-container">
+        <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" alt="Light Logo"/>
+        <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" alt="Dark Logo"/>
+    </div>
+    {%- endif %}
+    {% endblock brand_content %}
+</a>
+{% if not theme_sidebar_hide_name %}
+<a class="sidebar-brand{% if logo %} centered{% endif %}" href="{{ pathto(master_doc) }}">
+    <span class="sidebar-brand-text">{{ docstitle if docstitle else project }}</span>
+</a>
+{%- endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ except ImportError:
 
 project = 'pypowsybl'
 copyright = '2021, RTE (http://www.rte-france.com)'
+github_repository = "https://github.com/powsybl/pypowsybl/"
 
 
 # -- General configuration ---------------------------------------------------
@@ -66,6 +67,11 @@ html_short_title = 'pypowsybl'
 
 html_logo = '_static/logos/logo_lfe_powsybl.svg'
 html_favicon = "_static/favicon.ico"
+
+html_context = {
+    "sidebar_logo_href": "https://powsybl.readthedocs.io/",
+    "github_repository": "https://github.com/powsybl/pypowsybl/"
+}
 
 html_theme_options = {
     # the following 3 lines enable edit button

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,12 +70,12 @@ html_favicon = "_static/favicon.ico"
 
 html_context = {
     "sidebar_logo_href": "https://powsybl.readthedocs.io/",
-    "github_repository": "https://github.com/powsybl/pypowsybl/"
+    "github_repository": github_repository
 }
 
 html_theme_options = {
     # the following 3 lines enable edit button
-    "source_repository": "https://github.com/powsybl/pypowsybl/",
+    "source_repository": github_repository,
     "source_branch": "main",
     "source_directory": "docs/"
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs website update


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The powsybl logo on the documentation is taking you back to the index of the website.


**What is the new behavior (if this is a feature change)?**
Now that we have read the docs for the whole Powsybl project, I think it would be good to be coherent between every repository. So clicking on the logo should have the same effect: redirect to the https://powsybl.readthedocs.io/ website.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No
