### PR TITLE
Get element type from a node/breaker topo nodes dataframe

### DIFF
--- a/java/src/main/java/com/powsybl/python/network/Dataframes.java
+++ b/java/src/main/java/com/powsybl/python/network/Dataframes.java
@@ -310,18 +310,19 @@ public final class Dataframes {
         return nodes.stream().map(node -> {
             Terminal terminal = nodeBreakerView.getTerminal(node);
             if (terminal == null) {
-                return new NodeContext(node, null);
+                return new NodeContext(node, null, null);
             } else {
-                return new NodeContext(node, terminal.getConnectable().getId());
+                return new NodeContext(node, terminal.getConnectable().getId(), terminal.getConnectable().getType());
             }
-        }).collect(Collectors.toList());
+        }).toList();
     }
 
     private static DataframeMapper<VoltageLevel.NodeBreakerView, Void> createNodeBreakerViewNodes() {
         return new DataframeMapperBuilder<VoltageLevel.NodeBreakerView, NodeContext, Void>()
                 .itemsProvider(Dataframes::getNodeBreakerViewNodes)
-                .intsIndex("node", NodeContext::getNode)
-                .strings("connectable_id", node -> Objects.toString(node.getConnectableId(), ""))
+                .intsIndex("node", NodeContext::node)
+                .strings("connectable_id", node -> Objects.toString(node.connectableId(), ""))
+                .strings("connectable_type", node -> Objects.toString(node.connectableType(), ""))
                 .build();
     }
 

--- a/java/src/main/java/com/powsybl/python/network/NodeContext.java
+++ b/java/src/main/java/com/powsybl/python/network/NodeContext.java
@@ -7,26 +7,10 @@
  */
 package com.powsybl.python.network;
 
-import javax.annotation.Nullable;
-import java.util.Objects;
+import com.powsybl.iidm.network.IdentifiableType;
 
 /**
  * @author Etienne Lesot {@literal <etienne.lesot at rte-france.com>}
  */
-public class NodeContext {
-    private final int node;
-    private final String connectableId;
-
-    public NodeContext(int node, @Nullable String connectableId) {
-        this.node = Objects.requireNonNull(node);
-        this.connectableId = connectableId;
-    }
-
-    public int getNode() {
-        return node;
-    }
-
-    public String getConnectableId() {
-        return connectableId;
-    }
+public record NodeContext(int node, String connectableId, IdentifiableType connectableType) {
 }

--- a/pypowsybl/network/impl/node_breaker_topology.py
+++ b/pypowsybl/network/impl/node_breaker_topology.py
@@ -53,7 +53,8 @@ class NodeBreakerTopology:
 
         The dataframe includes the following columns:
 
-        - **connectable_id**: Connected element, if any.
+        - **connectable_id**: Connected element ID, if any.
+        - **connectable_type**: Connected element type, if any.
 
         This dataframe is indexed by the id of the nodes.
         """

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1539,6 +1539,8 @@ def test_node_breaker_view():
     assert 0 == switches.loc['S4VL1_BBS_LINES3S4_DISCONNECTOR']['node1']
     assert 5 == switches.loc['S4VL1_BBS_LINES3S4_DISCONNECTOR']['node2']
     assert 7 == len(nodes)
+    assert 'S4VL1_BBS' == nodes.iloc[0]['connectable_id']
+    assert 'BUSBAR_SECTION' == nodes.iloc[0]['connectable_type']
     assert topology.internal_connections.empty
 
     with pytest.raises(PyPowsyblError) as exc:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Whe getting a node/breaker topo, nodes dataframe, we only have the element IDs.


**What is the new behavior (if this is a feature change)?**
We now have in addition to element IDs, the elements types.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
