### PR TITLE
Fix Network create_switches docstring

### DIFF
--- a/pypowsybl/network/impl/network.py
+++ b/pypowsybl/network/impl/network.py
@@ -4189,7 +4189,7 @@ class Network:  # pylint: disable=too-many-public-methods
             Valid attributes are:
 
             - **id**: the identifier of the new switch
-            - **voltage_level1_id**: the voltage level where the new switch will be connected on side 1.
+            - **voltage_level_id**: the voltage level where the new switch will be connected.
               The voltage level must already exist.
             - **bus1_id**: the bus where the new switch will be connected on side 1,
               if the voltage level has a bus-breaker topology kind.
@@ -4211,11 +4211,11 @@ class Network:  # pylint: disable=too-many-public-methods
             .. code-block:: python
 
                 # In a bus-breaker voltage level, between configured buses B1 and B2
-                network.create_switches(id='BREAKER-1', voltage_level1_id='VL1', bus1_id='B1', bus2_id='B2',
+                network.create_switches(id='BREAKER-1', voltage_level_id='VL1', bus1_id='B1', bus2_id='B2',
                                         kind='BREAKER', open=False)
 
                 # In a node-breaker voltage level, between nodes 5 and 7
-                network.create_switches(id='BREAKER-1', voltage_level1_id='VL1', node1=5, node2=7,
+                network.create_switches(id='BREAKER-1', voltage_level_id='VL1', node1=5, node2=7,
                                         kind='BREAKER', open=False)
         """
         return self._create_elements(ElementType.SWITCH, [df], **kwargs)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bugfix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Network create_switches docstring incorrectly mentions `voltage_level1_id`


**What is the new behavior (if this is a feature change)?**
Network create_switches docstring correctly mentions `voltage_level_id`


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No
