### PR TITLE
Fix transformer g and b_at_current_tap per-uniting

### DIFF
--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -456,9 +456,9 @@ public final class NetworkDataframes {
                 .stringsIndex("id", triple -> triple.getLeft().getId())
                 .intsIndex("section", Triple::getRight)
                 .doubles("g", (p, context) -> perUnitG(context, p.getMiddle(), p.getLeft()),
-                    (p, g, context) -> p.getMiddle().setG(unPerUnitBG(context, p.getLeft(), g)))
+                    (p, g, context) -> p.getMiddle().setG(unPerUnitGB(context, p.getLeft(), g)))
                 .doubles("b", (p, context) -> perUnitB(context, p.getMiddle(), p.getLeft()),
-                    (p, b, context) -> p.getMiddle().setB(unPerUnitBG(context, p.getLeft(), b)))
+                    (p, b, context) -> p.getMiddle().setB(unPerUnitGB(context, p.getLeft(), b)))
                 .build();
     }
 
@@ -486,10 +486,10 @@ public final class NetworkDataframes {
                         .map(shuntCompensator -> Pair.of(shuntCompensator, (ShuntCompensatorLinearModel) shuntCompensator.getModel()));
         return NetworkDataframeMapperBuilder.ofStream(linearShunts, (net, s) -> Pair.of(checkShuntNonNull(net, s), checkLinearModel(net, s)))
                 .stringsIndex("id", p -> p.getLeft().getId())
-                .doubles("g_per_section", (p, context) -> perUnitBG(context, p.getRight().getGPerSection(), p.getLeft().getTerminal().getVoltageLevel().getNominalV()),
-                    (p, g, context) -> p.getRight().setGPerSection(unPerUnitBG(context, g, p.getLeft().getTerminal().getVoltageLevel().getNominalV())))
-                .doubles("b_per_section", (p, context) -> perUnitBG(context, p.getRight().getBPerSection(), p.getLeft().getTerminal().getVoltageLevel().getNominalV()),
-                    (p, b, context) -> p.getRight().setBPerSection(unPerUnitBG(context, b, p.getLeft().getTerminal().getVoltageLevel().getNominalV())))
+                .doubles("g_per_section", (p, context) -> perUnitGB(context, p.getRight().getGPerSection(), p.getLeft().getTerminal().getVoltageLevel().getNominalV()),
+                    (p, g, context) -> p.getRight().setGPerSection(unPerUnitGB(context, g, p.getLeft().getTerminal().getVoltageLevel().getNominalV())))
+                .doubles("b_per_section", (p, context) -> perUnitGB(context, p.getRight().getBPerSection(), p.getLeft().getTerminal().getVoltageLevel().getNominalV()),
+                    (p, b, context) -> p.getRight().setBPerSection(unPerUnitGB(context, b, p.getLeft().getTerminal().getVoltageLevel().getNominalV())))
                 .ints("max_section_count", p -> p.getLeft().getMaximumSectionCount(), (p, s) -> p.getRight().setMaximumSectionCount(s))
                 .build();
     }
