### PR TITLE
2 NullPointerException sources fixed

### DIFF
--- a/java/src/main/java/com/powsybl/dataframe/network/adders/NetworkUtils.java
+++ b/java/src/main/java/com/powsybl/dataframe/network/adders/NetworkUtils.java
@@ -18,7 +18,7 @@ import java.util.Optional;
  */
 public final class NetworkUtils {
 
-    private static final String DOES_NOT_EXIST = " does not exist.";
+    private static final String DOES_NOT_EXIST = "' does not exist.";
 
     private NetworkUtils() {
     }
@@ -26,7 +26,7 @@ public final class NetworkUtils {
     public static VoltageLevel getVoltageLevelOrThrow(Network network, String id) {
         VoltageLevel voltageLevel = network.getVoltageLevel(id);
         if (voltageLevel == null) {
-            throw new PowsyblException("Voltage level " + id + DOES_NOT_EXIST);
+            throw new PowsyblException("Voltage level '" + id + DOES_NOT_EXIST);
         }
         return voltageLevel;
     }
@@ -61,7 +61,7 @@ public final class NetworkUtils {
     public static Substation getSubstationOrThrow(Network network, String id) {
         Substation substation = network.getSubstation(id);
         if (substation == null) {
-            throw new PowsyblException("Substation " + id + DOES_NOT_EXIST);
+            throw new PowsyblException("Substation '" + id + DOES_NOT_EXIST);
         }
         return substation;
     }
@@ -69,7 +69,7 @@ public final class NetworkUtils {
     public static Identifiable<?> getIdentifiableOrThrow(Network network, String id) {
         Identifiable<?> identifiable = network.getIdentifiable(id);
         if (identifiable == null) {
-            throw new PowsyblException("Network element " + id + DOES_NOT_EXIST);
+            throw new PowsyblException("Network element '" + id + DOES_NOT_EXIST);
         }
         return identifiable;
     }

--- a/java/src/main/java/com/powsybl/python/network/NetworkCFunctions.java
+++ b/java/src/main/java/com/powsybl/python/network/NetworkCFunctions.java
@@ -557,8 +557,14 @@ public final class NetworkCFunctions {
     public static ArrayPointer<PyPowsyblApiHeader.SeriesPointer> getNodeBreakerViewSwitches(IsolateThread thread, ObjectHandle networkHandle, CCharPointer voltageLevel, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
         return doCatch(exceptionHandlerPtr, () -> {
             Network network = ObjectHandles.getGlobal().get(networkHandle);
-            VoltageLevel.NodeBreakerView nodeBreakerView = network.getVoltageLevel(CTypeUtil.toString(voltageLevel)).getNodeBreakerView();
-            return Dataframes.createCDataframe(Dataframes.nodeBreakerViewSwitches(), nodeBreakerView);
+            String voltageLevelId = CTypeUtil.toString(voltageLevel);
+            VoltageLevel vl = network.getVoltageLevel(voltageLevelId);
+            if (vl != null) {
+                VoltageLevel.NodeBreakerView nodeBreakerView = vl.getNodeBreakerView();
+                return Dataframes.createCDataframe(Dataframes.nodeBreakerViewSwitches(), nodeBreakerView);
+            } else {
+                throw new PowsyblException(String.format("Voltage level with id : %s was not found", voltageLevelId));
+            }
         });
     }
 
@@ -566,10 +572,14 @@ public final class NetworkCFunctions {
     public static ArrayPointer<PyPowsyblApiHeader.SeriesPointer> getNodeBreakerViewNodes(IsolateThread thread, ObjectHandle networkHandle, CCharPointer voltageLevel, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
         return doCatch(exceptionHandlerPtr, () -> {
             Network network = ObjectHandles.getGlobal().get(networkHandle);
-            VoltageLevel.NodeBreakerView nodeBreakerView = network.getVoltageLevel(CTypeUtil.toString(voltageLevel)).getNodeBreakerView();
-
-            return Dataframes.createCDataframe(Dataframes.nodeBreakerViewNodes(), nodeBreakerView);
-
+            String voltageLevelId = CTypeUtil.toString(voltageLevel);
+            VoltageLevel vl = network.getVoltageLevel(voltageLevelId);
+            if (vl != null) {
+                VoltageLevel.NodeBreakerView nodeBreakerView = vl.getNodeBreakerView();
+                return Dataframes.createCDataframe(Dataframes.nodeBreakerViewNodes(), nodeBreakerView);
+            } else {
+                throw new PowsyblException(String.format("Voltage level with id : %s was not found", voltageLevelId));
+            }
         });
     }
 
@@ -577,8 +587,14 @@ public final class NetworkCFunctions {
     public static ArrayPointer<PyPowsyblApiHeader.SeriesPointer> getNodeBreakerViewInternalConnections(IsolateThread thread, ObjectHandle networkHandle, CCharPointer voltageLevel, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
         return doCatch(exceptionHandlerPtr, () -> {
             Network network = ObjectHandles.getGlobal().get(networkHandle);
-            VoltageLevel.NodeBreakerView nodeBreakerView = network.getVoltageLevel(CTypeUtil.toString(voltageLevel)).getNodeBreakerView();
-            return Dataframes.createCDataframe(Dataframes.nodeBreakerViewInternalConnection(), nodeBreakerView);
+            String voltageLevelId = CTypeUtil.toString(voltageLevel);
+            VoltageLevel vl = network.getVoltageLevel(voltageLevelId);
+            if (vl != null) {
+                VoltageLevel.NodeBreakerView nodeBreakerView = vl.getNodeBreakerView();
+                return Dataframes.createCDataframe(Dataframes.nodeBreakerViewInternalConnection(), nodeBreakerView);
+            } else {
+                throw new PowsyblException(String.format("Voltage level with id : %s was not found", voltageLevelId));
+            }
         });
     }
 
@@ -708,7 +724,14 @@ public final class NetworkCFunctions {
             Network network = ObjectHandles.getGlobal().get(networkHandle);
             List<String> ids = CTypeUtil.toStringList(idsPointer, idsCount);
             List<String> properties = CTypeUtil.toStringList(propertiesPointer, propertiesCount);
-            ids.forEach(id -> properties.forEach(property -> network.getIdentifiable(id).removeProperty(property)));
+            ids.forEach(id -> properties.forEach(property -> {
+                Identifiable<?> identifiable = network.getIdentifiable(id);
+                if (identifiable != null) {
+                    identifiable.removeProperty(property);
+                } else {
+                    throw new PowsyblException(String.format("identifiable with id : %s does not exist", id));
+                }
+            }));
         });
     }
 

--- a/java/src/main/java/com/powsybl/python/network/NetworkCFunctions.java
+++ b/java/src/main/java/com/powsybl/python/network/NetworkCFunctions.java
@@ -17,11 +17,12 @@ import com.powsybl.dataframe.DataframeFilter;
 import com.powsybl.dataframe.DataframeFilter.AttributeFilterType;
 import com.powsybl.dataframe.SeriesDataType;
 import com.powsybl.dataframe.SeriesMetadata;
+import com.powsybl.dataframe.network.NetworkDataframeContext;
 import com.powsybl.dataframe.network.NetworkDataframeMapper;
 import com.powsybl.dataframe.network.NetworkDataframes;
-import com.powsybl.dataframe.network.NetworkDataframeContext;
 import com.powsybl.dataframe.network.adders.AliasDataframeAdder;
 import com.powsybl.dataframe.network.adders.NetworkElementAdders;
+import com.powsybl.dataframe.network.adders.NetworkUtils;
 import com.powsybl.dataframe.network.extensions.NetworkExtensions;
 import com.powsybl.dataframe.network.modifications.DataframeNetworkModificationType;
 import com.powsybl.dataframe.network.modifications.NetworkModifications;
@@ -554,74 +555,58 @@ public final class NetworkCFunctions {
     }
 
     @CEntryPoint(name = "getNodeBreakerViewSwitches")
-    public static ArrayPointer<PyPowsyblApiHeader.SeriesPointer> getNodeBreakerViewSwitches(IsolateThread thread, ObjectHandle networkHandle, CCharPointer voltageLevel, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
+    public static ArrayPointer<PyPowsyblApiHeader.SeriesPointer> getNodeBreakerViewSwitches(IsolateThread thread, ObjectHandle networkHandle, CCharPointer voltageLevelPtr, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
         return doCatch(exceptionHandlerPtr, () -> {
             Network network = ObjectHandles.getGlobal().get(networkHandle);
-            String voltageLevelId = CTypeUtil.toString(voltageLevel);
-            VoltageLevel vl = network.getVoltageLevel(voltageLevelId);
-            if (vl != null) {
-                VoltageLevel.NodeBreakerView nodeBreakerView = vl.getNodeBreakerView();
-                return Dataframes.createCDataframe(Dataframes.nodeBreakerViewSwitches(), nodeBreakerView);
-            } else {
-                throw new PowsyblException(String.format("Voltage level with id : %s was not found", voltageLevelId));
-            }
+            VoltageLevel.NodeBreakerView nodeBreakerView = NetworkUtils.getVoltageLevelOrThrow(network, CTypeUtil.toString(voltageLevelPtr)).getNodeBreakerView();
+            return Dataframes.createCDataframe(Dataframes.nodeBreakerViewSwitches(), nodeBreakerView);
         });
     }
 
     @CEntryPoint(name = "getNodeBreakerViewNodes")
-    public static ArrayPointer<PyPowsyblApiHeader.SeriesPointer> getNodeBreakerViewNodes(IsolateThread thread, ObjectHandle networkHandle, CCharPointer voltageLevel, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
+    public static ArrayPointer<PyPowsyblApiHeader.SeriesPointer> getNodeBreakerViewNodes(IsolateThread thread, ObjectHandle networkHandle, CCharPointer voltageLevelPtr, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
         return doCatch(exceptionHandlerPtr, () -> {
             Network network = ObjectHandles.getGlobal().get(networkHandle);
-            String voltageLevelId = CTypeUtil.toString(voltageLevel);
-            VoltageLevel vl = network.getVoltageLevel(voltageLevelId);
-            if (vl != null) {
-                VoltageLevel.NodeBreakerView nodeBreakerView = vl.getNodeBreakerView();
-                return Dataframes.createCDataframe(Dataframes.nodeBreakerViewNodes(), nodeBreakerView);
-            } else {
-                throw new PowsyblException(String.format("Voltage level with id : %s was not found", voltageLevelId));
-            }
+            VoltageLevel.NodeBreakerView nodeBreakerView = NetworkUtils.getVoltageLevelOrThrow(network, CTypeUtil.toString(voltageLevelPtr)).getNodeBreakerView();
+
+            return Dataframes.createCDataframe(Dataframes.nodeBreakerViewNodes(), nodeBreakerView);
+
         });
     }
 
     @CEntryPoint(name = "getNodeBreakerViewInternalConnections")
-    public static ArrayPointer<PyPowsyblApiHeader.SeriesPointer> getNodeBreakerViewInternalConnections(IsolateThread thread, ObjectHandle networkHandle, CCharPointer voltageLevel, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
+    public static ArrayPointer<PyPowsyblApiHeader.SeriesPointer> getNodeBreakerViewInternalConnections(IsolateThread thread, ObjectHandle networkHandle, CCharPointer voltageLevelPtr, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
         return doCatch(exceptionHandlerPtr, () -> {
             Network network = ObjectHandles.getGlobal().get(networkHandle);
-            String voltageLevelId = CTypeUtil.toString(voltageLevel);
-            VoltageLevel vl = network.getVoltageLevel(voltageLevelId);
-            if (vl != null) {
-                VoltageLevel.NodeBreakerView nodeBreakerView = vl.getNodeBreakerView();
-                return Dataframes.createCDataframe(Dataframes.nodeBreakerViewInternalConnection(), nodeBreakerView);
-            } else {
-                throw new PowsyblException(String.format("Voltage level with id : %s was not found", voltageLevelId));
-            }
+            VoltageLevel.NodeBreakerView nodeBreakerView = NetworkUtils.getVoltageLevelOrThrow(network, CTypeUtil.toString(voltageLevelPtr)).getNodeBreakerView();
+            return Dataframes.createCDataframe(Dataframes.nodeBreakerViewInternalConnection(), nodeBreakerView);
         });
     }
 
     @CEntryPoint(name = "getBusBreakerViewSwitches")
-    public static PyPowsyblApiHeader.ArrayPointer<PyPowsyblApiHeader.SeriesPointer> getBusBreakerViewSwitches(IsolateThread thread, ObjectHandle networkHandle, CCharPointer voltageLevel, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
+    public static PyPowsyblApiHeader.ArrayPointer<PyPowsyblApiHeader.SeriesPointer> getBusBreakerViewSwitches(IsolateThread thread, ObjectHandle networkHandle, CCharPointer voltageLevelPtr, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
         return doCatch(exceptionHandlerPtr, () -> {
             Network network = ObjectHandles.getGlobal().get(networkHandle);
-            VoltageLevel.BusBreakerView busBreakerView = network.getVoltageLevel(CTypeUtil.toString(voltageLevel)).getBusBreakerView();
+            VoltageLevel.BusBreakerView busBreakerView = NetworkUtils.getVoltageLevelOrThrow(network, CTypeUtil.toString(voltageLevelPtr)).getBusBreakerView();
             return Dataframes.createCDataframe(Dataframes.busBreakerViewSwitches(), busBreakerView);
         });
     }
 
     @CEntryPoint(name = "getBusBreakerViewBuses")
-    public static PyPowsyblApiHeader.ArrayPointer<PyPowsyblApiHeader.SeriesPointer> getBusBreakerViewBuses(IsolateThread thread, ObjectHandle networkHandle, CCharPointer voltageLevel, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
+    public static PyPowsyblApiHeader.ArrayPointer<PyPowsyblApiHeader.SeriesPointer> getBusBreakerViewBuses(IsolateThread thread, ObjectHandle networkHandle, CCharPointer voltageLevelPtr, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
         return doCatch(exceptionHandlerPtr, () -> {
             Network network = ObjectHandles.getGlobal().get(networkHandle);
-            VoltageLevel voltageLevel1 = network.getVoltageLevel(CTypeUtil.toString(voltageLevel));
-            return Dataframes.createCDataframe(Dataframes.busBreakerViewBuses(), voltageLevel1);
+            VoltageLevel voltageLevel = NetworkUtils.getVoltageLevelOrThrow(network, CTypeUtil.toString(voltageLevelPtr));
+            return Dataframes.createCDataframe(Dataframes.busBreakerViewBuses(), voltageLevel);
         });
     }
 
     @CEntryPoint(name = "getBusBreakerViewElements")
-    public static PyPowsyblApiHeader.ArrayPointer<PyPowsyblApiHeader.SeriesPointer> getBusBreakerViewElements(IsolateThread thread, ObjectHandle networkHandle, CCharPointer voltageLevel, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
+    public static PyPowsyblApiHeader.ArrayPointer<PyPowsyblApiHeader.SeriesPointer> getBusBreakerViewElements(IsolateThread thread, ObjectHandle networkHandle, CCharPointer voltageLevelPtr, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
         return doCatch(exceptionHandlerPtr, () -> {
             Network network = ObjectHandles.getGlobal().get(networkHandle);
-            VoltageLevel voltageLevel1 = network.getVoltageLevel(CTypeUtil.toString(voltageLevel));
-            return Dataframes.createCDataframe(Dataframes.busBreakerViewElements(), voltageLevel1);
+            VoltageLevel voltageLevel = NetworkUtils.getVoltageLevelOrThrow(network, CTypeUtil.toString(voltageLevelPtr));
+            return Dataframes.createCDataframe(Dataframes.busBreakerViewElements(), voltageLevel);
         });
     }
 
@@ -725,12 +710,8 @@ public final class NetworkCFunctions {
             List<String> ids = CTypeUtil.toStringList(idsPointer, idsCount);
             List<String> properties = CTypeUtil.toStringList(propertiesPointer, propertiesCount);
             ids.forEach(id -> properties.forEach(property -> {
-                Identifiable<?> identifiable = network.getIdentifiable(id);
-                if (identifiable != null) {
-                    identifiable.removeProperty(property);
-                } else {
-                    throw new PowsyblException(String.format("identifiable with id : %s does not exist", id));
-                }
+                Identifiable<?> identifiable = NetworkUtils.getIdentifiableOrThrow(network, id);
+                identifiable.removeProperty(property);
             }));
         });
     }

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1321,7 +1321,7 @@ def test_node_breaker_view():
 
     with pytest.raises(PyPowsyblError) as exc:
         n.get_node_breaker_topology('wrongVL')
-    assert 'Voltage level with id : wrongVL was not found' in str(exc)
+    assert "Voltage level \'wrongVL\' does not exist." in str(exc)
 
 
 def test_graph():
@@ -1868,7 +1868,7 @@ def test_properties():
 
     with pytest.raises(PyPowsyblError) as exc:
         network.remove_elements_properties(ids='notHere', properties='test')
-    assert 'identifiable with id : notHere does not exist' in str(exc)
+    assert "Network element \'notHere\' does not exist." in str(exc)
 
 
 def test_pathlib_load_save(tmpdir):

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1319,6 +1319,10 @@ def test_node_breaker_view():
     assert 7 == len(nodes)
     assert topology.internal_connections.empty
 
+    with pytest.raises(PyPowsyblError) as exc:
+        n.get_node_breaker_topology('wrongVL')
+    assert 'Voltage level with id : wrongVL was not found' in str(exc)
+
 
 def test_graph():
     n = pp.network.create_four_substations_node_breaker_network()
@@ -1861,6 +1865,10 @@ def test_properties():
     with pytest.raises(PyPowsyblError) as exc:
         network.add_elements_properties(properties)
     assert 'dataframe can not contain NaN values' in str(exc)
+
+    with pytest.raises(PyPowsyblError) as exc:
+        network.remove_elements_properties(ids='notHere', properties='test')
+    assert 'identifiable with id : notHere does not exist' in str(exc)
 
 
 def test_pathlib_load_save(tmpdir):

--- a/tests/test_network_elements_creation.py
+++ b/tests/test_network_elements_creation.py
@@ -825,14 +825,14 @@ def test_creating_vl_without_substation():
 def check_unknown_voltage_level_error_message(fn):
     with pytest.raises(PyPowsyblError) as exc:
         fn(voltage_level_id='UNKNOWN', id='S')
-    assert exc.match('Voltage level UNKNOWN does not exist')
+    assert exc.match("Voltage level 'UNKNOWN' does not exist")
 
 
 def test_error_messages():
     network = pn.create_eurostag_tutorial_example1_network()
     with pytest.raises(PyPowsyblError) as exc:
         network.create_voltage_levels(id='VL', substation_id='UNKNOWN', nominal_v=400)
-    assert exc.match('Substation UNKNOWN does not exist')
+    assert exc.match("Substation 'UNKNOWN' does not exist")
 
     check_unknown_voltage_level_error_message(network.create_loads)
     check_unknown_voltage_level_error_message(network.create_generators)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Two places could create NullPointerException :
- calling get_node_breaker_topology on a non existing voltage level
- trying to remove a property on a non existing identifiable


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No