### PR TITLE
Fix missing BusbarSection columns

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ cd docs
 ~~~
 Install the requirements the first time:
 ~~~bash
-pip install -r requirements.txt
+pip install -r ../requirements.txt
 ~~~
 Build the documentation:
 ~~~bash

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -919,6 +919,7 @@ public final class NetworkDataframes {
                 .doubles("angle", (busbar, context) -> perUnitAngle(context, busbar.getAngle()))
                 .strings("voltage_level_id", bbs -> bbs.getTerminal().getVoltageLevel().getId())
                 .strings("bus_id", bbs -> getBusId(bbs.getTerminal()))
+                .strings("bus_breaker_bus_id", getBusBreakerViewBusId(), NetworkDataframes::setBusBreakerViewBusId, false)
                 .ints("node", bbs -> getNode(bbs.getTerminal()), false)
                 .booleans("connected", bbs -> bbs.getTerminal().isConnected(), connectInjection())
                 .booleans("fictitious", Identifiable::isFictitious, Identifiable::setFictitious, false)

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -919,6 +919,7 @@ public final class NetworkDataframes {
                 .doubles("angle", (busbar, context) -> perUnitAngle(context, busbar.getAngle()))
                 .strings("voltage_level_id", bbs -> bbs.getTerminal().getVoltageLevel().getId())
                 .strings("bus_id", bbs -> getBusId(bbs.getTerminal()))
+                .ints("node", bbs -> getNode(bbs.getTerminal()), false)
                 .booleans("connected", bbs -> bbs.getTerminal().isConnected(), connectInjection())
                 .booleans("fictitious", Identifiable::isFictitious, Identifiable::setFictitious, false)
                 .addProperties()

--- a/pypowsybl/network/impl/network.py
+++ b/pypowsybl/network/impl/network.py
@@ -1960,17 +1960,17 @@ class Network:  # pylint: disable=too-many-public-methods
 
             will output something like:
 
-            ========== ========== ======== ======== ================ =========
-            \          fictitious        v    angle voltage_level_id connected
-            ========== ========== ======== ======== ================ =========
+            ========== ========== ======== ======== ================ ========= =========
+            \                name        v    angle voltage_level_id    bus_id connected
+            ========== ========== ======== ======== ================ ========= =========
             id
-             S1VL1_BBS      False 224.6139   2.2822            S1VL1      True
-            S1VL2_BBS1      False 400.0000   0.0000            S1VL2      True
-            S1VL2_BBS2      False 400.0000   0.0000            S1VL2      True
-             S2VL1_BBS      False 408.8470   0.7347            S2VL1      True
-             S3VL1_BBS      False 400.0000   0.0000            S3VL1      True
-             S4VL1_BBS      False 400.0000  -1.1259            S4VL1      True
-            ========== ========== ======== ======== ================ =========
+             S1VL1_BBS  S1VL1_BBS 224.6139   2.2822            S1VL1   S1VL1_0      True
+            S1VL2_BBS1 S1VL2_BBS1 400.0000   0.0000            S1VL2   S1VL2_0      True
+            S1VL2_BBS2 S1VL2_BBS2 400.0000   0.0000            S1VL2   S1VL2_0      True
+             S2VL1_BBS  S2VL1_BBS 408.8470   0.7347            S2VL1   S2VL1_0      True
+             S3VL1_BBS  S3VL1_BBS 400.0000   0.0000            S3VL1   S3VL1_0      True
+             S4VL1_BBS  S4VL1_BBS 400.0000  -1.1259            S4VL1   S4VL1_0      True
+            ========== ========== ======== ======== ================ ========= =========
 
             .. code-block:: python
 
@@ -1979,17 +1979,17 @@ class Network:  # pylint: disable=too-many-public-methods
 
             will output something like:
 
-            ========== ========== ======== ======== ================ =========
-            \          fictitious        v    angle voltage_level_id connected
-            ========== ========== ======== ======== ================ =========
+            ========== ========== ======== ======== ================ ======= ================== ==== ========= ==========
+            \                name        v    angle voltage_level_id  bus_id bus_breaker_bus_id node connected fictitious
+            ========== ========== ======== ======== ================ ======= ================== ==== ========= ==========
             id
-             S1VL1_BBS      False 224.6139   2.2822            S1VL1      True
-            S1VL2_BBS1      False 400.0000   0.0000            S1VL2      True
-            S1VL2_BBS2      False 400.0000   0.0000            S1VL2      True
-             S2VL1_BBS      False 408.8470   0.7347            S2VL1      True
-             S3VL1_BBS      False 400.0000   0.0000            S3VL1      True
-             S4VL1_BBS      False 400.0000  -1.1259            S4VL1      True
-            ========== ========== ======== ======== ================ =========
+             S1VL1_BBS  S1VL1_BBS 224.6139   2.2822            S1VL1 S1VL1_0            S1VL1_0    0      True      False
+            S1VL2_BBS1 S1VL2_BBS1 400.0000   0.0000            S1VL2 S1VL2_0            S1VL2_0    0      True      False
+            S1VL2_BBS2 S1VL2_BBS2 400.0000   0.0000            S1VL2 S1VL2_0            S1VL2_1    1      True      False
+             S2VL1_BBS  S2VL1_BBS 408.8470   0.7347            S2VL1 S2VL1_0            S2VL1_0    0      True      False
+             S3VL1_BBS  S3VL1_BBS 400.0000   0.0000            S3VL1 S3VL1_0            S3VL1_0    0      True      False
+             S4VL1_BBS  S4VL1_BBS 400.0000  -1.1259            S4VL1 S4VL1_0            S4VL1_0    0      True      False
+            ========== ========== ======== ======== ================ ======= ================== ==== ========= ==========
 
             .. code-block:: python
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1521,13 +1521,14 @@ def test_busbar_sections():
     expected = pd.DataFrame(index=pd.Series(name='id',
                                             data=['S1VL1_BBS', 'S1VL2_BBS1', 'S1VL2_BBS2', 'S2VL1_BBS', 'S3VL1_BBS',
                                                   'S4VL1_BBS']),
-                            columns=['name', 'v', 'angle', 'voltage_level_id', 'bus_id', 'node', 'connected', 'fictitious'],
-                            data=[['S1VL1_BBS', 224.6139, 2.2822, 'S1VL1', 'S1VL1_0', 0, True, True],
-                                  ['S1VL2_BBS1', 400.0000, 0.0000, 'S1VL2', 'S1VL2_0', 0, True, False],
-                                  ['S1VL2_BBS2', 400.0000, 0.0000, 'S1VL2', 'S1VL2_0', 1, True, False],
-                                  ['S2VL1_BBS', 408.8470, 0.7347, 'S2VL1', 'S2VL1_0', 0, True, False],
-                                  ['S3VL1_BBS', 400.0000, 0.0000, 'S3VL1', 'S3VL1_0', 0, True, False],
-                                  ['S4VL1_BBS', 400.0000, -1.1259, 'S4VL1', 'S4VL1_0', 0, True, False]])
+                            columns=['name', 'v', 'angle', 'voltage_level_id', 'bus_id', 'bus_breaker_bus_id', 'node',
+                                     'connected', 'fictitious'],
+                            data=[['S1VL1_BBS', 224.6139, 2.2822, 'S1VL1', 'S1VL1_0', 'S1VL1_0', 0, True, True],
+                                  ['S1VL2_BBS1', 400.0000, 0.0000, 'S1VL2', 'S1VL2_0', 'S1VL2_0', 0, True, False],
+                                  ['S1VL2_BBS2', 400.0000, 0.0000, 'S1VL2', 'S1VL2_0', 'S1VL2_1', 1, True, False],
+                                  ['S2VL1_BBS', 408.8470, 0.7347, 'S2VL1', 'S2VL1_0', 'S2VL1_0', 0, True, False],
+                                  ['S3VL1_BBS', 400.0000, 0.0000, 'S3VL1', 'S3VL1_0', 'S3VL1_0', 0, True, False],
+                                  ['S4VL1_BBS', 400.0000, -1.1259, 'S4VL1', 'S4VL1_0', 'S4VL1_0', 0, True, False]])
     pd.testing.assert_frame_equal(expected, n.get_busbar_sections(all_attributes=True), check_dtype=False)
 
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1521,13 +1521,13 @@ def test_busbar_sections():
     expected = pd.DataFrame(index=pd.Series(name='id',
                                             data=['S1VL1_BBS', 'S1VL2_BBS1', 'S1VL2_BBS2', 'S2VL1_BBS', 'S3VL1_BBS',
                                                   'S4VL1_BBS']),
-                            columns=['name', 'v', 'angle', 'voltage_level_id', 'bus_id', 'connected', 'fictitious'],
-                            data=[['S1VL1_BBS', 224.6139, 2.2822, 'S1VL1', 'S1VL1_0', True, True],
-                                  ['S1VL2_BBS1', 400.0000, 0.0000, 'S1VL2', 'S1VL2_0', True, False],
-                                  ['S1VL2_BBS2', 400.0000, 0.0000, 'S1VL2', 'S1VL2_0', True, False],
-                                  ['S2VL1_BBS', 408.8470, 0.7347, 'S2VL1', 'S2VL1_0', True, False],
-                                  ['S3VL1_BBS', 400.0000, 0.0000, 'S3VL1', 'S3VL1_0', True, False],
-                                  ['S4VL1_BBS', 400.0000, -1.1259, 'S4VL1', 'S4VL1_0', True, False]])
+                            columns=['name', 'v', 'angle', 'voltage_level_id', 'bus_id', 'node', 'connected', 'fictitious'],
+                            data=[['S1VL1_BBS', 224.6139, 2.2822, 'S1VL1', 'S1VL1_0', 0, True, True],
+                                  ['S1VL2_BBS1', 400.0000, 0.0000, 'S1VL2', 'S1VL2_0', 0, True, False],
+                                  ['S1VL2_BBS2', 400.0000, 0.0000, 'S1VL2', 'S1VL2_0', 1, True, False],
+                                  ['S2VL1_BBS', 408.8470, 0.7347, 'S2VL1', 'S2VL1_0', 0, True, False],
+                                  ['S3VL1_BBS', 400.0000, 0.0000, 'S3VL1', 'S3VL1_0', 0, True, False],
+                                  ['S4VL1_BBS', 400.0000, -1.1259, 'S4VL1', 'S4VL1_0', 0, True, False]])
     pd.testing.assert_frame_equal(expected, n.get_busbar_sections(all_attributes=True), check_dtype=False)
 
 

