### PR TITLE
Add convenient columns in transfos dataframe to get RXGB for current tap

### DIFF
--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -587,6 +587,10 @@ public final class NetworkDataframes {
                         TwoWindingsTransformer::setSelectedOperationalLimitsGroup2, false)
                 .doubles("rho", (twt, context) -> perUnitRho(context, twt, NetworkDataframes.computeRho(twt)), false)
                 .doubles("alpha", (twt, context) -> perUnitAngle(context, NetworkDataframes.computeAlpha(twt)), false)
+                .doubles("r_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeR(twt), twt), false)
+                .doubles("x_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeX(twt), twt), false)
+                .doubles("g_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeG(twt), twt), false)
+                .doubles("b_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeB(twt), twt), false)
                 .addProperties()
                 .build();
     }
@@ -616,6 +620,10 @@ public final class NetworkDataframes {
                         (twt, groupId) -> twt.getLeg1().setSelectedOperationalLimitsGroup(groupId), false)
                 .doubles("rho1", (twt, context) -> perUnitRho(context, twt, ThreeSides.ONE, NetworkDataframes.computeRho(twt, ThreeSides.ONE)), false)
                 .doubles("alpha1", (twt, context) -> perUnitAngle(context, NetworkDataframes.computeAlpha(twt, ThreeSides.ONE)), false)
+                .doubles("r1_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeR(twt, ThreeSides.ONE), twt), false)
+                .doubles("x1_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeX(twt, ThreeSides.ONE), twt), false)
+                .doubles("g1_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeG(twt, ThreeSides.ONE), twt), false)
+                .doubles("b1_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeB(twt, ThreeSides.ONE), twt), false)
                 .doubles("r2", (twt, context) -> perUnitRX(context, twt.getLeg2().getR(), twt), (twt, r2, context) -> twt.getLeg2().setR(unPerUnitRX(context, twt, r2)))
                 .doubles("x2", (twt, context) -> perUnitRX(context, twt.getLeg2().getX(), twt), (twt, x2, context) -> twt.getLeg2().setX(unPerUnitRX(context, twt, x2)))
                 .doubles("g2", (twt, context) -> perUnitBG(context, twt.getLeg2().getG(), twt), (twt, g2, context) -> twt.getLeg2().setG(unPerUnitBG(context, twt, g2)))
@@ -636,6 +644,10 @@ public final class NetworkDataframes {
                         (twt, groupId) -> twt.getLeg2().setSelectedOperationalLimitsGroup(groupId), false)
                 .doubles("rho2", (twt, context) -> perUnitRho(context, twt, ThreeSides.TWO, NetworkDataframes.computeRho(twt, ThreeSides.TWO)), false)
                 .doubles("alpha2", (twt, context) -> perUnitAngle(context, NetworkDataframes.computeAlpha(twt, ThreeSides.TWO)), false)
+                .doubles("r2_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeR(twt, ThreeSides.TWO), twt), false)
+                .doubles("x2_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeX(twt, ThreeSides.TWO), twt), false)
+                .doubles("g2_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeG(twt, ThreeSides.TWO), twt), false)
+                .doubles("b2_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeB(twt, ThreeSides.TWO), twt), false)
                 .doubles("r3", (twt, context) -> perUnitRX(context, twt.getLeg3().getR(), twt), (twt, r3, context) -> twt.getLeg3().setR(unPerUnitRX(context, twt, r3)))
                 .doubles("x3", (twt, context) -> perUnitRX(context, twt.getLeg3().getX(), twt), (twt, x3, context) -> twt.getLeg3().setX(unPerUnitRX(context, twt, x3)))
                 .doubles("g3", (twt, context) -> perUnitBG(context, twt.getLeg3().getG(), twt), (twt, g3, context) -> twt.getLeg3().setG(unPerUnitBG(context, twt, g3)))
@@ -656,6 +668,10 @@ public final class NetworkDataframes {
                         (twt, groupId) -> twt.getLeg3().setSelectedOperationalLimitsGroup(groupId), false)
                 .doubles("rho3", (twt, context) -> perUnitRho(context, twt, ThreeSides.THREE, NetworkDataframes.computeRho(twt, ThreeSides.THREE)), false)
                 .doubles("alpha3", (twt, context) -> perUnitAngle(context, NetworkDataframes.computeAlpha(twt, ThreeSides.THREE)), false)
+                .doubles("r3_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeR(twt, ThreeSides.THREE), twt), false)
+                .doubles("x3_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeX(twt, ThreeSides.THREE), twt), false)
+                .doubles("g3_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeG(twt, ThreeSides.THREE), twt), false)
+                .doubles("b3_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeB(twt, ThreeSides.THREE), twt), false)
                 .booleans("fictitious", Identifiable::isFictitious, Identifiable::setFictitious, false)
                 .addProperties()
                 .build();
@@ -1350,6 +1366,58 @@ public final class NetworkDataframes {
     private static double computeAlpha(ThreeWindingsTransformer twt, ThreeSides side) {
         ThreeWindingsTransformer.Leg leg = twt.getLeg(side);
         return leg.getPhaseTapChanger() != null ? leg.getPhaseTapChanger().getCurrentStep().getAlpha() : 0;
+    }
+
+    private static double computeR(TwoWindingsTransformer twt) {
+        return twt.getR()
+                * (twt.getRatioTapChanger() != null ? (1 + twt.getRatioTapChanger().getCurrentStep().getR() / 100.0) : 1)
+                * (twt.getPhaseTapChanger() != null ? (1 + twt.getPhaseTapChanger().getCurrentStep().getR() / 100.0) : 1);
+    }
+
+    private static double computeX(TwoWindingsTransformer twt) {
+        return twt.getX()
+                * (twt.getRatioTapChanger() != null ? (1 + twt.getRatioTapChanger().getCurrentStep().getX() / 100.0) : 1)
+                * (twt.getPhaseTapChanger() != null ? (1 + twt.getPhaseTapChanger().getCurrentStep().getX() / 100.0) : 1);
+    }
+
+    private static double computeG(TwoWindingsTransformer twt) {
+        return twt.getG()
+                * (twt.getRatioTapChanger() != null ? (1 + twt.getRatioTapChanger().getCurrentStep().getG() / 100.0) : 1)
+                * (twt.getPhaseTapChanger() != null ? (1 + twt.getPhaseTapChanger().getCurrentStep().getG() / 100.0) : 1);
+    }
+
+    private static double computeB(TwoWindingsTransformer twt) {
+        return twt.getB()
+                * (twt.getRatioTapChanger() != null ? (1 + twt.getRatioTapChanger().getCurrentStep().getB() / 100.0) : 1)
+                * (twt.getPhaseTapChanger() != null ? (1 + twt.getPhaseTapChanger().getCurrentStep().getB() / 100.0) : 1);
+    }
+
+    private static double computeR(ThreeWindingsTransformer twt, ThreeSides side) {
+        ThreeWindingsTransformer.Leg leg = twt.getLeg(side);
+        return leg.getR()
+                * (leg.getRatioTapChanger() != null ? (1 + leg.getRatioTapChanger().getCurrentStep().getR() / 100.0) : 1)
+                * (leg.getPhaseTapChanger() != null ? (1 + leg.getPhaseTapChanger().getCurrentStep().getR() / 100.0) : 1);
+    }
+
+    private static double computeX(ThreeWindingsTransformer twt, ThreeSides side) {
+        ThreeWindingsTransformer.Leg leg = twt.getLeg(side);
+        return leg.getX()
+                * (leg.getRatioTapChanger() != null ? (1 + leg.getRatioTapChanger().getCurrentStep().getX() / 100.0) : 1)
+                * (leg.getPhaseTapChanger() != null ? (1 + leg.getPhaseTapChanger().getCurrentStep().getX() / 100.0) : 1);
+    }
+
+    private static double computeG(ThreeWindingsTransformer twt, ThreeSides side) {
+        ThreeWindingsTransformer.Leg leg = twt.getLeg(side);
+        return leg.getG()
+                * (leg.getRatioTapChanger() != null ? (1 + leg.getRatioTapChanger().getCurrentStep().getG() / 100.0) : 1)
+                * (leg.getPhaseTapChanger() != null ? (1 + leg.getPhaseTapChanger().getCurrentStep().getG() / 100.0) : 1);
+    }
+
+    private static double computeB(ThreeWindingsTransformer twt, ThreeSides side) {
+        ThreeWindingsTransformer.Leg leg = twt.getLeg(side);
+        return leg.getB()
+                * (leg.getRatioTapChanger() != null ? (1 + leg.getRatioTapChanger().getCurrentStep().getB() / 100.0) : 1)
+                * (leg.getPhaseTapChanger() != null ? (1 + leg.getPhaseTapChanger().getCurrentStep().getB() / 100.0) : 1);
     }
 
     private static NetworkDataframeMapper ptcs() {

--- a/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
+++ b/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
@@ -444,7 +444,8 @@ class NetworkDataframesTest {
                 .extracting(Series::getName)
                 .containsExactly("id", "name", "r", "x", "g", "b", "rated_u1", "rated_u2", "rated_s", "p1", "q1", "i1", "p2", "q2", "i2",
                         "voltage_level1_id", "voltage_level2_id", "bus1_id", "bus_breaker_bus1_id", "node1", "bus2_id", "bus_breaker_bus2_id", "node2",
-                        "connected1", "connected2", "fictitious", "selected_limits_group_1", "selected_limits_group_2", "rho", "alpha");
+                        "connected1", "connected2", "fictitious", "selected_limits_group_1", "selected_limits_group_2", "rho", "alpha",
+                        "r_at_current_tap", "x_at_current_tap", "g_at_current_tap", "b_at_current_tap");
     }
 
     @Test
@@ -462,9 +463,9 @@ class NetworkDataframesTest {
         assertThat(allAttributeSeries)
                 .extracting(Series::getName)
                 .containsExactly("id", "name", "rated_u0",
-                        "r1", "x1", "g1", "b1", "rated_u1", "rated_s1", "ratio_tap_position1", "phase_tap_position1", "p1", "q1", "i1", "voltage_level1_id", "bus1_id", "bus_breaker_bus1_id", "node1", "connected1", "selected_limits_group_1", "rho1", "alpha1",
-                        "r2", "x2", "g2", "b2", "rated_u2", "rated_s2", "ratio_tap_position2", "phase_tap_position2", "p2", "q2", "i2", "voltage_level2_id", "bus2_id", "bus_breaker_bus2_id", "node2", "connected2", "selected_limits_group_2", "rho2", "alpha2",
-                        "r3", "x3", "g3", "b3", "rated_u3", "rated_s3", "ratio_tap_position3", "phase_tap_position3", "p3", "q3", "i3", "voltage_level3_id", "bus3_id", "bus_breaker_bus3_id", "node3", "connected3", "selected_limits_group_3", "rho3", "alpha3",
+                        "r1", "x1", "g1", "b1", "rated_u1", "rated_s1", "ratio_tap_position1", "phase_tap_position1", "p1", "q1", "i1", "voltage_level1_id", "bus1_id", "bus_breaker_bus1_id", "node1", "connected1", "selected_limits_group_1", "rho1", "alpha1", "r1_at_current_tap", "x1_at_current_tap", "g1_at_current_tap", "b1_at_current_tap",
+                        "r2", "x2", "g2", "b2", "rated_u2", "rated_s2", "ratio_tap_position2", "phase_tap_position2", "p2", "q2", "i2", "voltage_level2_id", "bus2_id", "bus_breaker_bus2_id", "node2", "connected2", "selected_limits_group_2", "rho2", "alpha2", "r2_at_current_tap", "x2_at_current_tap", "g2_at_current_tap", "b2_at_current_tap",
+                        "r3", "x3", "g3", "b3", "rated_u3", "rated_s3", "ratio_tap_position3", "phase_tap_position3", "p3", "q3", "i3", "voltage_level3_id", "bus3_id", "bus_breaker_bus3_id", "node3", "connected3", "selected_limits_group_3", "rho3", "alpha3", "r3_at_current_tap", "x3_at_current_tap", "g3_at_current_tap", "b3_at_current_tap",
                         "fictitious");
     }
 

--- a/pypowsybl/network/impl/network.py
+++ b/pypowsybl/network/impl/network.py
@@ -1118,10 +1118,10 @@ class Network:  # pylint: disable=too-many-public-methods
             - **r**: the resistance of the transformer at its "2" side  (in Ohm)
             - **x**: the reactance of the transformer at its "2" side (in Ohm)
             - **b**: the susceptance of transformer at its "2" side (in Siemens)
-            - **g**: the  conductance of transformer at its "2" side (in Siemens)
-            - **rated_u1**: The rated voltage of the transformer at side 1 (in kV)
-            - **rated_u2**: The rated voltage of the transformer at side 2 (in kV)
-            - **rated_s**:
+            - **g**: the conductance of transformer at its "2" side (in Siemens)
+            - **rated_u1**: the rated voltage of the transformer at side 1 (in kV)
+            - **rated_u2**: the rated voltage of the transformer at side 2 (in kV)
+            - **rated_s**: the rated apparent power of the transformer (in MVA)
             - **p1**: the active flow on the transformer at its "1" side, ``NaN`` if no loadflow has been computed (in MW)
             - **q1**: the reactive flow on the transformer at its "1" side, ``NaN`` if no loadflow has been computed  (in MVAr)
             - **i1**: the current on the transformer at its "1" side, ``NaN`` if no loadflow has been computed (in A)
@@ -1141,6 +1141,12 @@ class Network:  # pylint: disable=too-many-public-methods
             - **fictitious** (optional): ``True`` if the transformer is part of the model and not of the actual network
             - **selected_limits_group_1** (optional): Name of the selected operational limits group selected for side 1
             - **selected_limits_group_2** (optional): Name of the selected operational limits group selected for side 2
+            - **rho** (optional): the voltage ratio of the transformer at current tap position
+            - **alpha** (optional): the phase shift of the transformer at current tap position (in degree)
+            - **r_at_current_tap** (optional): the resistance of the transformer at current tap position (in Ohm)
+            - **x_at_current_tap** (optional): the reactance of the transformer at current tap position (in Ohm)
+            - **g_at_current_tap** (optional): the susceptance of the transformer at current tap position (in Ohm)
+            - **b_at_current_tap** (optional): the conductance of the transformer at current tap position (in Ohm)
 
             This dataframe is indexed by the id of the two windings transformers
 
@@ -1209,6 +1215,83 @@ class Network:  # pylint: disable=too-many-public-methods
 
         Returns:
             A dataframe of 3 windings transformers.
+
+        Notes:
+            The resulting dataframe, depending on the parameters, will include the following columns:
+
+            - **rated_u0**: the rated voltage of the transformer at middle point od the star model (in kV)
+            - **fictitious** (optional): ``True`` if the transformer is part of the model and not of the actual network
+            - **r1**: the leg 1 resistance of the transformer (in Ohm)
+            - **x1**: the leg 1 reactance of the transformer (in Ohm)
+            - **b1**: the leg 1 susceptance of transformer (in Siemens)
+            - **g1**: the leg 1 conductance of transformer (in Siemens)
+            - **rated_u1**: the leg 1 rated voltage of the transformer (in kV)
+            - **rated_s1**: the leg 1 rated apparent power of the transformer (in MVA)
+            - **ratio_tap_position1**: the leg 1 ratio tap changer current position
+            - **phase_tap_position1**: the leg 1 phase tap changer current position
+            - **p1**: the leg 1 active power flow on the transformer, ``NaN`` if no loadflow has been computed (in MW)
+            - **q1**: the leg 1 reactive power flow on the transformer, ``NaN`` if no loadflow has been computed  (in MVAr)
+            - **i1**: the leg 1 current on the transformer, ``NaN`` if no loadflow has been computed (in A)
+            - **voltage_level1_id**: the voltage level where the leg 1 of the transformer is connected
+            - **bus1_id**: the bus where the leg 1 of the transformer is connected
+            - **bus_breaker_bus1_id** (optional): the bus of the bus-breaker view where leg 1 of the transformer is connected
+            - **node1** (optional): the node where the leg 1 transformer is connected (only in node-breaker voltage levels)
+            - **connected1**: ``True`` if the leg 1 of the transformer is connected to a bus
+            - **selected_limits_group_1** (optional): the name of the selected operational limits group selected for the leg 1 of the transformer
+            - **rho1** (optional): the leg 1 voltage ratio of the transformer at current tap position
+            - **alpha1** (optional): the leg 1 phase shift of the transformer at current tap position (in degree)
+            - **r1_at_current_tap** (optional): the leg 1 resistance of the transformer at current tap position (in Ohm)
+            - **x1_at_current_tap** (optional): the leg 1 reactance of the transformer at current tap position (in Ohm)
+            - **g1_at_current_tap** (optional): the leg 1 susceptance of the transformer at current tap position (in Ohm)
+            - **b1_at_current_tap** (optional): the leg 1 conductance of the transformer at current tap position (in Ohm)
+            - **r2**: the leg 2 resistance of the transformer (in Ohm)
+            - **x2**: the leg 2 reactance of the transformer (in Ohm)
+            - **b2**: the leg 2 susceptance of transformer (in Siemens)
+            - **g2**: the leg 2 conductance of transformer (in Siemens)
+            - **rated_u2**: the leg 2 rated voltage of the transformer (in kV)
+            - **rated_s2**: the leg 2 rated apparent power of the transformer (in MVA)
+            - **ratio_tap_position2**: the leg 2 ratio tap changer current position
+            - **phase_tap_position2**: the leg 2 phase tap changer current position
+            - **p2**: the leg 2 active power flow on the transformer, ``NaN`` if no loadflow has been computed (in MW)
+            - **q2**: the leg 2 reactive power flow on the transformer, ``NaN`` if no loadflow has been computed (in MVAr)
+            - **i2**: the leg 2 current on the transformer, ``NaN`` if no loadflow has been computed (in A)
+            - **voltage_level2_id**: the voltage level where the leg 2 of the transformer is connected
+            - **bus2_id**: the bus where the leg 2 of the transformer is connected
+            - **bus_breaker_bus2_id** (optional): the bus of the bus-breaker view where leg 2 of the transformer is connected
+            - **node2** (optional): the node where the leg 2 transformer is connected (only in node-breaker voltage levels)
+            - **connected2**: ``True`` if the leg 2 of the transformer is connected to a bus
+            - **selected_limits_group_2** (optional): the name of the selected operational limits group selected for the leg 2 of the transformer
+            - **rho2** (optional): the leg 2 voltage ratio of the transformer at current tap position
+            - **alpha2** (optional): the leg 2 phase shift of the transformer at current tap position (in degree)
+            - **r2_at_current_tap** (optional): the leg 2 resistance of the transformer at current tap position (in Ohm)
+            - **x2_at_current_tap** (optional): the leg 2 reactance of the transformer at current tap position (in Ohm)
+            - **g2_at_current_tap** (optional): the leg 2 susceptance of the transformer at current tap position (in Ohm)
+            - **b2_at_current_tap** (optional): the leg 2 conductance of the transformer at current tap position (in Ohm)
+            - **r3**: the leg 3 resistance of the transformer (in Ohm)
+            - **x3**: the leg 3 reactance of the transformer (in Ohm)
+            - **b3**: the leg 3 susceptance of transformer (in Siemens)
+            - **g3**: the leg 3 conductance of transformer (in Siemens)
+            - **rated_u3**: the leg 3 rated voltage of the transformer (in kV)
+            - **rated_s3**: the leg 3 rated apparent power of the transformer (in MVA)
+            - **ratio_tap_position3**: the leg 3 ratio tap changer current position
+            - **phase_tap_position3**: the leg 3 phase tap changer current position
+            - **p3**: the leg 3 active power flow on the transformer, ``NaN`` if no loadflow has been computed (in MW)
+            - **q3**: the leg 3 reactive power flow on the transformer, ``NaN`` if no loadflow has been computed (in MVAr)
+            - **i3**: the leg 3 current on the transformer, ``NaN`` if no loadflow has been computed (in A)
+            - **voltage_level3_id**: the voltage level where the leg 3 of the transformer is connected
+            - **bus3_id**: the bus where the leg 3 of the transformer is connected
+            - **bus_breaker_bus3_id** (optional): the bus of the bus-breaker view where leg 3 of the transformer is connected
+            - **node3** (optional): the node where the leg 3 transformer is connected (only in node-breaker voltage levels)
+            - **connected3**: ``True`` if the leg 3 of the transformer is connected to a bus
+            - **selected_limits_group_3** (optional): the name of the selected operational limits group selected for the leg 3 of the transformer
+            - **rho3** (optional): the leg 3 voltage ratio of the transformer at current tap position
+            - **alpha3** (optional): the leg 3 phase shift of the transformer at current tap position (in degree)
+            - **r3_at_current_tap** (optional): the leg 3 resistance of the transformer at current tap position (in Ohm)
+            - **x3_at_current_tap** (optional): the leg 3 reactance of the transformer at current tap position (in Ohm)
+            - **g3_at_current_tap** (optional): the leg 3 susceptance of the transformer at current tap position (in Ohm)
+            - **b3_at_current_tap** (optional): the leg 3 conductance of the transformer at current tap position (in Ohm)
+
+            This dataframe is indexed by the id of the three windings transformers
         """
         return self.get_elements(ElementType.THREE_WINDINGS_TRANSFORMER, all_attributes, attributes, **kwargs)
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -2733,5 +2733,35 @@ def test_q_min_max_at_target_p():
     pd.testing.assert_frame_equal(expected_batteries, batteries, check_dtype=False)
 
 
+def test_rxbg_at_current_tap_transfo2():
+    network = pp.network.create_micro_grid_be_network()
+    transfo2 = network.get_2_windings_transformers(attributes=['r_at_current_tap', 'x_at_current_tap', 'g_at_current_tap', 'b_at_current_tap'])
+    expected_transfo2 = pd.DataFrame(index=pd.Series(name='id',
+                                                     data=['a708c3bc-465d-4fe7-b6ef-6fa6408a62b0',
+                                                           'b94318f6-6d24-4f56-96b9-df2531ad6543',
+                                                           'e482b89a-fa84-4ea9-8e70-a83d44790957']),
+                                     columns=['r_at_current_tap', 'x_at_current_tap', 'g_at_current_tap', 'b_at_current_tap'],
+                                     data=[[0.204769, 1.097992, 0.0, 0.0],
+                                           [0.2057, 2.78472, 0.0, 0.0],
+                                           [0.000903, 0.050402, 0.002009, -0.009626]])
+    pd.testing.assert_frame_equal(expected_transfo2, transfo2, check_dtype=False, atol=1e-6)
+
+
+def test_rxbg_at_current_tap_transfo3():
+    network = pp.network.create_micro_grid_be_network()
+    transfo3 = network.get_3_windings_transformers(attributes=['r1_at_current_tap', 'x1_at_current_tap', 'g1_at_current_tap', 'b1_at_current_tap',
+                                                               'r2_at_current_tap', 'x2_at_current_tap', 'g2_at_current_tap', 'b2_at_current_tap',
+                                                               'r3_at_current_tap', 'x3_at_current_tap', 'g3_at_current_tap', 'b3_at_current_tap'])
+    expected_transfo3 = pd.DataFrame(index=pd.Series(name='id',
+                                                     data=['84ed55f4-61f5-4d9d-8755-bba7b877a246']),
+                                     columns=['r1_at_current_tap', 'x1_at_current_tap', 'g1_at_current_tap', 'b1_at_current_tap',
+                                              'r2_at_current_tap', 'x2_at_current_tap', 'g2_at_current_tap', 'b2_at_current_tap',
+                                              'r3_at_current_tap', 'x3_at_current_tap', 'g3_at_current_tap', 'b3_at_current_tap'],
+                                     data=[[0.898462, 17.204128, 0.0, 0.000002,
+                                            1.07077, 19.6664, 0.0, 0.0,
+                                            4.837007, 21.760726, 0.0, 0.0]])
+    pd.testing.assert_frame_equal(expected_transfo3, transfo3, check_dtype=False, atol=1e-6)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the new behavior (if this is a feature change)?**
I added some extra read only columns that directly give the effective value of r,x,g,b at current tap position of the ratio tap changer and the phase tap changer taking into account the deviation value of the tap.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
