### PR TITLE
add attribute paired for dangling lines

### DIFF
--- a/java/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -605,6 +605,7 @@ public final class NetworkDataframes {
                 .booleans("connected", dl -> dl.getTerminal().isConnected(), connectInjection())
                 .strings("pairing_key", dl -> Objects.toString(dl.getPairingKey(), ""), DanglingLine::setPairingKey)
                 .strings("ucte_xnode_code", dl -> Objects.toString(dl.getPairingKey(), ""))
+                .booleans("paired", DanglingLine::isPaired)
                 .booleans("fictitious", Identifiable::isFictitious, Identifiable::setFictitious, false)
                 .strings("tie_line_id", dl -> dl.getTieLine().map(Identifiable::getId).orElse(""))
                 .addProperties()

--- a/java/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
+++ b/java/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
@@ -263,13 +263,13 @@ class NetworkDataframesTest {
         assertThat(series)
                 .extracting(Series::getName)
                 .containsExactly("id", "name", "r", "x", "g", "b", "p0", "q0", "p", "q", "i", "voltage_level_id", "bus_id",
-                        "connected", "pairing_key", "ucte_xnode_code", "tie_line_id");
+                        "connected", "pairing_key", "ucte_xnode_code", "paired", "tie_line_id");
         List<Series> allAttributeSeries = createDataFrame(DANGLING_LINE, network, new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()));
         assertThat(allAttributeSeries)
                 .extracting(Series::getName)
                 .containsExactly("id", "name", "r", "x", "g", "b", "p0", "q0", "p", "q", "i",
                         "boundary_p", "boundary_q", "boundary_v_mag", "boundary_v_angle",
-                        "voltage_level_id", "bus_id", "bus_breaker_bus_id", "node", "connected", "pairing_key", "ucte_xnode_code", "fictitious", "tie_line_id");
+                        "voltage_level_id", "bus_id", "bus_breaker_bus_id", "node", "connected", "pairing_key", "ucte_xnode_code", "paired", "fictitious", "tie_line_id");
     }
 
     @Test

--- a/pypowsybl/network/impl/network.py
+++ b/pypowsybl/network/impl/network.py
@@ -1234,6 +1234,7 @@ class Network:  # pylint: disable=too-many-public-methods
               - **fictitious** (optional): ``True`` if the dangling line is part of the model and not of the actual network
               - **pairing_key**: the pairing key associated to the dangling line, to be used for creating tie lines.
               - **ucte-xnode-code**: deprecated for pairing key.
+              - **paired**: if the dangling line is paired with a tie line
               - **tie_line_id**: the ID of the tie line if the dangling line is paired
 
             This dataframe is indexed by the id of the dangling lines

