### PR TITLE
Fix optional import of pandapower

### DIFF
--- a/pypowsybl/network/impl/pandapower_converter.py
+++ b/pypowsybl/network/impl/pandapower_converter.py
@@ -18,8 +18,6 @@ from pandas import DataFrame
 try:
     from pandapower import pandapowerNet
 except ImportError:
-    print("No installation of pandapower found, network.convert_from_pandapower method will not be usable")
-    print("Use 'pip install pypowsybl[pandapower]' to install the optional dependency if needed.")
     pandapowerNet = any
 
 from .network import Network

--- a/pypowsybl/network/impl/pandapower_converter.py
+++ b/pypowsybl/network/impl/pandapower_converter.py
@@ -13,9 +13,14 @@ from typing import Dict
 import numpy as np
 import pandas as pd
 import pypowsybl._pypowsybl as _pp
-from pandapower import pandapowerNet
 from pandas import Series
 from pandas import DataFrame
+try:
+    from pandapower import pandapowerNet
+except ImportError:
+    print("No installation of pandapower found, network.convert_from_pandapower method will not be usable")
+    print("Use 'pip install pypowsybl[pandapower]' to install the optional dependency if needed.")
+    pandapowerNet = any
 
 from .network import Network
 from .network_creation_util import create_empty

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     networkx
 
 [options.extras_require]
-extra =
+pandapower =
     pandapower>=2.4.11
 
 [options.package_data]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
If the user does not import pandapower, "import pypowsybl" result in an error


**What is the new behavior (if this is a feature change)?**
An import of pypowsybl without pandapower installed will notify the user that the convert_from_pandapower method will not be available and then completes correctly


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No