### PR TITLE
Revert python 3.13 support

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -44,11 +44,11 @@ jobs:
             abi: cp312,
             version: '3.12'
           }
-          - {
-            name: cp313,
-            abi: cp313,
-            version: '3.13'
-          }
+#          - {
+#            name: cp313,
+#            abi: cp313,
+#            version: '3.13'
+#          }
 
     steps:
       - name: Install Maven
@@ -174,10 +174,10 @@ jobs:
             name: cp312,
             version: '3.12',
           }
-          - {
-            name: cp313,
-            version: '3.13',
-          }
+#          - {
+#            name: cp313,
+#            version: '3.13',
+#          }
 
     steps:
       - name: Setup GraalVM

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Notebooks demonstrating PyPowSyBl features can be found in this [repository](htt
 
 ## Installation
 
-PyPowSyBl is released on [PyPi](https://pypi.org/project/pypowsybl/) for Python 3.8 to 3.13, on Linux, Windows and MacOS.
+PyPowSyBl is released on [PyPi](https://pypi.org/project/pypowsybl/) for Python 3.8 to 3.12, on Linux, Windows and MacOS.
 
 First, make sure you have an up-to-date version of pip and setuptools:
 ```bash

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
+;    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
     Operating System :: POSIX :: Linux


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
CI fails because scipy is not available for Python 3.13
Neither Pandas wihich is rebuilt from source.


**What is the new behavior (if this is a feature change)?**
We delay Python 3.13 support.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