@@ -555,10 +555,10 @@ public final class NetworkDataframes {
         return NetworkDataframeMapperBuilder.ofStream(Network::getTwoWindingsTransformerStream, getOrThrow(Network::getTwoWindingsTransformer, "Two windings transformer"))
                 .stringsIndex("id", TwoWindingsTransformer::getId)
                 .strings("name", twt -> twt.getOptionalName().orElse(""), Identifiable::setName)
-                .doubles("r", (twt, context) -> perUnitRX(context, twt.getR(), twt), (twt, r, context) -> twt.setR(unPerUnitRX(context, twt, r)))
-                .doubles("x", (twt, context) -> perUnitRX(context, twt.getX(), twt), (twt, x, context) -> twt.setX(unPerUnitRX(context, twt, x)))
-                .doubles("g", (twt, context) -> perUnitBG(context, twt, twt.getG()), (twt, g, context) -> twt.setG(unPerUnitBG(context, twt, g)))
-                .doubles("b", (twt, context) -> perUnitBG(context, twt, twt.getB()), (twt, b, context) -> twt.setB(unPerUnitBG(context, twt, b)))
+                .doubles("r", (twt, context) -> perUnitRX(context, twt, twt.getR()), (twt, r, context) -> twt.setR(unPerUnitRX(context, twt, r)))
+                .doubles("x", (twt, context) -> perUnitRX(context, twt, twt.getX()), (twt, x, context) -> twt.setX(unPerUnitRX(context, twt, x)))
+                .doubles("g", (twt, context) -> perUnitGB(context, twt, twt.getG()), (twt, g, context) -> twt.setG(unPerUnitGB(context, twt, g)))
+                .doubles("b", (twt, context) -> perUnitGB(context, twt, twt.getB()), (twt, b, context) -> twt.setB(unPerUnitGB(context, twt, b)))
                 .doubles("rated_u1", (twt, context) -> perUnitV(context, twt.getRatedU1(), twt.getTerminal1()),
                     (twt, ratedV1, context) -> twt.setRatedU1(unPerUnitV(context, ratedV1, twt.getTerminal1())))
                 .doubles("rated_u2", (twt, context) -> perUnitV(context, twt.getRatedU2(), twt.getTerminal2()),
@@ -587,10 +587,10 @@ public final class NetworkDataframes {
                         TwoWindingsTransformer::setSelectedOperationalLimitsGroup2, false)
                 .doubles("rho", (twt, context) -> perUnitRho(context, twt, NetworkDataframes.computeRho(twt)), false)
                 .doubles("alpha", (twt, context) -> perUnitAngle(context, NetworkDataframes.computeAlpha(twt)), false)
-                .doubles("r_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeR(twt), twt), false)
-                .doubles("x_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeX(twt), twt), false)
-                .doubles("g_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeG(twt), twt), false)
-                .doubles("b_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeB(twt), twt), false)
+                .doubles("r_at_current_tap", (twt, context) -> perUnitRX(context, twt, NetworkDataframes.computeR(twt)), false)
+                .doubles("x_at_current_tap", (twt, context) -> perUnitRX(context, twt, NetworkDataframes.computeX(twt)), false)
+                .doubles("g_at_current_tap", (twt, context) -> perUnitGB(context, twt, NetworkDataframes.computeG(twt)), false)
+                .doubles("b_at_current_tap", (twt, context) -> perUnitGB(context, twt, NetworkDataframes.computeB(twt)), false)
                 .addProperties()
                 .build();
     }
@@ -600,10 +600,10 @@ public final class NetworkDataframes {
                 .stringsIndex("id", ThreeWindingsTransformer::getId)
                 .strings("name", twt -> twt.getOptionalName().orElse(""), Identifiable::setName)
                 .doubles("rated_u0", (twt, context) -> context.isPerUnit() ? 1 : twt.getRatedU0())
-                .doubles("r1", (twt, context) -> perUnitRX(context, twt.getLeg1().getR(), twt), (twt, r1, context) -> twt.getLeg1().setR(unPerUnitRX(context, twt, r1)))
-                .doubles("x1", (twt, context) -> perUnitRX(context, twt.getLeg1().getX(), twt), (twt, x1, context) -> twt.getLeg1().setX(unPerUnitRX(context, twt, x1)))
-                .doubles("g1", (twt, context) -> perUnitBG(context, twt.getLeg1().getG(), twt), (twt, g1, context) -> twt.getLeg1().setG(unPerUnitBG(context, twt, g1)))
-                .doubles("b1", (twt, context) -> perUnitBG(context, twt.getLeg1().getB(), twt), (twt, b1, context) -> twt.getLeg1().setB(unPerUnitBG(context, twt, b1)))
+                .doubles("r1", (twt, context) -> perUnitRX(context, twt, twt.getLeg1().getR()), (twt, r1, context) -> twt.getLeg1().setR(unPerUnitRX(context, twt, r1)))
+                .doubles("x1", (twt, context) -> perUnitRX(context, twt, twt.getLeg1().getX()), (twt, x1, context) -> twt.getLeg1().setX(unPerUnitRX(context, twt, x1)))
+                .doubles("g1", (twt, context) -> perUnitGB(context, twt, twt.getLeg1().getG()), (twt, g1, context) -> twt.getLeg1().setG(unPerUnitGB(context, twt, g1)))
+                .doubles("b1", (twt, context) -> perUnitGB(context, twt, twt.getLeg1().getB()), (twt, b1, context) -> twt.getLeg1().setB(unPerUnitGB(context, twt, b1)))
                 .doubles("rated_u1", (twt, context) -> perUnitV(context, twt.getLeg1()), (twt, ratedU1, context) -> twt.getLeg1().setRatedU(unPerUnitV(context, ratedU1, twt.getLeg1())))
                 .doubles("rated_s1", (twt, context) -> twt.getLeg1().getRatedS(), (twt, ratedS1, context) -> twt.getLeg1().setRatedS(ratedS1))
                 .ints("ratio_tap_position1", getRatioTapPosition(ThreeWindingsTransformer::getLeg1), (t, v) -> setTapPosition(t.getLeg1().getRatioTapChanger(), v))
@@ -620,14 +620,14 @@ public final class NetworkDataframes {
                         (twt, groupId) -> twt.getLeg1().setSelectedOperationalLimitsGroup(groupId), false)
                 .doubles("rho1", (twt, context) -> perUnitRho(context, twt, ThreeSides.ONE, NetworkDataframes.computeRho(twt, ThreeSides.ONE)), false)
                 .doubles("alpha1", (twt, context) -> perUnitAngle(context, NetworkDataframes.computeAlpha(twt, ThreeSides.ONE)), false)
-                .doubles("r1_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeR(twt, ThreeSides.ONE), twt), false)
-                .doubles("x1_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeX(twt, ThreeSides.ONE), twt), false)
-                .doubles("g1_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeG(twt, ThreeSides.ONE), twt), false)
-                .doubles("b1_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeB(twt, ThreeSides.ONE), twt), false)
-                .doubles("r2", (twt, context) -> perUnitRX(context, twt.getLeg2().getR(), twt), (twt, r2, context) -> twt.getLeg2().setR(unPerUnitRX(context, twt, r2)))
-                .doubles("x2", (twt, context) -> perUnitRX(context, twt.getLeg2().getX(), twt), (twt, x2, context) -> twt.getLeg2().setX(unPerUnitRX(context, twt, x2)))
-                .doubles("g2", (twt, context) -> perUnitBG(context, twt.getLeg2().getG(), twt), (twt, g2, context) -> twt.getLeg2().setG(unPerUnitBG(context, twt, g2)))
-                .doubles("b2", (twt, context) -> perUnitBG(context, twt.getLeg2().getB(), twt), (twt, b2, context) -> twt.getLeg2().setB(unPerUnitBG(context, twt, b2)))
+                .doubles("r1_at_current_tap", (twt, context) -> perUnitRX(context, twt, NetworkDataframes.computeR(twt, ThreeSides.ONE)), false)
+                .doubles("x1_at_current_tap", (twt, context) -> perUnitRX(context, twt, NetworkDataframes.computeX(twt, ThreeSides.ONE)), false)
+                .doubles("g1_at_current_tap", (twt, context) -> perUnitGB(context, twt, NetworkDataframes.computeG(twt, ThreeSides.ONE)), false)
+                .doubles("b1_at_current_tap", (twt, context) -> perUnitGB(context, twt, NetworkDataframes.computeB(twt, ThreeSides.ONE)), false)
+                .doubles("r2", (twt, context) -> perUnitRX(context, twt, twt.getLeg2().getR()), (twt, r2, context) -> twt.getLeg2().setR(unPerUnitRX(context, twt, r2)))
+                .doubles("x2", (twt, context) -> perUnitRX(context, twt, twt.getLeg2().getX()), (twt, x2, context) -> twt.getLeg2().setX(unPerUnitRX(context, twt, x2)))
+                .doubles("g2", (twt, context) -> perUnitGB(context, twt, twt.getLeg2().getG()), (twt, g2, context) -> twt.getLeg2().setG(unPerUnitGB(context, twt, g2)))
+                .doubles("b2", (twt, context) -> perUnitGB(context, twt, twt.getLeg2().getB()), (twt, b2, context) -> twt.getLeg2().setB(unPerUnitGB(context, twt, b2)))
                 .doubles("rated_u2", (twt, context) -> perUnitV(context, twt.getLeg2()), (twt, ratedU2, context) -> twt.getLeg2().setRatedU(unPerUnitV(context, ratedU2, twt.getLeg2())))
                 .doubles("rated_s2", (twt, context) -> twt.getLeg2().getRatedS(), (twt, v, context) -> twt.getLeg2().setRatedS(v))
                 .ints("ratio_tap_position2", getRatioTapPosition(ThreeWindingsTransformer::getLeg2), (t, v) -> setTapPosition(t.getLeg2().getRatioTapChanger(), v))
@@ -644,14 +644,14 @@ public final class NetworkDataframes {
                         (twt, groupId) -> twt.getLeg2().setSelectedOperationalLimitsGroup(groupId), false)
                 .doubles("rho2", (twt, context) -> perUnitRho(context, twt, ThreeSides.TWO, NetworkDataframes.computeRho(twt, ThreeSides.TWO)), false)
                 .doubles("alpha2", (twt, context) -> perUnitAngle(context, NetworkDataframes.computeAlpha(twt, ThreeSides.TWO)), false)
-                .doubles("r2_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeR(twt, ThreeSides.TWO), twt), false)
-                .doubles("x2_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeX(twt, ThreeSides.TWO), twt), false)
-                .doubles("g2_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeG(twt, ThreeSides.TWO), twt), false)
-                .doubles("b2_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeB(twt, ThreeSides.TWO), twt), false)
-                .doubles("r3", (twt, context) -> perUnitRX(context, twt.getLeg3().getR(), twt), (twt, r3, context) -> twt.getLeg3().setR(unPerUnitRX(context, twt, r3)))
-                .doubles("x3", (twt, context) -> perUnitRX(context, twt.getLeg3().getX(), twt), (twt, x3, context) -> twt.getLeg3().setX(unPerUnitRX(context, twt, x3)))
-                .doubles("g3", (twt, context) -> perUnitBG(context, twt.getLeg3().getG(), twt), (twt, g3, context) -> twt.getLeg3().setG(unPerUnitBG(context, twt, g3)))
-                .doubles("b3", (twt, context) -> perUnitBG(context, twt.getLeg3().getB(), twt), (twt, b3, context) -> twt.getLeg3().setB(unPerUnitBG(context, twt, b3)))
+                .doubles("r2_at_current_tap", (twt, context) -> perUnitRX(context, twt, NetworkDataframes.computeR(twt, ThreeSides.TWO)), false)
+                .doubles("x2_at_current_tap", (twt, context) -> perUnitRX(context, twt, NetworkDataframes.computeX(twt, ThreeSides.TWO)), false)
+                .doubles("g2_at_current_tap", (twt, context) -> perUnitGB(context, twt, NetworkDataframes.computeG(twt, ThreeSides.TWO)), false)
+                .doubles("b2_at_current_tap", (twt, context) -> perUnitGB(context, twt, NetworkDataframes.computeB(twt, ThreeSides.TWO)), false)
+                .doubles("r3", (twt, context) -> perUnitRX(context, twt, twt.getLeg3().getR()), (twt, r3, context) -> twt.getLeg3().setR(unPerUnitRX(context, twt, r3)))
+                .doubles("x3", (twt, context) -> perUnitRX(context, twt, twt.getLeg3().getX()), (twt, x3, context) -> twt.getLeg3().setX(unPerUnitRX(context, twt, x3)))
+                .doubles("g3", (twt, context) -> perUnitGB(context, twt, twt.getLeg3().getG()), (twt, g3, context) -> twt.getLeg3().setG(unPerUnitGB(context, twt, g3)))
+                .doubles("b3", (twt, context) -> perUnitGB(context, twt, twt.getLeg3().getB()), (twt, b3, context) -> twt.getLeg3().setB(unPerUnitGB(context, twt, b3)))
                 .doubles("rated_u3", (twt, context) -> perUnitV(context, twt.getLeg3()), (twt, ratedU3, context) -> twt.getLeg3().setRatedU(unPerUnitV(context, ratedU3, twt.getLeg3())))
                 .doubles("rated_s3", (twt, context) -> twt.getLeg3().getRatedS(), (twt, v, context) -> twt.getLeg3().setRatedS(v))
                 .ints("ratio_tap_position3", getRatioTapPosition(ThreeWindingsTransformer::getLeg3), (t, v) -> setTapPosition(t.getLeg3().getRatioTapChanger(), v))
@@ -668,10 +668,10 @@ public final class NetworkDataframes {
                         (twt, groupId) -> twt.getLeg3().setSelectedOperationalLimitsGroup(groupId), false)
                 .doubles("rho3", (twt, context) -> perUnitRho(context, twt, ThreeSides.THREE, NetworkDataframes.computeRho(twt, ThreeSides.THREE)), false)
                 .doubles("alpha3", (twt, context) -> perUnitAngle(context, NetworkDataframes.computeAlpha(twt, ThreeSides.THREE)), false)
-                .doubles("r3_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeR(twt, ThreeSides.THREE), twt), false)
-                .doubles("x3_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeX(twt, ThreeSides.THREE), twt), false)
-                .doubles("g3_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeG(twt, ThreeSides.THREE), twt), false)
-                .doubles("b3_at_current_tap", (twt, context) -> perUnitRX(context, NetworkDataframes.computeB(twt, ThreeSides.THREE), twt), false)
+                .doubles("r3_at_current_tap", (twt, context) -> perUnitRX(context, twt, NetworkDataframes.computeR(twt, ThreeSides.THREE)), false)
+                .doubles("x3_at_current_tap", (twt, context) -> perUnitRX(context, twt, NetworkDataframes.computeX(twt, ThreeSides.THREE)), false)
+                .doubles("g3_at_current_tap", (twt, context) -> perUnitGB(context, twt, NetworkDataframes.computeG(twt, ThreeSides.THREE)), false)
+                .doubles("b3_at_current_tap", (twt, context) -> perUnitGB(context, twt, NetworkDataframes.computeB(twt, ThreeSides.THREE)), false)
                 .booleans("fictitious", Identifiable::isFictitious, Identifiable::setFictitious, false)
                 .addProperties()
                 .build();
@@ -1736,14 +1736,6 @@ public final class NetworkDataframes {
             }
             return equipment;
         };
-    }
-
-    private static TwoWindingsTransformer getT2OrThrow(Network network, String id) {
-        TwoWindingsTransformer twt = network.getTwoWindingsTransformer(id);
-        if (twt == null) {
-            throw new PowsyblException("Two windings transformer '" + id + "' not found");
-        }
-        return twt;
     }
 
     private static Injection<?> getInjectionOrThrow(Network network, String id) {

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/PerUnitUtil.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/PerUnitUtil.java
@@ -62,19 +62,19 @@ public final class PerUnitUtil {
     }
 
     public static double perUnitG(NetworkDataframeContext context, ShuntCompensator shuntCompensator) {
-        return perUnitBG(context, shuntCompensator.getG(), shuntCompensator.getTerminal().getVoltageLevel().getNominalV());
+        return perUnitGB(context, shuntCompensator.getG(), shuntCompensator.getTerminal().getVoltageLevel().getNominalV());
     }
 
     public static double perUnitG(NetworkDataframeContext context, ShuntCompensatorNonLinearModel.Section section, ShuntCompensator shuntCompensator) {
-        return perUnitBG(context, section.getG(), shuntCompensator.getTerminal().getVoltageLevel().getNominalV());
+        return perUnitGB(context, section.getG(), shuntCompensator.getTerminal().getVoltageLevel().getNominalV());
     }
 
-    public static double perUnitBG(NetworkDataframeContext context, double bg, ThreeWindingsTransformer twt) {
-        return perUnitBG(context, bg, twt.getRatedU0());
+    public static double perUnitGB(NetworkDataframeContext context, ThreeWindingsTransformer twt, double gb) {
+        return perUnitGB(context, gb, twt.getRatedU0());
     }
 
-    public static double perUnitBG(NetworkDataframeContext context, double bg, double nominalV) {
-        return context.isPerUnit() ? bg * pow(nominalV, 2) / context.getNominalApparentPower() : bg;
+    public static double perUnitGB(NetworkDataframeContext context, double gb, double nominalV) {
+        return context.isPerUnit() ? gb * pow(nominalV, 2) / context.getNominalApparentPower() : gb;
     }
 
     public static double perUnitG(NetworkDataframeContext context, double g, double r, double x, double nominalV1, double nominalV2) {
@@ -91,8 +91,8 @@ public final class PerUnitUtil {
             line.getTerminal2().getVoltageLevel().getNominalV(), line.getTerminal1().getVoltageLevel().getNominalV());
     }
 
-    public static double unPerUnitBG(NetworkDataframeContext context, TwoWindingsTransformer twt, double g) {
-        return unPerUnitBG(context, g, twt.getTerminal2().getVoltageLevel().getNominalV());
+    public static double unPerUnitGB(NetworkDataframeContext context, TwoWindingsTransformer twt, double gb) {
+        return unPerUnitGB(context, gb, twt.getTerminal2().getVoltageLevel().getNominalV());
     }
 
     public static double unPerUnitG(NetworkDataframeContext context, DanglingLine danglingLine, double g) {
@@ -100,16 +100,16 @@ public final class PerUnitUtil {
             danglingLine.getTerminal().getVoltageLevel().getNominalV(), danglingLine.getTerminal().getVoltageLevel().getNominalV());
     }
 
-    public static double unPerUnitBG(NetworkDataframeContext context, ShuntCompensator shuntCompensator, double bg) {
-        return unPerUnitBG(context, bg, shuntCompensator.getTerminal().getVoltageLevel().getNominalV());
+    public static double unPerUnitGB(NetworkDataframeContext context, ShuntCompensator shuntCompensator, double gb) {
+        return unPerUnitGB(context, gb, shuntCompensator.getTerminal().getVoltageLevel().getNominalV());
     }
 
-    public static double unPerUnitBG(NetworkDataframeContext context, ThreeWindingsTransformer twt, double bg) {
-        return unPerUnitBG(context, bg, twt.getRatedU0());
+    public static double unPerUnitGB(NetworkDataframeContext context, ThreeWindingsTransformer twt, double gb) {
+        return unPerUnitGB(context, gb, twt.getRatedU0());
     }
 
-    public static double unPerUnitBG(NetworkDataframeContext context, double bg, double nominalV) {
-        return context.isPerUnit() ? bg * context.getNominalApparentPower() / pow(nominalV, 2) : bg;
+    public static double unPerUnitGB(NetworkDataframeContext context, double gb, double nominalV) {
+        return context.isPerUnit() ? gb * context.getNominalApparentPower() / pow(nominalV, 2) : gb;
     }
 
     public static double unPerUnitG(NetworkDataframeContext context, double g, double r, double x, double nominalV1, double nominalV2) {
@@ -126,20 +126,20 @@ public final class PerUnitUtil {
             line.getTerminal2().getVoltageLevel().getNominalV(), line.getTerminal1().getVoltageLevel().getNominalV());
     }
 
-    public static double perUnitBG(NetworkDataframeContext context, TwoWindingsTransformer twt, double bg) {
-        return perUnitBG(context, bg, twt.getTerminal2().getVoltageLevel().getNominalV());
+    public static double perUnitGB(NetworkDataframeContext context, TwoWindingsTransformer twt, double gb) {
+        return perUnitGB(context, gb, twt.getTerminal2().getVoltageLevel().getNominalV());
     }
 
     public static double perUnitB(NetworkDataframeContext context, DanglingLine dl) {
-        return perUnitBG(context, dl.getB(), dl.getTerminal().getVoltageLevel().getNominalV());
+        return perUnitGB(context, dl.getB(), dl.getTerminal().getVoltageLevel().getNominalV());
     }
 
     public static double perUnitB(NetworkDataframeContext context, ShuntCompensatorNonLinearModel.Section section, ShuntCompensator shuntCompensator) {
-        return perUnitBG(context, section.getB(), shuntCompensator.getTerminal().getVoltageLevel().getNominalV());
+        return perUnitGB(context, section.getB(), shuntCompensator.getTerminal().getVoltageLevel().getNominalV());
     }
 
     public static double perUnitB(NetworkDataframeContext context, ShuntCompensator shuntCompensator) {
-        return perUnitBG(context, shuntCompensator.getB(), shuntCompensator.getTerminal().getVoltageLevel().getNominalV());
+        return perUnitGB(context, shuntCompensator.getB(), shuntCompensator.getTerminal().getVoltageLevel().getNominalV());
     }
 
     public static double perUnitB(NetworkDataframeContext context, double b, double r, double x, double nominalV1, double nominalV2) {
@@ -157,7 +157,7 @@ public final class PerUnitUtil {
     }
 
     public static double unPerUnitB(NetworkDataframeContext context, DanglingLine danglingLine, double b) {
-        return unPerUnitBG(context, b, danglingLine.getTerminal().getVoltageLevel().getNominalV());
+        return unPerUnitGB(context, b, danglingLine.getTerminal().getVoltageLevel().getNominalV());
     }
 
     public static double unPerUnitB(NetworkDataframeContext context, double b, double r, double x, double nominalV1, double nominalV2) {
@@ -196,11 +196,11 @@ public final class PerUnitUtil {
         return context.isPerUnit() ? (nominalV1 * nominalV2) / context.getNominalApparentPower() * r : r;
     }
 
-    public static double perUnitRX(NetworkDataframeContext context, double rx, TwoWindingsTransformer twt) {
+    public static double perUnitRX(NetworkDataframeContext context, TwoWindingsTransformer twt, double rx) {
         return perUnitRX(context, rx, twt.getTerminal2().getVoltageLevel().getNominalV(), twt.getTerminal2().getVoltageLevel().getNominalV());
     }
 
-    public static double perUnitRX(NetworkDataframeContext context, double rx, ThreeWindingsTransformer twt) {
+    public static double perUnitRX(NetworkDataframeContext context, ThreeWindingsTransformer twt, double rx) {
         return perUnitRX(context, rx, twt.getRatedU0(), twt.getRatedU0());
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
g and b for the current tap position are not correctly calculed in per unit, because of a bad copy paste


**What is the new behavior (if this is a feature change)?**
g and b for the current tap position are correctly calculed in per unit,


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
