### PR TITLE
Fix network save_to_string() encoding issue

### DIFF
--- a/java/pypowsybl/src/main/java/com/powsybl/python/network/NetworkCFunctions.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/python/network/NetworkCFunctions.java
@@ -291,7 +291,7 @@ public final class NetworkCFunctions {
                 try (InputStream is = new ByteArrayInputStream(dataSource.getData(Iterables.getOnlyElement(names)));
                      ByteArrayOutputStream os = new ByteArrayOutputStream()) {
                     IOUtils.copy(is, os);
-                    return CTypeUtil.toCharPtr(os.toString());
+                    return CTypeUtil.toCharPtr(os.toString(StandardCharsets.UTF_8));
                 }
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -2606,5 +2606,13 @@ def test_connect_disconnect_with_empty_bus():
     pd.testing.assert_frame_equal(expected_generators, generators, check_dtype=False)
 
 
+def test_enconding_issue():
+    network = pp.network.create_empty("test")
+    network.create_substations(id='Bürs')
+    substations = network.get_substations(attributes=[])
+    assert ['Bürs'] == substations.index.tolist()
+    assert '<iidm:substation id="Bürs"/>' in network.save_to_string(parameters={'iidm.export.xml.indent': 'false'})
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Encoding is not correctlty managed when using save_to_string. On Windows default one is CP1252 instead of UTF-8 which does not support some characters.


**What is the new behavior (if this is a feature change)?**
We explictely use UTF-8 encoding.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