--- a/tests/test_network_elements_creation.py
+++ b/tests/test_network_elements_creation.py
@@ -471,14 +471,15 @@ def test_busbar_sections():
     expected = pd.DataFrame(index=pd.Series(name='id',
                                             data=['S1VL1_BBS', 'S1VL2_BBS1', 'S1VL2_BBS2', 'S2VL1_BBS', 'S3VL1_BBS',
                                                   'S4VL1_BBS', 'S_TEST']),
-                            columns=['name', 'v', 'angle', 'voltage_level_id', 'bus_id', 'node', 'connected', 'fictitious'],
-                            data=[['S1VL1_BBS', 224.6139, 2.2822, 'S1VL1', 'S1VL1_0', 0, True, False],
-                                  ['S1VL2_BBS1', 400.0000, 0.0000, 'S1VL2', 'S1VL2_0', 0, True, False],
-                                  ['S1VL2_BBS2', 400.0000, 0.0000, 'S1VL2', 'S1VL2_0', 1, True, False],
-                                  ['S2VL1_BBS', 408.8470, 0.7347, 'S2VL1', 'S2VL1_0', 0, True, False],
-                                  ['S3VL1_BBS', 400.0000, 0.0000, 'S3VL1', 'S3VL1_0', 0, True, False],
-                                  ['S4VL1_BBS', 400.0000, -1.1259, 'S4VL1', 'S4VL1_0', 0, True, False],
-                                  ['S_TEST', nan, nan, 'S1VL1', 'S1VL1_0', 1, True, False]])
+                            columns=['name', 'v', 'angle', 'voltage_level_id', 'bus_id', 'bus_breaker_bus_id', 'node',
+                                     'connected', 'fictitious'],
+                            data=[['S1VL1_BBS', 224.6139, 2.2822, 'S1VL1', 'S1VL1_0', 'S1VL1_0', 0, True, False],
+                                  ['S1VL2_BBS1', 400.0000, 0.0000, 'S1VL2', 'S1VL2_0', 'S1VL2_0', 0, True, False],
+                                  ['S1VL2_BBS2', 400.0000, 0.0000, 'S1VL2', 'S1VL2_0', 'S1VL2_1', 1, True, False],
+                                  ['S2VL1_BBS', 408.8470, 0.7347, 'S2VL1', 'S2VL1_0', 'S2VL1_0', 0, True, False],
+                                  ['S3VL1_BBS', 400.0000, 0.0000, 'S3VL1', 'S3VL1_0', 'S3VL1_0', 0, True, False],
+                                  ['S4VL1_BBS', 400.0000, -1.1259, 'S4VL1', 'S4VL1_0', 'S4VL1_0', 0, True, False],
+                                  ['S_TEST', nan, nan, 'S1VL1', 'S1VL1_0', 'S1VL1_0', 1, True, False]])
     pd.testing.assert_frame_equal(expected, n.get_busbar_sections(all_attributes=True), check_dtype=False)
 
 

