### PR TITLE
Add per-unit for operational limits

### DIFF
--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -1546,23 +1546,16 @@ public final class NetworkDataframes {
     }
 
     private static double perUnitLimitValue(NetworkDataframeContext context, TemporaryLimitData limit) {
-        switch (limit.getType()) {
-            case CURRENT -> {
-                return perUnitI(context, limit.getValue(), limit.getPerUnitingNominalV());
-            }
-            case ACTIVE_POWER, APPARENT_POWER -> {
-                return perUnitPQ(context, limit.getValue());
-            }
-            case VOLTAGE -> {
-                return perUnitV(context, limit.getValue(), limit.getPerUnitingNominalV());
-            }
-            case VOLTAGE_ANGLE -> {
-                return perUnitAngle(context, limit.getValue());
-            }
-            default -> {
-                return 0.0;
-            }
-        }
+        return switch (limit.getType()) {
+            case CURRENT ->
+                perUnitI(context, limit.getValue(), limit.getPerUnitingNominalV());
+            case ACTIVE_POWER, APPARENT_POWER ->
+                perUnitPQ(context, limit.getValue());
+            case VOLTAGE ->
+                perUnitV(context, limit.getValue(), limit.getPerUnitingNominalV());
+            case VOLTAGE_ANGLE ->
+                perUnitAngle(context, limit.getValue());
+        };
     }
 
     private static Stream<Pair<String, ReactiveLimitsHolder>> streamReactiveLimitsHolder(Network network) {

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -1537,12 +1537,32 @@ public final class NetworkDataframes {
                 .enums("side", TemporaryLimitData.Side.class, TemporaryLimitData::getSide)
                 .strings("name", TemporaryLimitData::getName)
                 .enums("type", LimitType.class, TemporaryLimitData::getType)
-                .doubles("value", TemporaryLimitData::getValue)
+                .doubles("value", (limit, context) -> perUnitLimitValue(context, limit))
                 .ints("acceptable_duration", TemporaryLimitData::getAcceptableDuration)
                 .booleans("fictitious", TemporaryLimitData::isFictitious, false)
                 .strings("group_name", TemporaryLimitData::getGroupId, false)
                 .booleans("selected", TemporaryLimitData::isSelected, false)
                 .build();
+    }
+
+    private static double perUnitLimitValue(NetworkDataframeContext context, TemporaryLimitData limit) {
+        switch (limit.getType()) {
+            case CURRENT -> {
+                return perUnitI(context, limit.getValue(), limit.getPerUnitingNominalV());
+            }
+            case ACTIVE_POWER, APPARENT_POWER -> {
+                return perUnitPQ(context, limit.getValue());
+            }
+            case VOLTAGE -> {
+                return perUnitV(context, limit.getValue(), limit.getPerUnitingNominalV());
+            }
+            case VOLTAGE_ANGLE -> {
+                return perUnitAngle(context, limit.getValue());
+            }
+            default -> {
+                return 0.0;
+            }
+        }
     }
 
     private static Stream<Pair<String, ReactiveLimitsHolder>> streamReactiveLimitsHolder(Network network) {

--- a/java/pypowsybl/src/main/java/com/powsybl/python/network/TemporaryLimitData.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/python/network/TemporaryLimitData.java
@@ -27,6 +27,7 @@ public class TemporaryLimitData {
     private final boolean isFictitious;
     private final String groupId;
     private final boolean selected;
+    private final double perUnitingNominalV;
 
     public enum Side {
         NONE,
@@ -36,7 +37,7 @@ public class TemporaryLimitData {
     }
 
     public TemporaryLimitData(String id, String name, Side side, double value, LimitType type, IdentifiableType elementType,
-                              int acceptableDuration, boolean isFictitious, String groupId, boolean selected) {
+                              int acceptableDuration, boolean isFictitious, String groupId, boolean selected, double perUnitingNominalV) {
         this.id = Objects.requireNonNull(id);
         this.name = Objects.requireNonNull(name);
         this.side = side;
@@ -47,11 +48,12 @@ public class TemporaryLimitData {
         this.isFictitious = isFictitious;
         this.groupId = Objects.requireNonNull(groupId);
         this.selected = selected;
+        this.perUnitingNominalV = perUnitingNominalV;
     }
 
     public TemporaryLimitData(String id, String name, Side side, double value, LimitType type, IdentifiableType elementType,
-                              String groupId, boolean isSelected) {
-        this(id, name, side, value, type, elementType, -1, false, groupId, isSelected);
+                              String groupId, boolean isSelected, double perUnitingNominalV) {
+        this(id, name, side, value, type, elementType, -1, false, groupId, isSelected, perUnitingNominalV);
     }
 
     public String getId() {
@@ -92,5 +94,9 @@ public class TemporaryLimitData {
 
     public boolean isSelected() {
         return selected;
+    }
+
+    public double getPerUnitingNominalV() {
+        return perUnitingNominalV;
     }
 }

--- a/tests/test_per_unit.py
+++ b/tests/test_per_unit.py
@@ -8,6 +8,7 @@ from pypowsybl import per_unit_view
 import pypowsybl as pp
 import pandas as pd
 from numpy import nan
+import numpy.testing as npt
 import re
 import util
 import pytest
@@ -478,3 +479,18 @@ def test_phase_tap_changer_steps_per_unit():
     assert steps.loc['T196-2040-1', 0]['x'] == 3
     assert steps.loc['T196-2040-1', 0]['g'] == 4
     assert steps.loc['T196-2040-1', 0]['b'] == 2
+
+def test_limits_per_unit():
+    network = util.create_dangling_lines_network()
+    network.per_unit = True
+
+    limits = network.get_operational_limits()
+    values = limits["value"].values.tolist()
+    npt.assert_allclose(values, [0.173205, 0.207846, 0.242487], rtol=1e-5)
+
+    network = pp.network.create_eurostag_tutorial_example1_with_power_limits_network()
+    network.per_unit = True
+    limits = network.get_operational_limits(all_attributes=True).loc['NHV1_NHV2_1']
+    limits = limits[limits['name'] == 'permanent_limit']
+    values = limits["value"].values.tolist()
+    npt.assert_allclose(values, [5, 5, 11, 11])


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The operational limits table was not per-united even if the network was set to per-unit mode.


**What is the new behavior (if this is a feature change)?**
Now all limits are per-united depending on their type (current, voltage, power...)


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
