### PR TITLE
Complete integration of IIDM v1.14

### DIFF
--- a/cpp/pypowsybl-cpp/bindings.cpp
+++ b/cpp/pypowsybl-cpp/bindings.cpp
@@ -1018,6 +1018,13 @@ PYBIND11_MODULE(_pypowsybl, m) {
                     default:
                         throw pypowsybl::PyPowsyblError("Series type not supported: " + std::to_string(s.type));
                 }
+            })
+            .def_property_readonly("mask", [](const series& s) {
+                if (s.mask != nullptr) {
+                    return py::array(py::dtype::of<int>(), s.data.length, s.mask, py::cast(s.mask));
+                } else {
+                    return py::array();
+                }
             });
     bindArray<pypowsybl::SeriesArray>(m, "SeriesArray");
 

--- a/cpp/pypowsybl-java/powsybl-api.h
+++ b/cpp/pypowsybl-java/powsybl-api.h
@@ -273,6 +273,7 @@ typedef struct series_struct {
     unsigned char index;
     int type;
     array data;
+    int* mask;
 } series;
 
 /**

--- a/docs/user_guide/flowdecomposition.rst
+++ b/docs/user_guide/flowdecomposition.rst
@@ -116,9 +116,9 @@ As we cannot set a PST on an interconnection, we set an equivalent null load cal
     id                                                                                                                                                                                        
     BLOAD 11 BLOAD 12 2       0.5  1.5  0.0002  0.00015     400.0     400.0      NaN NaN NaN NaN NaN NaN NaN           BLOAD 1           BLOAD 1  BLOAD 1_1  BLOAD 1_0        True        True
     >>> network.get_phase_tap_changers()
-                        side  tap  solved_tap_position low_tap  high_tap  step_count on_load  regulating  regulation_mode  regulation_value  target_deadband regulating_bus_id
+                        side  tap  solved_tap_position low_tap  high_tap  step_count oltc  regulating  regulation_mode  regulation_value  target_deadband regulating_bus_id
     id
-    BLOAD 11 BLOAD 12 2         0                  NaN     -16        16          33    True       False  CURRENT_LIMITER               NaN              NaN
+    BLOAD 11 BLOAD 12 2         0                  NaN     -16        16          33 True       False  CURRENT_LIMITER               NaN              NaN
 
 Neutral tap position
 ^^^^^^^^^^^^^^^^^^^^
@@ -154,9 +154,9 @@ Here are the results with non-neutral tap position.
     >>> network = pp.network.load(str(DATA_DIR.joinpath('NETWORK_PST_FLOW_WITH_COUNTRIES.uct')))
     >>> network.update_phase_tap_changers(id="BLOAD 11 BLOAD 12 2", tap=1)
     >>> network.get_phase_tap_changers()
-                        side  tap  solved_tap_position low_tap  high_tap  step_count  on_load regulating regulation_mode  regulation_value  target_deadband regulating_bus_id
+                        side  tap  solved_tap_position low_tap  high_tap  step_count  oltc regulating regulation_mode  regulation_value  target_deadband regulating_bus_id
     id
-    BLOAD 11 BLOAD 12 2         1                  NaN     -16        16          33     True      False CURRENT_LIMITER               NaN              NaN
+    BLOAD 11 BLOAD 12 2         1                  NaN     -16        16          33  True      False CURRENT_LIMITER               NaN              NaN
     >>> flow_decomposition = pp.flowdecomposition.create_decomposition().add_monitored_elements(['FGEN  11 BLOAD 11 1', 'FGEN  11 BLOAD 12 1'])
     >>> flow_decomposition_dataframe = flow_decomposition.run(network)
     >>> flow_decomposition_dataframe

--- a/docs/user_guide/flowdecomposition.rst
+++ b/docs/user_guide/flowdecomposition.rst
@@ -116,9 +116,9 @@ As we cannot set a PST on an interconnection, we set an equivalent null load cal
     id                                                                                                                                                                                        
     BLOAD 11 BLOAD 12 2       0.5  1.5  0.0002  0.00015     400.0     400.0      NaN NaN NaN NaN NaN NaN NaN           BLOAD 1           BLOAD 1  BLOAD 1_1  BLOAD 1_0        True        True
     >>> network.get_phase_tap_changers()
-                        side  tap  low_tap  high_tap  step_count  regulating  regulation_mode  regulation_value  target_deadband regulating_bus_id
+                        side  tap  solved_tap_position low_tap  high_tap  step_count on_load  regulating  regulation_mode  regulation_value  target_deadband regulating_bus_id
     id
-    BLOAD 11 BLOAD 12 2         0      -16        16          33       False  CURRENT_LIMITER               NaN              NaN
+    BLOAD 11 BLOAD 12 2         0                  NaN     -16        16          33    True       False  CURRENT_LIMITER               NaN              NaN
 
 Neutral tap position
 ^^^^^^^^^^^^^^^^^^^^
@@ -154,9 +154,9 @@ Here are the results with non-neutral tap position.
     >>> network = pp.network.load(str(DATA_DIR.joinpath('NETWORK_PST_FLOW_WITH_COUNTRIES.uct')))
     >>> network.update_phase_tap_changers(id="BLOAD 11 BLOAD 12 2", tap=1)
     >>> network.get_phase_tap_changers()
-                        side  tap  low_tap  high_tap  step_count  regulating regulation_mode  regulation_value  target_deadband regulating_bus_id
+                        side  tap  solved_tap_position low_tap  high_tap  step_count  on_load regulating regulation_mode  regulation_value  target_deadband regulating_bus_id
     id
-    BLOAD 11 BLOAD 12 2         1      -16        16          33       False CURRENT_LIMITER               NaN              NaN
+    BLOAD 11 BLOAD 12 2         1                  NaN     -16        16          33     True      False CURRENT_LIMITER               NaN              NaN
     >>> flow_decomposition = pp.flowdecomposition.create_decomposition().add_monitored_elements(['FGEN  11 BLOAD 11 1', 'FGEN  11 BLOAD 12 1'])
     >>> flow_decomposition_dataframe = flow_decomposition.run(network)
     >>> flow_decomposition_dataframe

--- a/docs/user_guide/network.rst
+++ b/docs/user_guide/network.rst
@@ -396,7 +396,7 @@ You can add a ratio tap changer on the leg 1 of the three-winding transformer wi
 
     rtc_df = pd.DataFrame.from_records(
         index='id',
-        columns=['id', 'target_deadband', 'target_v', 'on_load', 'low_tap', 'tap', 'side'],
+        columns=['id', 'target_deadband', 'target_v', 'oltc', 'low_tap', 'tap', 'side'],
         data=[('T1', 2, 200, False, 0, 1, 'ONE')])
     steps_df = pd.DataFrame.from_records(
         index='id',

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/BaseDataframeMapperBuilder.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/BaseDataframeMapperBuilder.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang3.function.TriFunction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.function.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -139,6 +140,11 @@ public class BaseDataframeMapperBuilder<T, U, C, B extends BaseDataframeMapperBu
 
     public B intsIndex(String name, ToIntFunction<U> value) {
         series.add(new IntSeriesMapper<>(name, true, value));
+        return (B) this;
+    }
+
+    public B optionalInts(String name, Function<U, OptionalInt> value) {
+        series.add(new OptionalIntSeriesMapper<>(name, value));
         return (B) this;
     }
 

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/DataframeHandler.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/DataframeHandler.java
@@ -7,6 +7,8 @@
  */
 package com.powsybl.dataframe;
 