--- a/tests/test_network_elements_creation.py
+++ b/tests/test_network_elements_creation.py
@@ -471,14 +471,14 @@ def test_busbar_sections():
     expected = pd.DataFrame(index=pd.Series(name='id',
                                             data=['S1VL1_BBS', 'S1VL2_BBS1', 'S1VL2_BBS2', 'S2VL1_BBS', 'S3VL1_BBS',
                                                   'S4VL1_BBS', 'S_TEST']),
-                            columns=['name', 'v', 'angle', 'voltage_level_id', 'bus_id', 'connected', 'fictitious'],
-                            data=[['S1VL1_BBS', 224.6139, 2.2822, 'S1VL1', 'S1VL1_0', True, False],
-                                  ['S1VL2_BBS1', 400.0000, 0.0000, 'S1VL2', 'S1VL2_0', True, False],
-                                  ['S1VL2_BBS2', 400.0000, 0.0000, 'S1VL2', 'S1VL2_0', True, False],
-                                  ['S2VL1_BBS', 408.8470, 0.7347, 'S2VL1', 'S2VL1_0', True, False],
-                                  ['S3VL1_BBS', 400.0000, 0.0000, 'S3VL1', 'S3VL1_0', True, False],
-                                  ['S4VL1_BBS', 400.0000, -1.1259, 'S4VL1', 'S4VL1_0', True, False],
-                                  ['S_TEST', nan, nan, 'S1VL1', 'S1VL1_0', True, False]])
+                            columns=['name', 'v', 'angle', 'voltage_level_id', 'bus_id', 'node', 'connected', 'fictitious'],
+                            data=[['S1VL1_BBS', 224.6139, 2.2822, 'S1VL1', 'S1VL1_0', 0, True, False],
+                                  ['S1VL2_BBS1', 400.0000, 0.0000, 'S1VL2', 'S1VL2_0', 0, True, False],
+                                  ['S1VL2_BBS2', 400.0000, 0.0000, 'S1VL2', 'S1VL2_0', 1, True, False],
+                                  ['S2VL1_BBS', 408.8470, 0.7347, 'S2VL1', 'S2VL1_0', 0, True, False],
+                                  ['S3VL1_BBS', 400.0000, 0.0000, 'S3VL1', 'S3VL1_0', 0, True, False],
+                                  ['S4VL1_BBS', 400.0000, -1.1259, 'S4VL1', 'S4VL1_0', 0, True, False],
+                                  ['S_TEST', nan, nan, 'S1VL1', 'S1VL1_0', 1, True, False]])
     pd.testing.assert_frame_equal(expected, n.get_busbar_sections(all_attributes=True), check_dtype=False)
 
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bugfix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
network.get_busbar_sections() documentation mentions `bus_breaker_bus_id` and `node` optional columns which are not actually provided.


**What is the new behavior (if this is a feature change)?**
add missing `bus_breaker_bus_id` and `node` optional columns to Network.get_busbar_sections().


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No

