### PR TITLE
Fix provider parameters for short-circuit

### DIFF
--- a/java/pypowsybl/src/main/java/com/powsybl/python/shortcircuit/ShortCircuitAnalysisCFunctions.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/python/shortcircuit/ShortCircuitAnalysisCFunctions.java
@@ -8,6 +8,7 @@
 package com.powsybl.python.shortcircuit;
 
 import com.powsybl.commons.PowsyblException;
+import com.powsybl.commons.parameters.Parameter;
 import com.powsybl.commons.report.ReportNode;
 import com.powsybl.dataframe.shortcircuit.adders.FaultDataframeAdder;
 import com.powsybl.dataframe.update.UpdatingDataframe;
@@ -132,17 +133,14 @@ public final class ShortCircuitAnalysisCFunctions {
         return paramsPtr;
     }
 
-    static List<String> getSpecificParametersNames(ShortCircuitAnalysisProvider provider) {
-        // currently, the short-circuit APIs do not have this method.
-        // there is a List<Parameter> getSpecificParameters(), but its semantic must be checked
-        return Collections.emptyList();
-    }
-
     @CEntryPoint(name = "getShortCircuitAnalysisProviderParametersNames")
-    public static PyPowsyblApiHeader.ArrayPointer<CCharPointerPointer> getProviderParametersNames(IsolateThread thread, CCharPointer provider, PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
+    public static PyPowsyblApiHeader.ArrayPointer<CCharPointerPointer> getProviderParametersNames(IsolateThread thread,
+                                                                                                  CCharPointer provider,
+                                                                                                  PyPowsyblApiHeader.ExceptionHandlerPointer exceptionHandlerPtr) {
         return doCatch(exceptionHandlerPtr, () -> {
             String providerStr = CTypeUtil.toString(provider);
-            return Util.createCharPtrArray(getSpecificParametersNames(ShortCircuitAnalysisCUtils.getShortCircuitAnalysisProvider(providerStr)));
+            return Util.createCharPtrArray(ShortCircuitAnalysisCUtils.getShortCircuitAnalysisProvider(providerStr)
+                    .getSpecificParameters().stream().map(Parameter::getName).collect(Collectors.toList()));
         });
     }
 

--- a/java/pypowsybl/src/main/java/com/powsybl/python/shortcircuit/ShortCircuitAnalysisCFunctions.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/python/shortcircuit/ShortCircuitAnalysisCFunctions.java
@@ -33,8 +33,6 @@ import org.graalvm.nativeimage.c.type.CCharPointerPointer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.powsybl.python.commons.Util.*;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix 


**What is the current behavior?**
<!-- You can also link to an open issue here -->
It was not possible to get the provider parameters names of short circuit providers, despite the method to get them being similar to those used for loadflow provider

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
