### PR TITLE
Fix orderly-set version due to type error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pybind11[global]==2.13.6
 
 # optional dependencies
 pandapower==2.14.11
+orderly-set==5.3.0 # TO REMOVE WHEN FIXED
 
 # documentation dependencies
 sphinx==7.1.2


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Temporary dependency fix : orderly-set last release for Python 3.8 is borken due to typing annotations