### PR TITLE
Fix NPE + clarify error message for wrong extension names

### DIFF
--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/extensions/SecondaryVoltageControlDataframeProvider.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/extensions/SecondaryVoltageControlDataframeProvider.java
@@ -49,14 +49,20 @@ public class SecondaryVoltageControlDataframeProvider implements NetworkExtensio
     }
 
     private Stream<ControlZone> zonesStream(Network network) {
-        return network.getExtension(SecondaryVoltageControl.class)
-                .getControlZones().stream();
+        SecondaryVoltageControl ext = network.getExtension(SecondaryVoltageControl.class);
+        if (ext == null) {
+            throw new PowsyblException("Network " + network.getId() + " has no SecondaryVoltageControl extension.");
+        }
+        return ext.getControlZones().stream();
     }
 
     private Stream<ControlUnitWithZone> unitsStream(Network network) {
         List<ControlUnitWithZone> units = new ArrayList<>();
-        network.getExtension(SecondaryVoltageControl.class)
-                .getControlZones()
+        SecondaryVoltageControl ext = network.getExtension(SecondaryVoltageControl.class);
+        if (ext == null) {
+            throw new PowsyblException("Network " + network.getId() + " has no SecondaryVoltageControl extension.");
+        }
+        ext.getControlZones()
                 .forEach(zone -> {
                     units.addAll(zone.getControlUnits()
                             .stream()

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/extensions/SecondaryVoltageControlDataframeProvider.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/extensions/SecondaryVoltageControlDataframeProvider.java
@@ -31,6 +31,8 @@ import static java.util.stream.Collectors.toList;
 @AutoService(NetworkExtensionDataframeProvider.class)
 public class SecondaryVoltageControlDataframeProvider implements NetworkExtensionDataframeProvider {
 
+    private static final String NO_EXTENSION_MESSAGE = "No SecondaryVoltageControl extension found on network ";
+
     @Override
     public String getExtensionName() {
         return SecondaryVoltageControl.NAME;
@@ -51,7 +53,7 @@ public class SecondaryVoltageControlDataframeProvider implements NetworkExtensio
     private Stream<ControlZone> zonesStream(Network network) {
         SecondaryVoltageControl ext = network.getExtension(SecondaryVoltageControl.class);
         if (ext == null) {
-            throw new PowsyblException("Network " + network.getId() + " has no SecondaryVoltageControl extension.");
+            throw new PowsyblException(NO_EXTENSION_MESSAGE + network.getId());
         }
         return ext.getControlZones().stream();
     }
@@ -60,7 +62,7 @@ public class SecondaryVoltageControlDataframeProvider implements NetworkExtensio
         List<ControlUnitWithZone> units = new ArrayList<>();
         SecondaryVoltageControl ext = network.getExtension(SecondaryVoltageControl.class);
         if (ext == null) {
-            throw new PowsyblException("Network " + network.getId() + " has no SecondaryVoltageControl extension.");
+            throw new PowsyblException(NO_EXTENSION_MESSAGE + network.getId());
         }
         ext.getControlZones()
                 .forEach(zone -> {
@@ -79,7 +81,7 @@ public class SecondaryVoltageControlDataframeProvider implements NetworkExtensio
         public ControlZone getItem(Network network, UpdatingDataframe updatingDataframe, int lineNumber) {
             SecondaryVoltageControl ext = network.getExtension(SecondaryVoltageControl.class);
             if (ext == null) {
-                throw new PowsyblException("Network " + network.getId() + " has no SecondaryVoltageControl extension.");
+                throw new PowsyblException(NO_EXTENSION_MESSAGE + network.getId());
             }
             String name = updatingDataframe.getStringValue("name", lineNumber).orElse(null);
             ControlZone zone = ext.getControlZones().stream()
@@ -101,7 +103,7 @@ public class SecondaryVoltageControlDataframeProvider implements NetworkExtensio
         public ControlUnitWithZone getItem(Network network, UpdatingDataframe updatingDataframe, int lineNumber) {
             SecondaryVoltageControl ext = network.getExtension(SecondaryVoltageControl.class);
             if (ext == null) {
-                throw new PowsyblException("Network " + network.getId() + " has no SecondaryVoltageControl extension.");
+                throw new PowsyblException(NO_EXTENSION_MESSAGE + network.getId());
             }
             String id = updatingDataframe.getStringValue("unit_id", lineNumber).orElse(null);
 

--- a/java/pypowsybl/src/main/java/com/powsybl/python/network/NetworkCFunctions.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/python/network/NetworkCFunctions.java
@@ -470,7 +470,11 @@ public final class NetworkCFunctions {
                 Network network = ObjectHandles.getGlobal().get(networkHandle);
                 return Dataframes.createCDataframe(mapper, network, new DataframeFilter(), NetworkDataframeContext.DEFAULT);
             } else {
-                throw new PowsyblException("extension " + name + " not found");
+                String message = "No extension named " + name + " available";
+                if (tableName != null) {
+                    message = "No table " + tableName + " for extension " + name + " available";
+                }
+                throw new PowsyblException(message);
             }
         });
     }

--- a/java/pypowsybl/src/main/java/com/powsybl/python/network/NetworkCFunctions.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/python/network/NetworkCFunctions.java
@@ -470,13 +470,17 @@ public final class NetworkCFunctions {
                 Network network = ObjectHandles.getGlobal().get(networkHandle);
                 return Dataframes.createCDataframe(mapper, network, new DataframeFilter(), NetworkDataframeContext.DEFAULT);
             } else {
-                String message = "No extension named " + name + " available";
-                if (tableName != null) {
-                    message = "No table " + tableName + " for extension " + name + " available";
-                }
-                throw new PowsyblException(message);
+                throw new PowsyblException(errorMessageForWrongExtensionName(name, tableName));
             }
         });
+    }
+
+    private static String errorMessageForWrongExtensionName(String name, String tableName) {
+        String message = "No extension named " + name + " available";
+        if (tableName != null) {
+            message = "No table " + tableName + " for extension " + name + " available";
+        }
+        return message;
     }
 
     @CEntryPoint(name = "getExtensionsNames")
@@ -800,10 +804,7 @@ public final class NetworkCFunctions {
                 UpdatingDataframe updatingDataframe = createDataframe(dataframe);
                 mapper.updateSeries(network, updatingDataframe, NetworkDataframeContext.DEFAULT);
             } else {
-                if (tableName != null) {
-                    throw new PowsyblException("table " + tableName + " of extension " + name + " not found");
-                }
-                throw new PowsyblException("extension " + name + " not found");
+                throw new PowsyblException(errorMessageForWrongExtensionName(name, tableName));
             }
         });
     }
@@ -833,7 +834,7 @@ public final class NetworkCFunctions {
                 List<SeriesMetadata> seriesMetadata = mapper.getSeriesMetadata();
                 return CTypeUtil.createSeriesMetadata(seriesMetadata);
             } else {
-                throw new PowsyblException("extension " + name + " not found");
+                throw new PowsyblException(errorMessageForWrongExtensionName(name, tableName));
             }
         });
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
A NPE could occur in SecondaryVoltageControl extension dataframe getter if no extension was defined.

Also, the error raised when a wrong name for a table and/or an extension was given from the python side was not clear enough ("extension <name> not found") and could be misunderstood as "There is no extension of this type on the network" instead of "This is not a known name for an extension/table"


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix 

**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**

