### PR TITLE
Add regulated bus ID to generator, VSC and SVC dataframes

### DIFF
--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -296,6 +296,8 @@ public final class NetworkDataframes {
                 .booleans("voltage_regulator_on", Generator::isVoltageRegulatorOn, Generator::setVoltageRegulatorOn)
                 .strings("regulated_element_id", generator -> NetworkUtil.getRegulatedElementId(generator::getRegulatingTerminal),
                         (generator, elementId) -> NetworkUtil.setRegulatingTerminal(generator::setRegulatingTerminal, generator.getNetwork(), elementId))
+                .strings("regulated_bus_id", generator -> getBusId(generator.getRegulatingTerminal()), false)
+                .strings("regulated_bus_breaker_bus_id", generator -> getBusBreakerViewBusId(generator.getRegulatingTerminal()), false)
                 .doubles("p", getPerUnitP(), setPerUnitP())
                 .doubles("q", getPerUnitQ(), setPerUnitQ())
                 .doubles("i", (g, context) -> perUnitI(context, g.getTerminal()))
@@ -780,6 +782,8 @@ public final class NetworkDataframes {
                 .booleans("voltage_regulator_on", VscConverterStation::isVoltageRegulatorOn, VscConverterStation::setVoltageRegulatorOn)
                 .strings("regulated_element_id", vsc -> NetworkUtil.getRegulatedElementId(vsc::getRegulatingTerminal),
                         (vsc, elementId) -> NetworkUtil.setRegulatingTerminal(vsc::setRegulatingTerminal, vsc.getNetwork(), elementId))
+                .strings("regulated_bus_id", vsc -> getBusId(vsc.getRegulatingTerminal()), false)
+                .strings("regulated_bus_breaker_bus_id", vsc -> getBusBreakerViewBusId(vsc.getRegulatingTerminal()), false)
                 .doubles("p", getPerUnitP(), setPerUnitP())
                 .doubles("q", getPerUnitQ(), setPerUnitQ())
                 .doubles("i", (st, context) -> perUnitI(context, st.getTerminal()))
@@ -808,6 +812,8 @@ public final class NetworkDataframes {
                         StaticVarCompensator::getRegulationMode, StaticVarCompensator::setRegulationMode)
                 .strings("regulated_element_id", svc -> NetworkUtil.getRegulatedElementId(svc::getRegulatingTerminal),
                         (svc, elementId) -> NetworkUtil.setRegulatingTerminal(svc::setRegulatingTerminal, svc.getNetwork(), elementId))
+                .strings("regulated_bus_id", svc -> getBusId(svc.getRegulatingTerminal()), false)
+                .strings("regulated_bus_breaker_bus_id", svc -> getBusBreakerViewBusId(svc.getRegulatingTerminal()), false)
                 .doubles("p", getPerUnitP(), setPerUnitP())
                 .doubles("q", getPerUnitQ(), setPerUnitQ())
                 .doubles("i", (st, context) -> perUnitI(context, st.getTerminal()))

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -49,6 +49,8 @@ public final class NetworkDataframes {
     private static final String MAX_Q_AT_TARGET_P = "max_q_at_target_p";
     private static final String MIN_Q_AT_P = "min_q_at_p";
     private static final String MAX_Q_AT_P = "max_q_at_p";
+    private static final String REGULATED_BUS_ID = "regulated_bus_id";
+    private static final String REGULATED_BUS_BREAKER_BUS_ID = "regulated_bus_breaker_bus_id";
 
     private NetworkDataframes() {
     }
@@ -296,8 +298,8 @@ public final class NetworkDataframes {
                 .booleans("voltage_regulator_on", Generator::isVoltageRegulatorOn, Generator::setVoltageRegulatorOn)
                 .strings("regulated_element_id", generator -> NetworkUtil.getRegulatedElementId(generator::getRegulatingTerminal),
                         (generator, elementId) -> NetworkUtil.setRegulatingTerminal(generator::setRegulatingTerminal, generator.getNetwork(), elementId))
-                .strings("regulated_bus_id", generator -> getBusId(generator.getRegulatingTerminal()), false)
-                .strings("regulated_bus_breaker_bus_id", generator -> getBusBreakerViewBusId(generator.getRegulatingTerminal()), false)
+                .strings(REGULATED_BUS_ID, generator -> getBusId(generator.getRegulatingTerminal()), false)
+                .strings(REGULATED_BUS_BREAKER_BUS_ID, generator -> getBusBreakerViewBusId(generator.getRegulatingTerminal()), false)
                 .doubles("p", getPerUnitP(), setPerUnitP())
                 .doubles("q", getPerUnitQ(), setPerUnitQ())
                 .doubles("i", (g, context) -> perUnitI(context, g.getTerminal()))
@@ -782,8 +784,8 @@ public final class NetworkDataframes {
                 .booleans("voltage_regulator_on", VscConverterStation::isVoltageRegulatorOn, VscConverterStation::setVoltageRegulatorOn)
                 .strings("regulated_element_id", vsc -> NetworkUtil.getRegulatedElementId(vsc::getRegulatingTerminal),
                         (vsc, elementId) -> NetworkUtil.setRegulatingTerminal(vsc::setRegulatingTerminal, vsc.getNetwork(), elementId))
-                .strings("regulated_bus_id", vsc -> getBusId(vsc.getRegulatingTerminal()), false)
-                .strings("regulated_bus_breaker_bus_id", vsc -> getBusBreakerViewBusId(vsc.getRegulatingTerminal()), false)
+                .strings(REGULATED_BUS_ID, vsc -> getBusId(vsc.getRegulatingTerminal()), false)
+                .strings(REGULATED_BUS_BREAKER_BUS_ID, vsc -> getBusBreakerViewBusId(vsc.getRegulatingTerminal()), false)
                 .doubles("p", getPerUnitP(), setPerUnitP())
                 .doubles("q", getPerUnitQ(), setPerUnitQ())
                 .doubles("i", (st, context) -> perUnitI(context, st.getTerminal()))
@@ -812,8 +814,8 @@ public final class NetworkDataframes {
                         StaticVarCompensator::getRegulationMode, StaticVarCompensator::setRegulationMode)
                 .strings("regulated_element_id", svc -> NetworkUtil.getRegulatedElementId(svc::getRegulatingTerminal),
                         (svc, elementId) -> NetworkUtil.setRegulatingTerminal(svc::setRegulatingTerminal, svc.getNetwork(), elementId))
-                .strings("regulated_bus_id", svc -> getBusId(svc.getRegulatingTerminal()), false)
-                .strings("regulated_bus_breaker_bus_id", svc -> getBusBreakerViewBusId(svc.getRegulatingTerminal()), false)
+                .strings(REGULATED_BUS_ID, svc -> getBusId(svc.getRegulatingTerminal()), false)
+                .strings(REGULATED_BUS_BREAKER_BUS_ID, svc -> getBusBreakerViewBusId(svc.getRegulatingTerminal()), false)
                 .doubles("p", getPerUnitP(), setPerUnitP())
                 .doubles("q", getPerUnitQ(), setPerUnitQ())
                 .doubles("i", (st, context) -> perUnitI(context, st.getTerminal()))

--- a/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
+++ b/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
@@ -179,8 +179,8 @@ class NetworkDataframesTest {
                 .extracting(Series::getName)
                 .containsExactly("id", "name", "energy_source", "target_p", "min_p", "max_p", "min_q", "max_q",
                         "min_q_at_target_p", "max_q_at_target_p", "min_q_at_p", "max_q_at_p", "rated_s", "reactive_limits_kind",
-                        "target_v", "target_q", "voltage_regulator_on", "regulated_element_id", "p", "q", "i", "voltage_level_id",
-                        "bus_id", "bus_breaker_bus_id", "node", "condenser", "connected", "fictitious");
+                        "target_v", "target_q", "voltage_regulator_on", "regulated_element_id", "regulated_bus_id", "regulated_bus_breaker_bus_id",
+                        "p", "q", "i", "voltage_level_id", "bus_id", "bus_breaker_bus_id", "node", "condenser", "connected", "fictitious");
     }
 
     @Test
@@ -427,7 +427,8 @@ class NetworkDataframesTest {
                 .extracting(Series::getName)
                 .containsExactly("id", "name", "loss_factor", "min_q", "max_q", "min_q_at_target_p", "max_q_at_target_p",
                         "min_q_at_p", "max_q_at_p", "reactive_limits_kind", "target_v", "target_q", "voltage_regulator_on", "regulated_element_id",
-                        "p", "q", "i", "voltage_level_id", "bus_id", "bus_breaker_bus_id", "node", "connected", "fictitious", "hvdc_line_id");
+                        "regulated_bus_id", "regulated_bus_breaker_bus_id", "p", "q", "i", "voltage_level_id", "bus_id", "bus_breaker_bus_id", "node",
+                        "connected", "fictitious", "hvdc_line_id");
     }
 
     @Test
@@ -549,8 +550,8 @@ class NetworkDataframesTest {
         assertThat(allAttributeSeries)
                 .extracting(Series::getName)
                 .containsExactly("id", "name", "b_min", "b_max", "target_v", "target_q", "regulation_mode",
-                        "regulated_element_id", "p", "q", "i", "voltage_level_id", "bus_id", "bus_breaker_bus_id",
-                        "node", "connected", "fictitious");
+                        "regulated_element_id", "regulated_bus_id", "regulated_bus_breaker_bus_id", "p", "q", "i",
+                        "voltage_level_id", "bus_id", "bus_breaker_bus_id", "node", "connected", "fictitious");
     }
 
     @Test

--- a/pypowsybl/network/impl/network.py
+++ b/pypowsybl/network/impl/network.py
@@ -746,6 +746,8 @@ class Network:  # pylint: disable=too-many-public-methods
               - **target_q**: the target reactive value for the generator (in MVAr)
               - **voltage_regulator_on**: ``True`` if the generator regulates voltage
               - **regulated_element_id**: the ID of the network element where voltage is regulated
+              - **regulated_bus_id**: the ID of the bus from bus view where voltage is regulated
+              - **regulated_bus_breaker_bus_id**: the ID of the bus from bus/breaker view where voltage is regulated
               - **p**: the actual active production of the generator (``NaN`` if no loadflow has been computed)
               - **q**: the actual reactive production of the generator (``NaN`` if no loadflow has been computed)
               - **i**: the current on the generator, ``NaN`` if no loadflow has been computed (in A)
@@ -1690,6 +1692,8 @@ class Network:  # pylint: disable=too-many-public-methods
               - **reactive_limits_kind**: type of the reactive limit of the VSC converter station (can be MIN_MAX, CURVE or NONE)
               - **voltage_regulator_on**: The voltage regulator status
               - **regulated_element_id**: The ID of the network element where voltage is regulated
+              - **regulated_bus_id**: the ID of the bus from bus view where voltage is regulated
+              - **regulated_bus_breaker_bus_id**: the ID of the bus from bus/breaker view where voltage is regulated
               - **p**: active flow on the VSC  converter station, ``NaN`` if no loadflow has been computed (in MW)
               - **q**: the reactive flow on the VSC converter station, ``NaN`` if no loadflow has been computed  (in MVAr)
               - **i**: The current on the VSC converter station, ``NaN`` if no loadflow has been computed (in A)
@@ -1775,6 +1779,8 @@ class Network:  # pylint: disable=too-many-public-methods
               - **target_q**: The reactive power setpoint
               - **regulation_mode**: The regulation mode
               - **regulated_element_id**: The ID of the network element where voltage is regulated
+              - **regulated_bus_id**: the ID of the bus from bus view where voltage is regulated
+              - **regulated_bus_breaker_bus_id**: the ID of the bus from bus/breaker view where voltage is regulated
               - **p**: active flow on the var compensator, ``NaN`` if no loadflow has been computed (in MW)
               - **q**: the reactive flow on the var compensator, ``NaN`` if no loadflow has been computed  (in MVAr)
               - **i**: The current on the var compensator, ``NaN`` if no loadflow has been computed (in A)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -2763,5 +2763,12 @@ def test_rxbg_at_current_tap_transfo3():
     pd.testing.assert_frame_equal(expected_transfo3, transfo3, check_dtype=False, atol=1e-6)
 
 
+def test_regulated_bus_id():
+    n = pp.network.create_four_substations_node_breaker_network()
+    gens = n.get_generators(attributes=['regulated_bus_id', 'regulated_bus_breaker_bus_id'])
+    assert 'S1VL2_0' == gens['regulated_bus_id']['GH1']
+    assert 'S1VL2_7' == gens['regulated_bus_breaker_bus_id']['GH1']
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature



**What is the new behavior (if this is a feature change)?**
We can get the regulated bus ID from bus view or bus/breaker view.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