+import java.util.OptionalInt;
+
 /**
  * Receives series data, is in charge of doing something with it,
  * typically writing to a data structure.
@@ -18,6 +20,11 @@ public interface DataframeHandler {
     @FunctionalInterface
     interface IntSeriesWriter {
         void set(int index, int value);
+    }
+
+    @FunctionalInterface
+    interface OptionalIntSeriesWriter {
+        void set(int index, OptionalInt value);
     }
 
     @FunctionalInterface
@@ -44,6 +51,8 @@ public interface DataframeHandler {
     StringSeriesWriter newStringSeries(String name, int size);
 
     IntSeriesWriter newIntSeries(String name, int size);
+
+    OptionalIntSeriesWriter newOptionalIntSeries(String name, int size);
 
     BooleanSeriesWriter newBooleanSeries(String name, int size);
 

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/OptionalIntSeriesMapper.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/OptionalIntSeriesMapper.java
@@ -1,0 +1,35 @@
+package com.powsybl.dataframe;
+
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.function.Function;
+
+public class OptionalIntSeriesMapper<T, C> implements SeriesMapper<T, C> {
+
+    private final SeriesMetadata metadata;
+    private Function<T, OptionalInt> value;
+
+    public OptionalIntSeriesMapper(String name, Function<T, OptionalInt> value) {
+        this(name, value, true);
+    }
+
+    public OptionalIntSeriesMapper(String name, Function<T, OptionalInt> value, boolean defaultAttribute) {
+        this.metadata = new SeriesMetadata(false, name, false, SeriesDataType.INT, defaultAttribute);
+        this.value = value;
+    }
+
+    @Override
+    public SeriesMetadata getMetadata() {
+        return metadata;
+    }
+
+    @Override
+    public void createSeries(List<T> items, DataframeHandler handler, C context) {
+        boolean index = metadata.isIndex();
+        String name = metadata.getName();
+        DataframeHandler.OptionalIntSeriesWriter writer = handler.newOptionalIntSeries(name, items.size());
+        for (int i = 0; i < items.size(); i++) {
+            writer.set(i, value.apply(items.get(i)));
+        }
+    }
+}

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/OptionalIntSeriesMapper.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/OptionalIntSeriesMapper.java
@@ -1,13 +1,23 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
 package com.powsybl.dataframe;
 
 import java.util.List;
 import java.util.OptionalInt;
 import java.util.function.Function;
 
+/**
+ * @author Hugo Kulesza {@literal <hugo.kulesza at rte-france.com>}
+ */
 public class OptionalIntSeriesMapper<T, C> implements SeriesMapper<T, C> {
 
     private final SeriesMetadata metadata;
-    private Function<T, OptionalInt> value;
+    private final Function<T, OptionalInt> value;
 
     public OptionalIntSeriesMapper(String name, Function<T, OptionalInt> value) {
         this(name, value, true);

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/OptionalIntSeriesMapper.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/OptionalIntSeriesMapper.java
@@ -25,7 +25,6 @@ public class OptionalIntSeriesMapper<T, C> implements SeriesMapper<T, C> {
 
     @Override
     public void createSeries(List<T> items, DataframeHandler handler, C context) {
-        boolean index = metadata.isIndex();
         String name = metadata.getName();
         DataframeHandler.OptionalIntSeriesWriter writer = handler.newOptionalIntSeries(name, items.size());
         for (int i = 0; i < items.size(); i++) {

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/impl/DefaultDataframeHandler.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/impl/DefaultDataframeHandler.java
@@ -10,6 +10,7 @@ package com.powsybl.dataframe.impl;
 import com.powsybl.dataframe.DataframeHandler;
 
 import java.util.Objects;
+import java.util.OptionalInt;
 import java.util.function.Consumer;
 
 /**
@@ -54,6 +55,13 @@ public class DefaultDataframeHandler implements DataframeHandler {
     @Override
     public IntSeriesWriter newIntSeries(String name, int size) {
         int[] values = new int[size];
+        seriesConsumer.accept(new Series(name, values));
+        return (i, s) -> values[i] = s;
+    }
+
+    @Override
+    public OptionalIntSeriesWriter newOptionalIntSeries(String name, int size) {
+        OptionalInt[] values = new OptionalInt[size];
         seriesConsumer.accept(new Series(name, values));
         return (i, s) -> values[i] = s;
     }

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/impl/Series.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/impl/Series.java
@@ -10,6 +10,7 @@ package com.powsybl.dataframe.impl;
 import com.powsybl.commons.PowsyblException;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 
 /**
  * POJO representation of a series.
@@ -21,40 +22,47 @@ public class Series {
     private final String name;
     private final double[] doubles;
     private final int[] ints;
+    private final OptionalInt[] optionalInts;
     private final boolean[] booleans;
     private final String[] strings;
 
     public Series(String name, double[] values) {
-        this(false, name, values, null, null, null);
+        this(false, name, values, null, null, null, null);
     }
 
     public Series(String name, String[] values) {
-        this(false, name, null, null, null, values);
+        this(false, name, null, null, null, null, values);
     }
 
     public Series(String name, int[] values) {
-        this(false, name, null, values, null, null);
+        this(false, name, null, values, null, null, null);
+    }
+
+    public Series(String name, OptionalInt[] values) {
+        this(false, name, null, null, values, null, null);
     }
 
     public Series(String name, boolean[] values) {
-        this(false, name, null, null, values, null);
+        this(false, name, null, null, null, values, null);
     }
 
-    public Series(boolean index, String name, double[] doubles, int[] ints, boolean[] booleans, String[] strings) {
+    public Series(boolean index, String name, double[] doubles, int[] ints,
+                  OptionalInt[] optionalInts, boolean[] booleans, String[] strings) {
         this.index = index;
         this.name = name;
         this.doubles = doubles;
         this.ints = ints;
+        this.optionalInts = optionalInts;
         this.booleans = booleans;
         this.strings = strings;
     }
 
     public static Series index(String name, String[] values) {
-        return new Series(true, name, null, null, null, values);
+        return new Series(true, name, null, null, null, null, values);
     }
 
     public static Series index(String name, int[] values) {
-        return new Series(true, name, null, values, null, null);
+        return new Series(true, name, null, values, null, null, null);
     }
 
     public boolean isIndex() {
@@ -73,6 +81,11 @@ public class Series {
     public int[] getInts() {
         return Optional.ofNullable(ints)
             .orElseThrow(() -> createException(getName(), "int"));
+    }
+
+    public OptionalInt[] getOptionalInts() {
+        return Optional.ofNullable(optionalInts)
+                .orElseThrow(() -> createException(getName(), "optional ints"));
     }
 
     public boolean[] getBooleans() {

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -1301,7 +1301,7 @@ public final class NetworkDataframes {
                 .ints("low_tap", row -> row.getRtc().getLowTapPosition())
                 .ints("high_tap", row -> row.getRtc().getHighTapPosition())
                 .ints("step_count", row -> row.getRtc().getStepCount())
-                .booleans("on_load", row -> row.getRtc().hasLoadTapChangingCapabilities(), (row, v) -> row.getRtc().setLoadTapChangingCapabilities(v))
+                .booleans("oltc", row -> row.getRtc().hasLoadTapChangingCapabilities(), (row, v) -> row.getRtc().setLoadTapChangingCapabilities(v))
                 .booleans(REGULATING, row -> row.getRtc().isRegulating(), (row, v) -> row.getRtc().setRegulating(v))
                 .doubles("target_v", (row, context) -> getTransformerTargetV(row.getRtc(), context),
                         (row, targetV, context) -> setTransformerTargetV(row.getRtc(), targetV, context))
@@ -1441,7 +1441,7 @@ public final class NetworkDataframes {
                 .ints("low_tap", t -> t.getPtc().getLowTapPosition())
                 .ints("high_tap", t -> t.getPtc().getHighTapPosition())
                 .ints("step_count", t -> t.getPtc().getStepCount())
-                .booleans("on_load", t -> t.getPtc().hasLoadTapChangingCapabilities(), (t, v) -> t.getPtc().setLoadTapChangingCapabilities(v))
+                .booleans("oltc", t -> t.getPtc().hasLoadTapChangingCapabilities(), (t, v) -> t.getPtc().setLoadTapChangingCapabilities(v))
                 .booleans(REGULATING, t -> t.getPtc().isRegulating(), (t, v) -> t.getPtc().setRegulating(v))
                 .enums("regulation_mode", PhaseTapChanger.RegulationMode.class, t -> t.getPtc().getRegulationMode(), (t, v) -> t.getPtc().setRegulationMode(v))
                 .doubles("regulation_value", (t, context) -> t.getPtc().getRegulationValue(),

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -1438,6 +1438,7 @@ public final class NetworkDataframes {
                 .ints("low_tap", t -> t.getPtc().getLowTapPosition())
                 .ints("high_tap", t -> t.getPtc().getHighTapPosition())
                 .ints("step_count", t -> t.getPtc().getStepCount())
+                .booleans("on_load", t -> t.getPtc().hasLoadTapChangingCapabilities(), (t, v) -> t.getPtc().setLoadTapChangingCapabilities(v))
                 .booleans(REGULATING, t -> t.getPtc().isRegulating(), (t, v) -> t.getPtc().setRegulating(v))
                 .enums("regulation_mode", PhaseTapChanger.RegulationMode.class, t -> t.getPtc().getRegulationMode(), (t, v) -> t.getPtc().setRegulationMode(v))
                 .doubles("regulation_value", (t, context) -> t.getPtc().getRegulationValue(),

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -428,6 +428,7 @@ public final class NetworkDataframes {
                 .enums("model_type", ShuntCompensatorModelType.class, ShuntCompensator::getModelType)
                 .ints("max_section_count", ShuntCompensator::getMaximumSectionCount)
                 .ints("section_count", ShuntCompensator::getSectionCount, ShuntCompensator::setSectionCount)
+                .optionalInts("solved_section_count", ShuntCompensator::findSolvedSectionCount)
                 .booleans("voltage_regulation_on", ShuntCompensator::isVoltageRegulatorOn, ShuntCompensator::setVoltageRegulatorOn)
                 .doubles("target_v", (sc, context) -> perUnitTargetV(context, sc.getTargetV(), sc.getRegulatingTerminal(), sc.getTerminal()),
                     (sc, v, context) -> sc.setTargetV(unPerUnitTargetV(context, v, sc.getRegulatingTerminal(), sc.getTerminal())))
@@ -1296,6 +1297,7 @@ public final class NetworkDataframes {
                 .stringsIndex("id", TapChangerRow::getId)
                 .strings("side", TapChangerRow::getSide)
                 .ints("tap", row -> row.getRtc().getTapPosition(), (row, p) -> row.getRtc().setTapPosition(p))
+                .optionalInts("solved_tap_position", row -> row.getRtc().findSolvedTapPosition())
                 .ints("low_tap", row -> row.getRtc().getLowTapPosition())
                 .ints("high_tap", row -> row.getRtc().getHighTapPosition())
                 .ints("step_count", row -> row.getRtc().getStepCount())
@@ -1435,6 +1437,7 @@ public final class NetworkDataframes {
                 .stringsIndex("id", TapChangerRow::getId)
                 .strings("side", TapChangerRow::getSide)
                 .ints("tap", t -> t.getPtc().getTapPosition(), (t, v) -> t.getPtc().setTapPosition(v))
+                .optionalInts("solved_tap_position", t -> t.getPtc().findSolvedTapPosition())
                 .ints("low_tap", t -> t.getPtc().getLowTapPosition())
                 .ints("high_tap", t -> t.getPtc().getHighTapPosition())
                 .ints("step_count", t -> t.getPtc().getStepCount())

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/adders/RatioTapChangerDataframeAdder.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/adders/RatioTapChangerDataframeAdder.java
@@ -28,7 +28,7 @@ public class RatioTapChangerDataframeAdder implements NetworkElementAdder {
             SeriesMetadata.stringIndex("id"),
             SeriesMetadata.ints("tap"),
             SeriesMetadata.ints("low_tap"),
-            SeriesMetadata.booleans("on_load"),
+            SeriesMetadata.booleans("oltc"),
             SeriesMetadata.doubles("target_v"),
             SeriesMetadata.doubles("target_deadband"),
             SeriesMetadata.booleans("regulating"),
@@ -72,7 +72,7 @@ public class RatioTapChangerDataframeAdder implements NetworkElementAdder {
             this.ids = tapChangersDf.getStrings("id");
             this.taps = tapChangersDf.getInts("tap");
             this.lowTaps = tapChangersDf.getInts("low_tap");
-            this.onLoad = tapChangersDf.getInts("on_load");
+            this.onLoad = tapChangersDf.getInts("oltc");
             this.targetV = tapChangersDf.getDoubles("target_v");
             this.targetDeadband = tapChangersDf.getDoubles("target_deadband");
             this.regulating = tapChangersDf.getInts("regulating");

--- a/java/pypowsybl/src/main/java/com/powsybl/python/commons/CommonCFunctions.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/python/commons/CommonCFunctions.java
@@ -88,6 +88,7 @@ public final class CommonCFunctions {
         } else {
             UnmanagedMemory.free(seriesPointer.data().getPtr());
         }
+        UnmanagedMemory.free(seriesPointer.getMask());
         UnmanagedMemory.free(seriesPointer.getName());
     }
 

--- a/java/pypowsybl/src/main/java/com/powsybl/python/commons/CommonCFunctions.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/python/commons/CommonCFunctions.java
@@ -88,7 +88,9 @@ public final class CommonCFunctions {
         } else {
             UnmanagedMemory.free(seriesPointer.data().getPtr());
         }
-        UnmanagedMemory.free(seriesPointer.getMask());
+        if (seriesPointer.getMask().isNonNull()) {
+            UnmanagedMemory.free(seriesPointer.getMask());
+        }
         UnmanagedMemory.free(seriesPointer.getName());
     }
 

--- a/java/pypowsybl/src/main/java/com/powsybl/python/commons/PyPowsyblApiHeader.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/python/commons/PyPowsyblApiHeader.java
@@ -764,6 +764,12 @@ public final class PyPowsyblApiHeader {
         @CFieldAddress("data")
         <T extends PointerBase> ArrayPointer<T> data();
 
+        @CField("mask")
+        CIntPointer getMask();
+
+        @CField("mask")
+        void setMask(CIntPointer mask);
+
         SeriesPointer addressOf(int index);
     }
 

--- a/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
+++ b/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
@@ -624,7 +624,7 @@ class NetworkDataframesTest {
         assertThat(series)
                 .extracting(Series::getName)
                 .containsExactly("id", "side", "tap", "solved_tap_position", "low_tap", "high_tap", "step_count",
-                        "on_load", "regulating", "target_v", "target_deadband", "regulating_bus_id");
+                        "oltc", "regulating", "target_v", "target_deadband", "regulating_bus_id");
     }
 
     @Test
@@ -635,7 +635,7 @@ class NetworkDataframesTest {
         assertThat(series)
                 .extracting(Series::getName)
                 .containsExactly("id", "side", "tap", "solved_tap_position", "low_tap", "high_tap", "step_count",
-                        "on_load", "regulating", "regulation_mode", "regulation_value", "target_deadband", "regulating_bus_id");
+                        "oltc", "regulating", "regulation_mode", "regulation_value", "target_deadband", "regulating_bus_id");
     }
 
     @Test

--- a/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
+++ b/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
@@ -17,6 +17,7 @@ import com.powsybl.dataframe.impl.DefaultDataframeHandler;
 import com.powsybl.dataframe.impl.Series;
 import com.powsybl.dataframe.network.extensions.NetworkExtensions;
 import com.powsybl.dataframe.update.*;
+import com.powsybl.ieeecdf.converter.IeeeCdfNetworkFactory;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.*;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
@@ -383,21 +384,19 @@ class NetworkDataframesTest {
 
     @Test
     void shunts() {
-        Network network = IeeeCdfNetworkFactory.create14();
+        Network network = EurostagTutorialExample1Factory.create();
         List<Series> series = createDataFrame(SHUNT_COMPENSATOR, network);
 
         assertThat(series)
                 .extracting(Series::getName)
-                .containsExactly("id", "name", "g", "b", "model_type", "max_section_count", "section_count",
-                        "solved_section_count", "voltage_regulation_on", "target_v", "target_deadband",
-                        "regulating_bus_id", "p", "q", "i", "voltage_level_id", "bus_id", "connected");
+                .containsExactly("id", "name", "g", "b", "model_type", "max_section_count", "section_count", "voltage_regulation_on",
+                        "target_v", "target_deadband", "regulating_bus_id", "p", "q", "i", "voltage_level_id", "bus_id", "connected");
         List<Series> allAttributeSeries = createDataFrame(SHUNT_COMPENSATOR, network, new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()));
         assertThat(allAttributeSeries)
                 .extracting(Series::getName)
-                .containsExactly("id", "name", "g", "b", "model_type", "max_section_count", "section_count",
-                        "solved_section_count", "voltage_regulation_on", "target_v", "target_deadband",
-                        "regulating_bus_id", "p", "q", "i", "voltage_level_id", "bus_id", "bus_breaker_bus_id",
-                        "node", "connected", "fictitious");
+                .containsExactly("id", "name", "g", "b", "model_type", "max_section_count", "section_count", "voltage_regulation_on",
+                        "target_v", "target_deadband", "regulating_bus_id", "p", "q", "i",
+                        "voltage_level_id", "bus_id", "bus_breaker_bus_id", "node", "connected", "fictitious");
     }
 
     @Test

--- a/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
+++ b/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
@@ -383,19 +383,21 @@ class NetworkDataframesTest {
 
     @Test
     void shunts() {
-        Network network = EurostagTutorialExample1Factory.create();
+        Network network = IeeeCdfNetworkFactory.create14();
         List<Series> series = createDataFrame(SHUNT_COMPENSATOR, network);
 
         assertThat(series)
                 .extracting(Series::getName)
-                .containsExactly("id", "name", "g", "b", "model_type", "max_section_count", "section_count", "voltage_regulation_on",
-                        "target_v", "target_deadband", "regulating_bus_id", "p", "q", "i", "voltage_level_id", "bus_id", "connected");
+                .containsExactly("id", "name", "g", "b", "model_type", "max_section_count", "section_count",
+                        "solved_section_count", "voltage_regulation_on", "target_v", "target_deadband",
+                        "regulating_bus_id", "p", "q", "i", "voltage_level_id", "bus_id", "connected");
         List<Series> allAttributeSeries = createDataFrame(SHUNT_COMPENSATOR, network, new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()));
         assertThat(allAttributeSeries)
                 .extracting(Series::getName)
-                .containsExactly("id", "name", "g", "b", "model_type", "max_section_count", "section_count", "voltage_regulation_on",
-                        "target_v", "target_deadband", "regulating_bus_id", "p", "q", "i",
-                        "voltage_level_id", "bus_id", "bus_breaker_bus_id", "node", "connected", "fictitious");
+                .containsExactly("id", "name", "g", "b", "model_type", "max_section_count", "section_count",
+                        "solved_section_count", "voltage_regulation_on", "target_v", "target_deadband",
+                        "regulating_bus_id", "p", "q", "i", "voltage_level_id", "bus_id", "bus_breaker_bus_id",
+                        "node", "connected", "fictitious");
     }
 
     @Test
@@ -634,8 +636,8 @@ class NetworkDataframesTest {
 
         assertThat(series)
                 .extracting(Series::getName)
-                .containsExactly("id", "side", "tap", "low_tap", "high_tap", "step_count", "regulating", "regulation_mode",
-                        "regulation_value", "target_deadband", "regulating_bus_id");
+                .containsExactly("id", "side", "tap", "solved_tap_position", "low_tap", "high_tap", "step_count",
+                        "on_load", "regulating", "regulation_mode", "regulation_value", "target_deadband", "regulating_bus_id");
     }
 
     @Test

--- a/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
+++ b/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
@@ -17,7 +17,6 @@ import com.powsybl.dataframe.impl.DefaultDataframeHandler;
 import com.powsybl.dataframe.impl.Series;
 import com.powsybl.dataframe.network.extensions.NetworkExtensions;
 import com.powsybl.dataframe.update.*;
-import com.powsybl.ieeecdf.converter.IeeeCdfNetworkFactory;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.*;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
@@ -389,12 +388,12 @@ class NetworkDataframesTest {
 
         assertThat(series)
                 .extracting(Series::getName)
-                .containsExactly("id", "name", "g", "b", "model_type", "max_section_count", "section_count", "voltage_regulation_on",
+                .containsExactly("id", "name", "g", "b", "model_type", "max_section_count", "section_count", "solved_section_count", "voltage_regulation_on",
                         "target_v", "target_deadband", "regulating_bus_id", "p", "q", "i", "voltage_level_id", "bus_id", "connected");
         List<Series> allAttributeSeries = createDataFrame(SHUNT_COMPENSATOR, network, new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()));
         assertThat(allAttributeSeries)
                 .extracting(Series::getName)
-                .containsExactly("id", "name", "g", "b", "model_type", "max_section_count", "section_count", "voltage_regulation_on",
+                .containsExactly("id", "name", "g", "b", "model_type", "max_section_count", "section_count", "solved_section_count", "voltage_regulation_on",
                         "target_v", "target_deadband", "regulating_bus_id", "p", "q", "i",
                         "voltage_level_id", "bus_id", "bus_breaker_bus_id", "node", "connected", "fictitious");
     }
@@ -624,8 +623,8 @@ class NetworkDataframesTest {
 
         assertThat(series)
                 .extracting(Series::getName)
-                .containsExactly("id", "side", "tap", "low_tap", "high_tap", "step_count", "on_load", "regulating", "target_v",
-                        "target_deadband", "regulating_bus_id");
+                .containsExactly("id", "side", "tap", "solved_tap_position", "low_tap", "high_tap", "step_count",
+                        "on_load", "regulating", "target_v", "target_deadband", "regulating_bus_id");
     }
 
     @Test

--- a/pypowsybl/network/impl/network.py
+++ b/pypowsybl/network/impl/network.py
@@ -1348,7 +1348,8 @@ class Network:  # pylint: disable=too-many-public-methods
 
               - **model_type**:
               - **max_section_count**: The maximum number of sections that may be switched on
-              - **section_count**: The current number of section that may be switched on
+              - **section_count**: The number of section in service (input for the computation)
+              - **solved_section_count**: The number of section in service (output of a computation, ``NaN`` before any loadflow)
               - **p**: the active flow on the shunt, ``NaN`` if no loadflow has been computed (in MW)
               - **q**: the reactive flow on the shunt, ``NaN`` if no loadflow has been computed  (in MVAr)
               - **i**: the current in the shunt, ``NaN`` if no loadflow has been computed  (in A)
@@ -2425,7 +2426,8 @@ class Network:  # pylint: disable=too-many-public-methods
             The resulting dataframe, depending on the parameters, will include the following columns:
 
               - **side**: the ratio tap changer side in case of a belonging to a 3 windings transformer, empty for a 2 windings transformer
-              - **tap**: the current tap position
+              - **tap**: the current tap position (input of a loadflow)
+              - **solved_tap_position**: the tap position obtained after running a loadflow (``NaN`` before any computation)
               - **low_tap**: the low tap position (usually 0, but could be different depending on the data origin)
               - **high_tap**: the high tap position
               - **step_count**: the count of taps, should be equal to (high_tap - low_tap)
@@ -2446,12 +2448,12 @@ class Network:  # pylint: disable=too-many-public-methods
 
             will output something like:
 
-            ========== ==== === ======= ======== ========== ======= ========== ======== =============== =================
-            \          side tap low_tap high_tap step_count on_load regulating target_v target_deadband regulating_bus_id
-            ========== ==== === ======= ======== ========== ======= ========== ======== =============== =================
+            ========== ==== === =================== ======= ======== ========== ======= ========== ======== =============== =================
+            \          side tap solved_tap_position low_tap high_tap step_count on_load regulating target_v target_deadband regulating_bus_id
+            ========== ==== === =================== ======= ======== ========== ======= ========== ======== =============== =================
             id
-            NHV2_NLOAD        1       0        2          3    True       True    158.0             0.0          VLLOAD_0
-            ========== ==== === ======= ======== ========== ======= ========== ======== =============== =================
+            NHV2_NLOAD        1                 NaN       0        2          3    True       True    158.0             0.0          VLLOAD_0
+            ========== ==== === =================== ======= ======== ========== ======= ========== ======== =============== =================
 
             .. code-block:: python
 
@@ -2460,12 +2462,12 @@ class Network:  # pylint: disable=too-many-public-methods
 
             will output something like:
 
-            ========== ==== === ======= ======== ========== ======= ========== ======== =============== =================
-            \          side tap low_tap high_tap step_count on_load regulating target_v target_deadband regulating_bus_id
-            ========== ==== === ======= ======== ========== ======= ========== ======== =============== =================
+            ========== ==== === =================== ======= ======== ========== ======= ========== ======== =============== ================= ==============
+            \          side tap solved_tap_position low_tap high_tap step_count on_load regulating target_v target_deadband regulating_bus_id regulated_side
+            ========== ==== === =================== ======= ======== ========== ======= ========== ======== =============== ================= ==============
             id
-            NHV2_NLOAD        1       0        2          3    True       True    158.0             0.0          VLLOAD_0
-            ========== ==== === ======= ======== ========== ======= ========== ======== =============== =================
+            NHV2_NLOAD        1                 nan       0        2          3    True       True    158.0             0.0          VLLOAD_0            TWO
+            ========== ==== === =================== ======= ======== ========== ======= ========== ======== =============== ================= ==============
 
             .. code-block:: python
 
@@ -2501,10 +2503,12 @@ class Network:  # pylint: disable=too-many-public-methods
             The resulting dataframe, depending on the parameters, will include the following columns:
 
               - **side**: the phase tap changer side in case of a belonging to a 3 windings transformer, empty for a 2 windings transformer
-              - **tap**: the current tap position
+              - **tap**: the current tap position (input of a loadflow)
+              - **solved_tap_position**: the tap position obtained after running a loadflow (``NaN`` before any computation)
               - **low_tap**: the low tap position (usually 0, but could be different depending on the data origin)
               - **high_tap**: the high tap position
               - **step_count**: the count of taps, should be equal to (high_tap - low_tap)
+              - **on_load**: true if the tap changer has on-load regulation capability
               - **regulating**: true if the phase shifter is in regulation
               - **regulation_mode**: regulation mode, among CURRENT_LIMITER, ACTIVE_POWER_CONTROL, and FIXED_TAP
               - **regulation_value**: the target value, in A or MW, depending on regulation_mode
@@ -2522,12 +2526,12 @@ class Network:  # pylint: disable=too-many-public-methods
 
             will output something like:
 
-            === ==== === ======= ======== ========== ========== =============== ================ =============== =================
-            \   side tap low_tap high_tap step_count regulating regulation_mode regulation_value target_deadband regulating_bus_id
-            === ==== === ======= ======== ========== ========== =============== ================ =============== =================
+            === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== =================
+            \   side tap low_tap solved_tap_position high_tap step_count on_load regulating regulation_mode regulation_value target_deadband regulating_bus_id
+            === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== =================
             id
-            TWT       15       0       32         33      False       FIXED_TAP              NaN             NaN           S1VL1_0
-            === ==== === ======= ======== ========== ========== =============== ================ =============== =================
+            TWT       15       0                 NaN       32         33    True     False CURRENT_LIMITER              NaN             NaN           S1VL1_0
+            === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== =================
 
             .. code-block:: python
 
@@ -2536,12 +2540,12 @@ class Network:  # pylint: disable=too-many-public-methods
 
             will output something like:
 
-            === ==== === ======= ======== ========== ========== =============== ================ =============== =================
-            \   side tap low_tap high_tap step_count regulating regulation_mode regulation_value target_deadband regulating_bus_id
-            === ==== === ======= ======== ========== ========== =============== ================ =============== =================
+            === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== ================= ==============
+            \   side tap low_tap solved_tap_position high_tap step_count on_load regulating regulation_mode regulation_value target_deadband regulating_bus_id regulated_side
+            === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== ================= ==============
             id
-            TWT       15       0       32         33      False       FIXED_TAP              NaN             NaN           S1VL1_0
-            === ==== === ======= ======== ========== ========== =============== ================ =============== =================
+            TWT       15       0                 NaN       32         33    True      False  CURRENT_LIMITER              NaN             NaN           S1VL1_0             ONE
+            === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== ================= ==============
 
             .. code-block:: python
 

--- a/pypowsybl/network/impl/network.py
+++ b/pypowsybl/network/impl/network.py
@@ -2544,7 +2544,7 @@ class Network:  # pylint: disable=too-many-public-methods
             \   side tap low_tap solved_tap_position high_tap step_count on_load regulating regulation_mode regulation_value target_deadband regulating_bus_id regulated_side
             === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== ================= ==============
             id
-            TWT       15       0                 NaN       32         33    True      False CURRENT_LIMITER              NaN             NaN           S1VL1_0             ONE
+            TWT       15       0                 NaN       32         33    True      False CURRENT_LIMITER              NaN             NaN           S1VL1_0            ONE
             === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== ================= ==============
 
             .. code-block:: python

--- a/pypowsybl/network/impl/network.py
+++ b/pypowsybl/network/impl/network.py
@@ -2530,7 +2530,7 @@ class Network:  # pylint: disable=too-many-public-methods
             \   side tap low_tap solved_tap_position high_tap step_count on_load regulating regulation_mode regulation_value target_deadband regulating_bus_id
             === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== =================
             id
-            TWT       15       0                 NaN       32         33    True     False CURRENT_LIMITER              NaN             NaN           S1VL1_0
+            TWT       15       0                 NaN       32         33    True      False CURRENT_LIMITER              NaN             NaN           S1VL1_0
             === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== =================
 
             .. code-block:: python

--- a/pypowsybl/network/impl/network.py
+++ b/pypowsybl/network/impl/network.py
@@ -2431,7 +2431,7 @@ class Network:  # pylint: disable=too-many-public-methods
               - **low_tap**: the low tap position (usually 0, but could be different depending on the data origin)
               - **high_tap**: the high tap position
               - **step_count**: the count of taps, should be equal to (high_tap - low_tap)
-              - **on_load**: true if the tap changer has on-load regulation capability
+              - **oltc**: true if the tap changer has on-load regulation capability
               - **regulating**: true if the tap changer is in regulation
               - **target_v**: the target voltage in kV, if the tap changer is in regulation
               - **target_deadband**: the regulation deadband around the target voltage, in kV
@@ -2448,12 +2448,12 @@ class Network:  # pylint: disable=too-many-public-methods
 
             will output something like:
 
-            ========== ==== === =================== ======= ======== ========== ======= ========== ======== =============== =================
-            \          side tap solved_tap_position low_tap high_tap step_count on_load regulating target_v target_deadband regulating_bus_id
-            ========== ==== === =================== ======= ======== ========== ======= ========== ======== =============== =================
+            ========== ==== === =================== ======= ======== ========== ==== ========== ======== =============== =================
+            \          side tap solved_tap_position low_tap high_tap step_count oltc regulating target_v target_deadband regulating_bus_id
+            ========== ==== === =================== ======= ======== ========== ==== ========== ======== =============== =================
             id
-            NHV2_NLOAD        1                 NaN       0        2          3    True       True    158.0             0.0          VLLOAD_0
-            ========== ==== === =================== ======= ======== ========== ======= ========== ======== =============== =================
+            NHV2_NLOAD        1                 NaN       0        2          3 True       True    158.0             0.0          VLLOAD_0
+            ========== ==== === =================== ======= ======== ========== ==== ========== ======== =============== =================
 
             .. code-block:: python
 
@@ -2462,12 +2462,12 @@ class Network:  # pylint: disable=too-many-public-methods
 
             will output something like:
 
-            ========== ==== === =================== ======= ======== ========== ======= ========== ======== =============== ================= ==============
-            \          side tap solved_tap_position low_tap high_tap step_count on_load regulating target_v target_deadband regulating_bus_id regulated_side
-            ========== ==== === =================== ======= ======== ========== ======= ========== ======== =============== ================= ==============
+            ========== ==== === =================== ======= ======== ========== ==== ========== ======== =============== ================= ==============
+            \          side tap solved_tap_position low_tap high_tap step_count oltc regulating target_v target_deadband regulating_bus_id regulated_side
+            ========== ==== === =================== ======= ======== ========== ==== ========== ======== =============== ================= ==============
             id
-            NHV2_NLOAD        1                 nan       0        2          3    True       True    158.0             0.0          VLLOAD_0            TWO
-            ========== ==== === =================== ======= ======== ========== ======= ========== ======== =============== ================= ==============
+            NHV2_NLOAD        1                 nan       0        2          3 True       True    158.0             0.0          VLLOAD_0            TWO
+            ========== ==== === =================== ======= ======== ========== ==== ========== ======== =============== ================= ==============
 
             .. code-block:: python
 
@@ -2508,7 +2508,7 @@ class Network:  # pylint: disable=too-many-public-methods
               - **low_tap**: the low tap position (usually 0, but could be different depending on the data origin)
               - **high_tap**: the high tap position
               - **step_count**: the count of taps, should be equal to (high_tap - low_tap)
-              - **on_load**: true if the tap changer has on-load regulation capability
+              - **oltc**: true if the tap changer has on-load regulation capability
               - **regulating**: true if the phase shifter is in regulation
               - **regulation_mode**: regulation mode, among CURRENT_LIMITER, ACTIVE_POWER_CONTROL, and FIXED_TAP
               - **regulation_value**: the target value, in A or MW, depending on regulation_mode
@@ -2526,12 +2526,12 @@ class Network:  # pylint: disable=too-many-public-methods
 
             will output something like:
 
-            === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== =================
-            \   side tap low_tap solved_tap_position high_tap step_count on_load regulating regulation_mode regulation_value target_deadband regulating_bus_id
-            === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== =================
+            === ==== === ======= =================== ======== ========== ==== ========== =============== ================ =============== =================
+            \   side tap low_tap solved_tap_position high_tap step_count oltc regulating regulation_mode regulation_value target_deadband regulating_bus_id
+            === ==== === ======= =================== ======== ========== ==== ========== =============== ================ =============== =================
             id
-            TWT       15       0                 NaN       32         33    True      False CURRENT_LIMITER              NaN             NaN           S1VL1_0
-            === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== =================
+            TWT       15       0                 NaN       32         33 True      False CURRENT_LIMITER              NaN             NaN           S1VL1_0
+            === ==== === ======= =================== ======== ========== ==== ========== =============== ================ =============== =================
 
             .. code-block:: python
 
@@ -2540,12 +2540,12 @@ class Network:  # pylint: disable=too-many-public-methods
 
             will output something like:
 
-            === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== ================= ==============
-            \   side tap low_tap solved_tap_position high_tap step_count on_load regulating regulation_mode regulation_value target_deadband regulating_bus_id regulated_side
-            === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== ================= ==============
+            === ==== === ======= =================== ======== ========== ==== ========== =============== ================ =============== ================= ==============
+            \   side tap low_tap solved_tap_position high_tap step_count oltc regulating regulation_mode regulation_value target_deadband regulating_bus_id regulated_side
+            === ==== === ======= =================== ======== ========== ==== ========== =============== ================ =============== ================= ==============
             id
-            TWT       15       0                 NaN       32         33    True      False CURRENT_LIMITER              NaN             NaN           S1VL1_0            ONE
-            === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== ================= ==============
+            TWT       15       0                 NaN       32         33 True      False CURRENT_LIMITER              NaN             NaN           S1VL1_0            ONE
+            === ==== === ======= =================== ======== ========== ==== ========== =============== ================ =============== ================= ==============
 
             .. code-block:: python
 
@@ -3465,7 +3465,7 @@ class Network:  # pylint: disable=too-many-public-methods
             Attributes that can be updated are:
 
             - `tap`
-            - `on_load`
+            - `oltc`
             - `regulating`,
             - `regulated_side`,
             - `target_v`
@@ -4927,10 +4927,10 @@ class Network:  # pylint: disable=too-many-public-methods
             - **id**: the transformer where this tap changer will be created
             - **tap**: the current tap position
             - **low_tap**: the number of the lowest tap position (default 0)
-            - **on_load**: true if the transformer has on-load voltage regulation capability
+            - **oltc**: true if the transformer has on-load voltage regulation capability
             - **target_v**: the target voltage, in kV
             - **target_deadband**: the target voltage regulation deadband, in kV
-            - **regulating**: true if the tap changer should regulate voltage (**on_load** must be true to set this to true)
+            - **regulating**: true if the tap changer should regulate voltage (**oltc** must be true to set this to true)
             - **regulated_side**: the side where voltage is regulated (ONE or TWO if two-winding transformer, ONE, TWO
               or THREE if three-winding transformer)
             - **side**: Side of the tap changer (only for three-winding transformers)
@@ -4951,7 +4951,7 @@ class Network:  # pylint: disable=too-many-public-methods
 
                 rtc_df = pd.DataFrame.from_records(
                     index='id',
-                    columns=['id', 'target_deadband', 'target_v', 'on_load', 'low_tap', 'tap'],
+                    columns=['id', 'target_deadband', 'target_v', 'oltc', 'low_tap', 'tap'],
                     data=[('NGEN_NHV1', 2, 200, False, 0, 1)])
                 steps_df = pd.DataFrame.from_records(
                     index='id',

--- a/pypowsybl/network/impl/network.py
+++ b/pypowsybl/network/impl/network.py
@@ -2544,7 +2544,7 @@ class Network:  # pylint: disable=too-many-public-methods
             \   side tap low_tap solved_tap_position high_tap step_count on_load regulating regulation_mode regulation_value target_deadband regulating_bus_id regulated_side
             === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== ================= ==============
             id
-            TWT       15       0                 NaN       32         33    True      False  CURRENT_LIMITER              NaN             NaN           S1VL1_0             ONE
+            TWT       15       0                 NaN       32         33    True      False CURRENT_LIMITER              NaN             NaN           S1VL1_0             ONE
             === ==== === ======= =================== ======== ========== ======= ========== =============== ================ =============== ================= ==============
 
             .. code-block:: python

--- a/pypowsybl/utils/impl/util.py
+++ b/pypowsybl/utils/impl/util.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 from os import PathLike
-from typing import Union
+from typing import Union, Any
 import pandas as pd
 import numpy as np
 from pypowsybl import _pypowsybl
@@ -15,7 +15,7 @@ PathOrStr = Union[str, PathLike]
 
 
 def create_data_frame_from_series_array(series_array: _pypowsybl.SeriesArray) -> pd.DataFrame:
-    series_dict = {}
+    series_dict: dict[str, Any] = {}
     index_data = []
     index_names = []
     for series in series_array:

--- a/pypowsybl/utils/impl/util.py
+++ b/pypowsybl/utils/impl/util.py
@@ -8,6 +8,7 @@
 from os import PathLike
 from typing import Union
 import pandas as pd
+import numpy as np
 from pypowsybl import _pypowsybl
 
 PathOrStr = Union[str, PathLike]
@@ -22,7 +23,10 @@ def create_data_frame_from_series_array(series_array: _pypowsybl.SeriesArray) ->
             index_data.append(series.data)
             index_names.append(series.name)
         else:
-            series_dict[series.name] = series.data
+            if series.mask.any():
+                series_dict[series.name] = np.ma.masked_array(series.data, series.mask)
+            else:
+                series_dict[series.name] = series.data
     if not index_names:
         raise ValueError('No index in returned dataframe')
     if len(index_names) == 1:

--- a/tests/test_java_perunit.py
+++ b/tests/test_java_perunit.py
@@ -353,7 +353,7 @@ def test_ratio_tap_changers_per_unit():
     n = pp.network.create_eurostag_tutorial_example1_network()
     n.per_unit = True
     expected = pd.DataFrame(index=pd.Series(name='id', data=['NHV2_NLOAD']),
-                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load',
+                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'oltc',
                                      'regulating', 'target_v', 'target_deadband', 'regulating_bus_id'],
                             data=[['', 1, nan, 0, 2, 3, True, True, 1.05, 0.0, 'VLLOAD_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)

--- a/tests/test_java_perunit.py
+++ b/tests/test_java_perunit.py
@@ -128,11 +128,10 @@ def test_shunt_compensators_per_unit():
     n = pp.network.create_four_substations_node_breaker_network()
     n.per_unit = True
     expected = pd.DataFrame(index=pd.Series(name='id', data=['SHUNT']),
-                            columns=['name', 'g', 'b', 'model_type', 'max_section_count', 'section_count',
+                            columns=['name', 'g', 'b', 'model_type', 'max_section_count', 'section_count', 'solved_section_count',
                                      'voltage_regulation_on', 'target_v', 'target_deadband', 'regulating_bus_id',
-                                     'p', 'q', 'i',
-                                     'voltage_level_id', 'bus_id', 'connected'],
-                            data=[['', 0, -19.2, 'LINEAR', 1, 1, False, nan, nan, 'S1VL2_0', nan, 19.2, nan, 'S1VL2',
+                                     'p', 'q', 'i', 'voltage_level_id', 'bus_id', 'connected'],
+                            data=[['', 0, -19.2, 'LINEAR', 1, 1, nan, False, nan, nan, 'S1VL2_0', nan, 19.2, nan, 'S1VL2',
                                    'S1VL2_0', True]])
     pd.testing.assert_frame_equal(expected, n.get_shunt_compensators(), check_dtype=False, atol=1e-2)
 
@@ -354,9 +353,9 @@ def test_ratio_tap_changers_per_unit():
     n = pp.network.create_eurostag_tutorial_example1_network()
     n.per_unit = True
     expected = pd.DataFrame(index=pd.Series(name='id', data=['NHV2_NLOAD']),
-                            columns=['side', 'tap', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
-                                     'target_v', 'target_deadband', 'regulating_bus_id'],
-                            data=[['', 1, 0, 2, 3, True, True, 1.05, 0.0, 'VLLOAD_0']])
+                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load',
+                                     'regulating', 'target_v', 'target_deadband', 'regulating_bus_id'],
+                            data=[['', 1, nan, 0, 2, 3, True, True, 1.05, 0.0, 'VLLOAD_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)
 
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -889,18 +889,18 @@ def test_exception():
 def test_ratio_tap_changers():
     n = pp.network.create_eurostag_tutorial_example1_network()
     expected = pd.DataFrame(index=pd.Series(name='id', data=['NHV2_NLOAD']),
-                            columns=['side', 'tap', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
-                                     'target_v', 'target_deadband', 'regulating_bus_id'],
-                            data=[['', 1, 0, 2, 3, True, True, 158.0, 0.0, 'VLLOAD_0']])
+                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load',
+                                     'regulating', 'target_v', 'target_deadband', 'regulating_bus_id'],
+                            data=[['', 1, nan, 0, 2, 3, True, True, 158.0, 0.0, 'VLLOAD_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)
     update = pd.DataFrame(index=['NHV2_NLOAD'],
                           columns=['tap', 'regulating', 'target_v'],
                           data=[[0, False, 180]])
     n.update_ratio_tap_changers(update)
     expected = pd.DataFrame(index=pd.Series(name='id', data=['NHV2_NLOAD']),
-                            columns=['side', 'tap', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
-                                     'target_v', 'target_deadband', 'regulating_bus_id'],
-                            data=[['', 0, 0, 2, 3, True, False, 180.0, 0.0, 'VLLOAD_0']])
+                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load',
+                                     'regulating', 'target_v', 'target_deadband', 'regulating_bus_id'],
+                            data=[['', 0, nan, 0, 2, 3, True, False, 180.0, 0.0, 'VLLOAD_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)
 
 
@@ -909,11 +909,11 @@ def test_ratio_tap_changers_3_windings():
     expected = pd.DataFrame(index=pd.Series(name='id', data=['b94318f6-6d24-4f56-96b9-df2531ad6543',
                                                              'e482b89a-fa84-4ea9-8e70-a83d44790957',
                                                              '84ed55f4-61f5-4d9d-8755-bba7b877a246']),
-                            columns=['side', 'tap', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
-                                     'target_v', 'target_deadband', 'regulating_bus_id'],
-                            data=[['', 10, 1, 25, 25, True, False, 0.0, 0.5, '8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0'],
-                                  ['', 14, 1, 33, 33, True, True, 10.815, 0.5, '4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386_0'],
-                                  ['TWO', 17, 1, 33, 33, True, False, 0.0, 0.5, 'b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c_0']])
+                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load',
+                                     'regulating', 'target_v', 'target_deadband', 'regulating_bus_id'],
+                            data=[['', 10, 10, 1, 25, 25, True, False, 0.0, 0.5, '8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0'],
+                                  ['', 14, 18, 1, 33, 33, True, True, 10.815, 0.5, '4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386_0'],
+                                  ['TWO', 17, 17, 1, 33, 33, True, False, 0.0, 0.5, 'b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)
 
     update = pd.DataFrame(index=pd.MultiIndex.from_tuples([('84ed55f4-61f5-4d9d-8755-bba7b877a246', 'TWO')],
@@ -925,11 +925,11 @@ def test_ratio_tap_changers_3_windings():
     expected = pd.DataFrame(index=pd.Series(name='id', data=['b94318f6-6d24-4f56-96b9-df2531ad6543',
                                                              'e482b89a-fa84-4ea9-8e70-a83d44790957',
                                                              '84ed55f4-61f5-4d9d-8755-bba7b877a246']),
-                            columns=['side', 'tap', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
-                                     'target_v', 'target_deadband', 'regulating_bus_id'],
-                            data=[['', 10, 1, 25, 25, True, False, 0.0, 0.5, '8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0'],
-                                  ['', 14, 1, 33, 33, True, True, 10.815, 0.5, '4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386_0'],
-                                  ['TWO', 9, 1, 33, 33, True, True, 16.7, 0.5, 'b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c_0']])
+                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load',
+                                     'regulating', 'target_v', 'target_deadband', 'regulating_bus_id'],
+                            data=[['', 10, 10, 1, 25, 25, True, False, 0.0, 0.5, '8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0'],
+                                  ['', 14, 18, 1, 33, 33, True, True, 10.815, 0.5, '4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386_0'],
+                                  ['TWO', 9, 17, 1, 33, 33, True, True, 16.7, 0.5, 'b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)
 
     steps = n.get_ratio_tap_changer_steps()
@@ -941,10 +941,11 @@ def test_ratio_tap_changers_3_windings():
 def test_phase_tap_changers():
     n = pp.network.create_four_substations_node_breaker_network()
     tap_changers = n.get_phase_tap_changers()
-    assert ['side', 'tap', 'low_tap', 'high_tap', 'step_count', 'regulating', 'regulation_mode',
-            'regulation_value', 'target_deadband', 'regulating_bus_id'] == tap_changers.columns.tolist()
+    assert ['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+            'regulation_mode', 'regulation_value', 'target_deadband', 'regulating_bus_id'] == tap_changers.columns.tolist()
     twt_values = tap_changers.loc['TWT']
     assert 15 == twt_values.tap
+    assert pd.isna(twt_values.solved_tap_position)
     assert 0 == twt_values.low_tap
     assert 32 == twt_values.high_tap
     assert 33 == twt_values.step_count
@@ -958,8 +959,8 @@ def test_phase_tap_changers():
     n.update_ratio_tap_changers(id='TWT', regulating=False)
     n.update_phase_tap_changers(update)
     tap_changers = n.get_phase_tap_changers()
-    assert ['side', 'tap', 'low_tap', 'high_tap', 'step_count', 'regulating', 'regulation_mode',
-            'regulation_value', 'target_deadband', 'regulating_bus_id'] == tap_changers.columns.tolist()
+    assert ['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+            'regulation_mode', 'regulation_value', 'target_deadband', 'regulating_bus_id'] == tap_changers.columns.tolist()
     twt_values = tap_changers.loc['TWT']
     assert 10 == twt_values.tap
     assert twt_values.regulating
@@ -1413,10 +1414,10 @@ def test_shunt():
     assert not df['fictitious']['SHUNT']
     expected = pd.DataFrame(index=pd.Series(name='id', data=['SHUNT']),
                             columns=['name', 'g', 'b', 'model_type', 'max_section_count', 'section_count',
-                                     'voltage_regulation_on', 'target_v',
+                                     'solved_section_count', 'voltage_regulation_on', 'target_v',
                                      'target_deadband', 'regulating_bus_id', 'p', 'q', 'i',
                                      'voltage_level_id', 'bus_id', 'connected'],
-                            data=[['', 0.0, -0.012, 'LINEAR', 1, 1, False, nan, nan,
+                            data=[['', 0.0, -0.012, 'LINEAR', 1, 1, nan, False, nan, nan,
                                    'S1VL2_0', nan, 1920, nan, 'S1VL2', 'S1VL2_0', True]])
     pd.testing.assert_frame_equal(expected, n.get_shunt_compensators(), check_dtype=False)
     n.update_shunt_compensators(
@@ -1430,10 +1431,10 @@ def test_shunt():
                      data=[[True]]))
     expected = pd.DataFrame(index=pd.Series(name='id', data=['SHUNT']),
                             columns=['name', 'g', 'b', 'model_type', 'max_section_count', 'section_count',
-                                     'voltage_regulation_on', 'target_v',
+                                     'solved_section_count', 'voltage_regulation_on', 'target_v',
                                      'target_deadband', 'regulating_bus_id', 'p', 'q', 'i',
                                      'voltage_level_id', 'bus_id', 'connected'],
-                            data=[['', 0.0, -0.0, 'LINEAR', 1, 0, True, 50, 3,
+                            data=[['', 0.0, -0.0, 'LINEAR', 1, 0, nan, True, 50, 3,
                                    '', nan, 1900, nan, 'S1VL2', '', False]])
     pd.testing.assert_frame_equal(expected, n.get_shunt_compensators(), check_dtype=False)
     shunts = n.get_shunt_compensators(attributes=['bus_breaker_bus_id', 'node'])

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -889,7 +889,7 @@ def test_exception():
 def test_ratio_tap_changers():
     n = pp.network.create_eurostag_tutorial_example1_network()
     expected = pd.DataFrame(index=pd.Series(name='id', data=['NHV2_NLOAD']),
-                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load',
+                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'oltc',
                                      'regulating', 'target_v', 'target_deadband', 'regulating_bus_id'],
                             data=[['', 1, nan, 0, 2, 3, True, True, 158.0, 0.0, 'VLLOAD_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)
@@ -898,7 +898,7 @@ def test_ratio_tap_changers():
                           data=[[0, False, 180]])
     n.update_ratio_tap_changers(update)
     expected = pd.DataFrame(index=pd.Series(name='id', data=['NHV2_NLOAD']),
-                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'oltc', 'regulating',
                                      'target_v', 'target_deadband', 'regulating_bus_id'],
                             data=[['', 0, nan, 0, 2, 3, True, False, 180.0, 0.0, 'VLLOAD_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)
@@ -909,7 +909,7 @@ def test_ratio_tap_changers_3_windings():
     expected = pd.DataFrame(index=pd.Series(name='id', data=['b94318f6-6d24-4f56-96b9-df2531ad6543',
                                                              'e482b89a-fa84-4ea9-8e70-a83d44790957',
                                                              '84ed55f4-61f5-4d9d-8755-bba7b877a246']),
-                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'oltc', 'regulating',
                                      'target_v', 'target_deadband', 'regulating_bus_id'],
                             data=[['', 10, 10, 1, 25, 25, True, False, 0.0, 0.5, '8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0'],
                                   ['', 14, 18, 1, 33, 33, True, True, 10.815, 0.5, '4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386_0'],
@@ -925,7 +925,7 @@ def test_ratio_tap_changers_3_windings():
     expected = pd.DataFrame(index=pd.Series(name='id', data=['b94318f6-6d24-4f56-96b9-df2531ad6543',
                                                              'e482b89a-fa84-4ea9-8e70-a83d44790957',
                                                              '84ed55f4-61f5-4d9d-8755-bba7b877a246']),
-                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'oltc', 'regulating',
                                      'target_v', 'target_deadband', 'regulating_bus_id'],
                             data=[['', 10, 10, 1, 25, 25, True, False, 0.0, 0.5, '8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0'],
                                   ['', 14, 18, 1, 33, 33, True, True, 10.815, 0.5, '4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386_0'],
@@ -941,7 +941,7 @@ def test_ratio_tap_changers_3_windings():
 def test_phase_tap_changers():
     n = pp.network.create_four_substations_node_breaker_network()
     tap_changers = n.get_phase_tap_changers()
-    assert ['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+    assert ['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'oltc', 'regulating',
             'regulation_mode', 'regulation_value', 'target_deadband', 'regulating_bus_id'] == tap_changers.columns.tolist()
     twt_values = tap_changers.loc['TWT']
     assert 15 == twt_values.tap
@@ -958,7 +958,7 @@ def test_phase_tap_changers():
     n.update_ratio_tap_changers(id='TWT', regulating=False)
     n.update_phase_tap_changers(update)
     tap_changers = n.get_phase_tap_changers()
-    assert ['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+    assert ['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'oltc', 'regulating',
             'regulation_mode', 'regulation_value', 'target_deadband', 'regulating_bus_id'] == tap_changers.columns.tolist()
     twt_values = tap_changers.loc['TWT']
     assert 10 == twt_values.tap

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -889,18 +889,18 @@ def test_exception():
 def test_ratio_tap_changers():
     n = pp.network.create_eurostag_tutorial_example1_network()
     expected = pd.DataFrame(index=pd.Series(name='id', data=['NHV2_NLOAD']),
-                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load',
-                                     'regulating', 'target_v', 'target_deadband', 'regulating_bus_id'],
-                            data=[['', 1, nan, 0, 2, 3, True, True, 158.0, 0.0, 'VLLOAD_0']])
+                            columns=['side', 'tap', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+                                     'target_v', 'target_deadband', 'regulating_bus_id'],
+                            data=[['', 1, 0, 2, 3, True, True, 158.0, 0.0, 'VLLOAD_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)
     update = pd.DataFrame(index=['NHV2_NLOAD'],
                           columns=['tap', 'regulating', 'target_v'],
                           data=[[0, False, 180]])
     n.update_ratio_tap_changers(update)
     expected = pd.DataFrame(index=pd.Series(name='id', data=['NHV2_NLOAD']),
-                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load',
-                                     'regulating', 'target_v', 'target_deadband', 'regulating_bus_id'],
-                            data=[['', 0, nan, 0, 2, 3, True, False, 180.0, 0.0, 'VLLOAD_0']])
+                            columns=['side', 'tap', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+                                     'target_v', 'target_deadband', 'regulating_bus_id'],
+                            data=[['', 0, 0, 2, 3, True, False, 180.0, 0.0, 'VLLOAD_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)
 
 
@@ -909,11 +909,11 @@ def test_ratio_tap_changers_3_windings():
     expected = pd.DataFrame(index=pd.Series(name='id', data=['b94318f6-6d24-4f56-96b9-df2531ad6543',
                                                              'e482b89a-fa84-4ea9-8e70-a83d44790957',
                                                              '84ed55f4-61f5-4d9d-8755-bba7b877a246']),
-                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load',
-                                     'regulating', 'target_v', 'target_deadband', 'regulating_bus_id'],
-                            data=[['', 10, 10, 1, 25, 25, True, False, 0.0, 0.5, '8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0'],
-                                  ['', 14, 18, 1, 33, 33, True, True, 10.815, 0.5, '4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386_0'],
-                                  ['TWO', 17, 17, 1, 33, 33, True, False, 0.0, 0.5, 'b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c_0']])
+                            columns=['side', 'tap', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+                                     'target_v', 'target_deadband', 'regulating_bus_id'],
+                            data=[['', 10, 1, 25, 25, True, False, 0.0, 0.5, '8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0'],
+                                  ['', 14, 1, 33, 33, True, True, 10.815, 0.5, '4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386_0'],
+                                  ['TWO', 17, 1, 33, 33, True, False, 0.0, 0.5, 'b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)
 
     update = pd.DataFrame(index=pd.MultiIndex.from_tuples([('84ed55f4-61f5-4d9d-8755-bba7b877a246', 'TWO')],
@@ -925,11 +925,11 @@ def test_ratio_tap_changers_3_windings():
     expected = pd.DataFrame(index=pd.Series(name='id', data=['b94318f6-6d24-4f56-96b9-df2531ad6543',
                                                              'e482b89a-fa84-4ea9-8e70-a83d44790957',
                                                              '84ed55f4-61f5-4d9d-8755-bba7b877a246']),
-                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load',
-                                     'regulating', 'target_v', 'target_deadband', 'regulating_bus_id'],
-                            data=[['', 10, 10, 1, 25, 25, True, False, 0.0, 0.5, '8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0'],
-                                  ['', 14, 18, 1, 33, 33, True, True, 10.815, 0.5, '4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386_0'],
-                                  ['TWO', 9, 17, 1, 33, 33, True, True, 16.7, 0.5, 'b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c_0']])
+                            columns=['side', 'tap', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+                                     'target_v', 'target_deadband', 'regulating_bus_id'],
+                            data=[['', 10, 1, 25, 25, True, False, 0.0, 0.5, '8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0'],
+                                  ['', 14, 1, 33, 33, True, True, 10.815, 0.5, '4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386_0'],
+                                  ['TWO', 9, 1, 33, 33, True, True, 16.7, 0.5, 'b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)
 
     steps = n.get_ratio_tap_changer_steps()
@@ -945,7 +945,6 @@ def test_phase_tap_changers():
             'regulation_mode', 'regulation_value', 'target_deadband', 'regulating_bus_id'] == tap_changers.columns.tolist()
     twt_values = tap_changers.loc['TWT']
     assert 15 == twt_values.tap
-    assert pd.isna(twt_values.solved_tap_position)
     assert 0 == twt_values.low_tap
     assert 32 == twt_values.high_tap
     assert 33 == twt_values.step_count
@@ -1414,10 +1413,10 @@ def test_shunt():
     assert not df['fictitious']['SHUNT']
     expected = pd.DataFrame(index=pd.Series(name='id', data=['SHUNT']),
                             columns=['name', 'g', 'b', 'model_type', 'max_section_count', 'section_count',
-                                     'solved_section_count', 'voltage_regulation_on', 'target_v',
+                                     'voltage_regulation_on', 'target_v',
                                      'target_deadband', 'regulating_bus_id', 'p', 'q', 'i',
                                      'voltage_level_id', 'bus_id', 'connected'],
-                            data=[['', 0.0, -0.012, 'LINEAR', 1, 1, nan, False, nan, nan,
+                            data=[['', 0.0, -0.012, 'LINEAR', 1, 1, False, nan, nan,
                                    'S1VL2_0', nan, 1920, nan, 'S1VL2', 'S1VL2_0', True]])
     pd.testing.assert_frame_equal(expected, n.get_shunt_compensators(), check_dtype=False)
     n.update_shunt_compensators(
@@ -1431,10 +1430,10 @@ def test_shunt():
                      data=[[True]]))
     expected = pd.DataFrame(index=pd.Series(name='id', data=['SHUNT']),
                             columns=['name', 'g', 'b', 'model_type', 'max_section_count', 'section_count',
-                                     'solved_section_count', 'voltage_regulation_on', 'target_v',
+                                     'voltage_regulation_on', 'target_v',
                                      'target_deadband', 'regulating_bus_id', 'p', 'q', 'i',
                                      'voltage_level_id', 'bus_id', 'connected'],
-                            data=[['', 0.0, -0.0, 'LINEAR', 1, 0, nan, True, 50, 3,
+                            data=[['', 0.0, -0.0, 'LINEAR', 1, 0, True, 50, 3,
                                    '', nan, 1900, nan, 'S1VL2', '', False]])
     pd.testing.assert_frame_equal(expected, n.get_shunt_compensators(), check_dtype=False)
     shunts = n.get_shunt_compensators(attributes=['bus_breaker_bus_id', 'node'])

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -889,18 +889,18 @@ def test_exception():
 def test_ratio_tap_changers():
     n = pp.network.create_eurostag_tutorial_example1_network()
     expected = pd.DataFrame(index=pd.Series(name='id', data=['NHV2_NLOAD']),
-                            columns=['side', 'tap', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
-                                     'target_v', 'target_deadband', 'regulating_bus_id'],
-                            data=[['', 1, 0, 2, 3, True, True, 158.0, 0.0, 'VLLOAD_0']])
+                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load',
+                                     'regulating', 'target_v', 'target_deadband', 'regulating_bus_id'],
+                            data=[['', 1, nan, 0, 2, 3, True, True, 158.0, 0.0, 'VLLOAD_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)
     update = pd.DataFrame(index=['NHV2_NLOAD'],
                           columns=['tap', 'regulating', 'target_v'],
                           data=[[0, False, 180]])
     n.update_ratio_tap_changers(update)
     expected = pd.DataFrame(index=pd.Series(name='id', data=['NHV2_NLOAD']),
-                            columns=['side', 'tap', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
                                      'target_v', 'target_deadband', 'regulating_bus_id'],
-                            data=[['', 0, 0, 2, 3, True, False, 180.0, 0.0, 'VLLOAD_0']])
+                            data=[['', 0, nan, 0, 2, 3, True, False, 180.0, 0.0, 'VLLOAD_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)
 
 
@@ -909,11 +909,11 @@ def test_ratio_tap_changers_3_windings():
     expected = pd.DataFrame(index=pd.Series(name='id', data=['b94318f6-6d24-4f56-96b9-df2531ad6543',
                                                              'e482b89a-fa84-4ea9-8e70-a83d44790957',
                                                              '84ed55f4-61f5-4d9d-8755-bba7b877a246']),
-                            columns=['side', 'tap', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
                                      'target_v', 'target_deadband', 'regulating_bus_id'],
-                            data=[['', 10, 1, 25, 25, True, False, 0.0, 0.5, '8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0'],
-                                  ['', 14, 1, 33, 33, True, True, 10.815, 0.5, '4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386_0'],
-                                  ['TWO', 17, 1, 33, 33, True, False, 0.0, 0.5, 'b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c_0']])
+                            data=[['', 10, 10, 1, 25, 25, True, False, 0.0, 0.5, '8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0'],
+                                  ['', 14, 18, 1, 33, 33, True, True, 10.815, 0.5, '4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386_0'],
+                                  ['TWO', 17, 17, 1, 33, 33, True, False, 0.0, 0.5, 'b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)
 
     update = pd.DataFrame(index=pd.MultiIndex.from_tuples([('84ed55f4-61f5-4d9d-8755-bba7b877a246', 'TWO')],
@@ -925,11 +925,11 @@ def test_ratio_tap_changers_3_windings():
     expected = pd.DataFrame(index=pd.Series(name='id', data=['b94318f6-6d24-4f56-96b9-df2531ad6543',
                                                              'e482b89a-fa84-4ea9-8e70-a83d44790957',
                                                              '84ed55f4-61f5-4d9d-8755-bba7b877a246']),
-                            columns=['side', 'tap', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+                            columns=['side', 'tap', 'solved_tap_position' 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
                                      'target_v', 'target_deadband', 'regulating_bus_id'],
-                            data=[['', 10, 1, 25, 25, True, False, 0.0, 0.5, '8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0'],
-                                  ['', 14, 1, 33, 33, True, True, 10.815, 0.5, '4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386_0'],
-                                  ['TWO', 9, 1, 33, 33, True, True, 16.7, 0.5, 'b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c_0']])
+                            data=[['', 10, 10, 1, 25, 25, True, False, 0.0, 0.5, '8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0'],
+                                  ['', 14, 18, 1, 33, 33, True, True, 10.815, 0.5, '4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386_0'],
+                                  ['TWO', 9, 17, 1, 33, 33, True, True, 16.7, 0.5, 'b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)
 
     steps = n.get_ratio_tap_changer_steps()
@@ -1413,10 +1413,10 @@ def test_shunt():
     assert not df['fictitious']['SHUNT']
     expected = pd.DataFrame(index=pd.Series(name='id', data=['SHUNT']),
                             columns=['name', 'g', 'b', 'model_type', 'max_section_count', 'section_count',
-                                     'voltage_regulation_on', 'target_v',
+                                     'solved_section_count', 'voltage_regulation_on', 'target_v',
                                      'target_deadband', 'regulating_bus_id', 'p', 'q', 'i',
                                      'voltage_level_id', 'bus_id', 'connected'],
-                            data=[['', 0.0, -0.012, 'LINEAR', 1, 1, False, nan, nan,
+                            data=[['', 0.0, -0.012, 'LINEAR', 1, 1, nan, False, nan, nan,
                                    'S1VL2_0', nan, 1920, nan, 'S1VL2', 'S1VL2_0', True]])
     pd.testing.assert_frame_equal(expected, n.get_shunt_compensators(), check_dtype=False)
     n.update_shunt_compensators(
@@ -1430,10 +1430,10 @@ def test_shunt():
                      data=[[True]]))
     expected = pd.DataFrame(index=pd.Series(name='id', data=['SHUNT']),
                             columns=['name', 'g', 'b', 'model_type', 'max_section_count', 'section_count',
-                                     'voltage_regulation_on', 'target_v',
+                                     'solved_section_count', 'voltage_regulation_on', 'target_v',
                                      'target_deadband', 'regulating_bus_id', 'p', 'q', 'i',
                                      'voltage_level_id', 'bus_id', 'connected'],
-                            data=[['', 0.0, -0.0, 'LINEAR', 1, 0, True, 50, 3,
+                            data=[['', 0.0, -0.0, 'LINEAR', 1, 0, nan, True, 50, 3,
                                    '', nan, 1900, nan, 'S1VL2', '', False]])
     pd.testing.assert_frame_equal(expected, n.get_shunt_compensators(), check_dtype=False)
     shunts = n.get_shunt_compensators(attributes=['bus_breaker_bus_id', 'node'])

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -925,7 +925,7 @@ def test_ratio_tap_changers_3_windings():
     expected = pd.DataFrame(index=pd.Series(name='id', data=['b94318f6-6d24-4f56-96b9-df2531ad6543',
                                                              'e482b89a-fa84-4ea9-8e70-a83d44790957',
                                                              '84ed55f4-61f5-4d9d-8755-bba7b877a246']),
-                            columns=['side', 'tap', 'solved_tap_position' 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
                                      'target_v', 'target_deadband', 'regulating_bus_id'],
                             data=[['', 10, 10, 1, 25, 25, True, False, 0.0, 0.5, '8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0'],
                                   ['', 14, 18, 1, 33, 33, True, True, 10.815, 0.5, '4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386_0'],

--- a/tests/test_network_elements_creation.py
+++ b/tests/test_network_elements_creation.py
@@ -284,8 +284,8 @@ def test_voltage_levels_creation():
 def test_ratio_tap_changers_creation():
     n = pn.create_eurostag_tutorial_example1_network()
     rtc_df = dataframe_from_string("""
-id         target_deadband  target_v  on_load  low_tap  tap  regulating  regulated_side
-NGEN_NHV1                2       200     True        0    1        True             ONE
+id         target_deadband  target_v  oltc  low_tap  tap  regulating  regulated_side
+NGEN_NHV1                2       200  True        0    1        True             ONE
 """)
 
     steps_df = dataframe_from_string("""
@@ -299,7 +299,7 @@ NGEN_NHV1  2  2  1  1  0.5
     rtc = n.get_ratio_tap_changers(all_attributes=True).loc['NGEN_NHV1']
     assert rtc.target_deadband == 2
     assert rtc.target_v == 200
-    assert rtc.on_load
+    assert rtc.oltc
     assert rtc.low_tap == 0
     assert rtc.tap == 1
     assert rtc.regulating
@@ -1000,7 +1000,7 @@ def test_3_windings_transformers_creation():
     #Add ratio tap changer
     rtc_df = pd.DataFrame.from_records(
         index='id',
-        columns=['id', 'target_deadband', 'target_v', 'on_load', 'low_tap', 'tap', 'side'],
+        columns=['id', 'target_deadband', 'target_v', 'oltc', 'low_tap', 'tap', 'side'],
         data=[('TWT_TEST', 2, 200, False, 0, 1, 'ONE')])
     steps_df = pd.DataFrame.from_records(
         index='id',

--- a/tests/test_per_unit.py
+++ b/tests/test_per_unit.py
@@ -193,11 +193,10 @@ def test_shunt_compensators_per_unit():
     with pytest.warns(DeprecationWarning, match=re.escape("Per-unit view is deprecated and slow (make a deep copy of the network), use per unit mode of the network instead")):
         n = per_unit_view(n, 100)
     expected = pd.DataFrame(index=pd.Series(name='id', data=['SHUNT']),
-                            columns=['name', 'g', 'b', 'model_type', 'max_section_count', 'section_count',
+                            columns=['name', 'g', 'b', 'model_type', 'max_section_count', 'section_count', 'solved_section_count',
                                      'voltage_regulation_on', 'target_v', 'target_deadband', 'regulating_bus_id',
-                                     'p', 'q', 'i',
-                                     'voltage_level_id', 'bus_id', 'connected'],
-                            data=[['', 0, -19.2, 'LINEAR', 1, 1, False, nan, nan, 'S1VL2_0', nan, 19.2, nan, 'S1VL2',
+                                     'p', 'q', 'i', 'voltage_level_id', 'bus_id', 'connected'],
+                            data=[['', 0, -19.2, 'LINEAR', 1, 1, nan, False, nan, nan, 'S1VL2_0', nan, 19.2, nan, 'S1VL2',
                                    'S1VL2_0', True]])
     pd.testing.assert_frame_equal(expected, n.get_shunt_compensators(), check_dtype=False, atol=1e-2)
 
@@ -423,9 +422,9 @@ def test_ratio_tap_changers_per_unit():
     with pytest.warns(DeprecationWarning, match=re.escape("Per-unit view is deprecated and slow (make a deep copy of the network), use per unit mode of the network instead")):
         n = per_unit_view(n, 100)
     expected = pd.DataFrame(index=pd.Series(name='id', data=['NHV2_NLOAD']),
-                            columns=['side', 'tap', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
                                      'target_v', 'target_deadband', 'regulating_bus_id'],
-                            data=[['', 1, 0, 2, 3, True, True, 1.053, 0.0, 'VLLOAD_0']])
+                            data=[['', 1, nan, 0, 2, 3, True, True, 1.053, 0.0, 'VLLOAD_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)
 
 

--- a/tests/test_per_unit.py
+++ b/tests/test_per_unit.py
@@ -422,7 +422,7 @@ def test_ratio_tap_changers_per_unit():
     with pytest.warns(DeprecationWarning, match=re.escape("Per-unit view is deprecated and slow (make a deep copy of the network), use per unit mode of the network instead")):
         n = per_unit_view(n, 100)
     expected = pd.DataFrame(index=pd.Series(name='id', data=['NHV2_NLOAD']),
-                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'on_load', 'regulating',
+                            columns=['side', 'tap', 'solved_tap_position', 'low_tap', 'high_tap', 'step_count', 'oltc', 'regulating',
                                      'target_v', 'target_deadband', 'regulating_bus_id'],
                             data=[['', 1, nan, 0, 2, 3, True, True, 1.053, 0.0, 'VLLOAD_0']])
     pd.testing.assert_frame_equal(expected, n.get_ratio_tap_changers(), check_dtype=False, atol=1e-2)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #1031 
Add solved values for tap position of tap changers and section count of shunt/compensators, 'on_load' field for phase tap changer

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

- 'tap' Series in the phase and ratio tap changer dataframes are now only the input of the computation. The output of a loadflow for this property is now obtainable with the 'solved_tap_position' Series.
- 'on_load' Series in the ratio tap changers dataframe has been changed to 'oltc'. It now must be set to True to set 'regulating' to True
- Similarly, 'section_count' of shunt_compensators is now only the input, the output being 'solved_section_count'. 