--- a/tests/test_java_perunit.py
+++ b/tests/test_java_perunit.py
@@ -144,17 +144,17 @@ def test_dangling_lines_per_unit():
 
     expected = pd.DataFrame(index=pd.Series(name='id', data=['DL']),
                             columns=['name', 'r', 'x', 'g', 'b', 'p0', 'q0', 'p', 'q', 'i', 'voltage_level_id',
-                                     'bus_id', 'connected', 'pairing_key', 'ucte_xnode_code', 'tie_line_id'],
+                                     'bus_id', 'connected', 'pairing_key', 'ucte_xnode_code', 'paired', 'tie_line_id'],
                             data=[['', 0.1, 0.01, 0.01, 0.001, 0.5, 0.3, 0.5482, 0.3029, 0.6263, 'VL', 'VL_0',
-                                   True, '', '', '']])
+                                   True, '', '', False, '']])
     dangling_lines = n.get_dangling_lines()
     pd.testing.assert_frame_equal(expected, dangling_lines, check_dtype=False, atol=10 ** -4)
     n.update_dangling_lines(pd.DataFrame(index=['DL'], columns=['p0', 'q0'], data=[[0.75, 0.25]]))
     expected = pd.DataFrame(index=pd.Series(name='id', data=['DL']),
                             columns=['name', 'r', 'x', 'g', 'b', 'p0', 'q0', 'p', 'q', 'i', 'voltage_level_id',
-                                     'bus_id', 'connected', 'pairing_key', 'ucte_xnode_code', 'tie_line_id'],
+                                     'bus_id', 'connected', 'pairing_key', 'ucte_xnode_code', 'paired', 'tie_line_id'],
                             data=[['', 0.1, 0.01, 0.01, 0.001, 0.75, 0.25, 0.5482, 0.3029, 0.6263, 'VL', 'VL_0',
-                                   True, '', '', '']])
+                                   True, '', '', False, '']])
     dangling_lines = n.get_dangling_lines()
     pd.testing.assert_frame_equal(expected, dangling_lines, check_dtype=False, atol=10 ** -4)
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1003,18 +1003,18 @@ def test_dangling_lines():
     expected = pd.DataFrame(index=pd.Series(name='id', data=['DL']),
                             columns=['name', 'r', 'x', 'g', 'b', 'p0', 'q0', 'p', 'q', 'i', 'voltage_level_id',
                                      'bus_id',
-                                     'connected', 'pairing_key', 'ucte_xnode_code', 'tie_line_id'],
+                                     'connected', 'pairing_key', 'ucte_xnode_code', 'paired', 'tie_line_id'],
                             data=[['', 10.0, 1.0, 0.0001, 0.00001, 50.0, 30.0, nan, nan, nan, 'VL', 'VL_0', True,
-                                   '', '', '']])
+                                   '', '', False, '']])
     pd.testing.assert_frame_equal(expected, n.get_dangling_lines(), check_dtype=False)
     n.update_dangling_lines(
         pd.DataFrame(index=['DL'], columns=['r', 'x', 'g', 'b', 'p0', 'q0', 'connected'],
                      data=[[11.0, 1.1, 0.0002, 0.00002, 40.0, 40.0, False]]))
     updated = pd.DataFrame(index=pd.Series(name='id', data=['DL']),
                            columns=['name', 'r', 'x', 'g', 'b', 'p0', 'q0', 'p', 'q', 'i', 'voltage_level_id',
-                                    'bus_id', 'connected', 'pairing_key', 'ucte_xnode_code', 'tie_line_id'],
+                                    'bus_id', 'connected', 'pairing_key', 'ucte_xnode_code', 'paired', 'tie_line_id'],
                            data=[['', 11.0, 1.1, 0.0002, 0.00002, 40.0, 40.0, nan, nan, nan, 'VL', '', False,
-                                  '', '', '']])
+                                  '', '', False, '']])
     pd.testing.assert_frame_equal(updated, n.get_dangling_lines(), check_dtype=False)
     n = util.create_dangling_lines_network()
     dangling_lines = n.get_dangling_lines(attributes=['bus_breaker_bus_id', 'node'])

--- a/tests/test_per_unit.py
+++ b/tests/test_per_unit.py
@@ -199,17 +199,17 @@ def test_dangling_lines_per_unit():
 
     expected = pd.DataFrame(index=pd.Series(name='id', data=['DL']),
                             columns=['name', 'r', 'x', 'g', 'b', 'p0', 'q0', 'p', 'q', 'i', 'voltage_level_id',
-                                     'bus_id', 'connected', 'pairing_key', 'ucte_xnode_code', 'tie_line_id'],
+                                     'bus_id', 'connected', 'pairing_key', 'ucte_xnode_code', 'paired', 'tie_line_id'],
                             data=[['', 0.1, 0.01, 0.01, 0.001, 0.5, 0.3, 0.5482, 0.3029, 0.6263, 'VL', 'VL_0',
-                                   True, '', '', '']])
+                                   True, '', '', False, '']])
     dangling_lines = n.get_dangling_lines()
     pd.testing.assert_frame_equal(expected, dangling_lines, check_dtype=False, atol=10 ** -4)
     n.update_dangling_lines(pd.DataFrame(index=['DL'], columns=['p0', 'q0'], data=[[0.75, 0.25]]))
     expected = pd.DataFrame(index=pd.Series(name='id', data=['DL']),
                             columns=['name', 'r', 'x', 'g', 'b', 'p0', 'q0', 'p', 'q', 'i', 'voltage_level_id',
-                                     'bus_id', 'connected', 'pairing_key', 'ucte_xnode_code', 'tie_line_id'],
+                                     'bus_id', 'connected', 'pairing_key', 'ucte_xnode_code', 'paired', 'tie_line_id'],
                             data=[['', 0.1, 0.01, 0.01, 0.001, 0.75, 0.25, 0.5482, 0.3029, 0.6263, 'VL', 'VL_0',
-                                   True, '', '', '']])
+                                   True, '', '', False, '']])
     dangling_lines = n.get_dangling_lines()
     pd.testing.assert_frame_equal(expected, dangling_lines, check_dtype=False, atol=10 ** -4)
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
feature


**What is the new behavior (if this is a feature change)?**
it adds a new field on dangling line dataframe to know if a dangling line is paired with a tie line


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No