### PR TITLE
Temporarily remove arm64 macos builds

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -111,12 +111,12 @@ jobs:
             macosx_deployment_target: "10.16", # to ensure pip finds wheel when Big Sur is configured to return 10.16 as version instead of 11.0
             bdist_wheel_args: "--plat-name macosx-11.0-x86_64", # needed to avoid the wheel to be named -universal2
           }
-          - {
-            name: darwin-arm64,
-            os: macos-15,
-            macosx_deployment_target: "11", # first arm64 version of macosx
-            bdist_wheel_args: "--plat-name macosx-11.0-arm64", # needed to avoid the wheel to be named -universal2
-          }
+#          - {
+#            name: darwin-arm64,
+#            os: macos-15,
+#            macosx_deployment_target: "11", # first arm64 version of macosx
+#            bdist_wheel_args: "--plat-name macosx-11.0-arm64", # needed to avoid the wheel to be named -universal2
+#          }
           - {
             name: windows,
             os: windows-2022,

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -139,12 +139,12 @@ jobs:
             macosx_deployment_target: "10.16", # to ensure pip finds wheel when Big Sur is configured to return 10.16 as version instead of 11.0
             bdist_wheel_args: "--plat-name macosx-11.0-x86_64", # needed to avoid the wheel to be named -universal2
           }
-          - {
-            name: darwin-arm64,
-            os: macos-15,
-            macosx_deployment_target: "11", # first arm64 version of macosx
-            bdist_wheel_args: "--plat-name macosx-11.0-arm64", # needed to avoid the wheel to be named -universal2
-          }
+#          - {
+#            name: darwin-arm64,
+#            os: macos-15,
+#            macosx_deployment_target: "11", # first arm64 version of macosx
+#            bdist_wheel_args: "--plat-name macosx-11.0-arm64", # needed to avoid the wheel to be named -universal2
+#          }
           - {
             name: windows,
             os: windows-2022,

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -83,12 +83,12 @@ jobs:
             name: darwin,
             os: macos-13,
           }
-          - {
-            name: darwin-arm64,
-            os: macos-15,
-            macosx_deployment_target: "11", # first arm64 version of macosx
-            bdist_wheel_args: "--plat-name macosx-11.0-arm64", # needed to avoid the wheel to be named -universal2
-          }
+#          - {
+#            name: darwin-arm64,
+#            os: macos-15,
+#            macosx_deployment_target: "11", # first arm64 version of macosx
+#            bdist_wheel_args: "--plat-name macosx-11.0-arm64", # needed to avoid the wheel to be named -universal2
+#          }
           - {
             name: windows,
             os: windows-2022,

--- a/.github/workflows/snapshot-ci.yml
+++ b/.github/workflows/snapshot-ci.yml
@@ -23,7 +23,7 @@ jobs:
         config:
           - { name: ubuntu, os: ubuntu-22.04 }
           - { name: darwin, os: macos-13, macosx_deployment_target: "10.16", bdist_wheel_args: "--plat-name macosx-11.0-x86_64" }
-          - { name: darwin-arm64, os: macos-15, macosx_deployment_target: "11", bdist_wheel_args: "--plat-name macosx-11.0-arm64" }
+          #- { name: darwin-arm64, os: macos-15, macosx_deployment_target: "11", bdist_wheel_args: "--plat-name macosx-11.0-arm64" }
           - { name: windows, os: windows-2022 }
         python:
           - { name: cp39, version: '3.9' }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Temporarily removing the various macos arm64 builds, since the github runners for it have only 7GB of RAM and we are now reaching the limit.
A stable solution is being worked on to reintroduce the builds


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
