### PR TITLE
OpenRao - fix test_rao

### DIFF
--- a/docs/user_guide/rao.rst
+++ b/docs/user_guide/rao.rst
@@ -91,7 +91,7 @@ Remedial action results are also available in a pandas dataframe :
 
     >>> ra_results = rao_result.get_ra_results()
     >>> ra_results.columns
-    Index(['remedial_action_id', 'optimized_instant', 'contingency', 'activated',
+    Index(['remedial_action_id', 'optimized_instant', 'contingency',
            'optimized_tap', 'optimized_set_point'],
           dtype='object')
 

--- a/java/pypowsybl/src/main/java/com/powsybl/python/rao/RaoDataframes.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/python/rao/RaoDataframes.java
@@ -162,7 +162,7 @@ public final class RaoDataframes {
                 Optional<Contingency> contingencyOpt = state.getContingency();
                 // Only go through activated remedial actions
                 if (raoResult.isActivatedDuringState(state, ra)) {
-                    Pair<Double, Double> optimizedValues = getActivatedRangeAction(ra, state, raoResult);
+                    Pair<Double, Double> optimizedValues = getOptimizedRangeActionValues(ra, state, raoResult);
                     double optimizedTap = optimizedValues.getLeft();
                     double optimizedSetPoint = optimizedValues.getRight();
                     // Network actions will have optimizedTap and optimizedSetpoint set to NaN
@@ -180,7 +180,7 @@ public final class RaoDataframes {
         return results;
     }
 
-    private static Pair<Double, Double> getActivatedRangeAction(RemedialAction<?> ra, State state, RaoResult raoResult) {
+    private static Pair<Double, Double> getOptimizedRangeActionValues(RemedialAction<?> ra, State state, RaoResult raoResult) {
         double optimizedTap = Double.NaN; // Use a double for tap so we can set it to NaN when not relevant
         double optimizedSetPoint = Double.NaN;
         if (ra instanceof RangeAction<?> rangeAction) {

--- a/java/pypowsybl/src/main/java/com/powsybl/python/rao/RaoDataframes.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/python/rao/RaoDataframes.java
@@ -64,7 +64,7 @@ public final class RaoDataframes {
 
     public record VoltageCnecResult(String cnecId, Instant instant, String contingency, TwoSides side, double minVoltage, double maxVoltage, double margin) { }
 
-    public record ActivatedRemedialActionResult(String remedialActionId, Instant instant, String contingency, boolean activated, double optimizedTap, double optimizedSetPoint) { }
+    public record ActivatedRemedialActionResult(String remedialActionId, Instant instant, String contingency, double optimizedTap, double optimizedSetPoint) { }
 
     public record CostResult(Instant instant, double functionalCost, double virtualCost, double cost) { }
 
@@ -159,22 +159,27 @@ public final class RaoDataframes {
                 Optional<Contingency> contingencyOpt = state.getContingency();
                 double optimizedTap = Double.NaN; // Use a double for tap so we can set it to NaN when not relevant
                 double optimizedSetPoint = Double.NaN;
-                if (ra instanceof RangeAction<?> rangeAction) {
-                    if (rangeAction instanceof PstRangeAction pstRangeAction) {
-                        optimizedTap = raoResult.getOptimizedTapOnState(state, pstRangeAction);
-                    } else {
-                        optimizedSetPoint = raoResult.getOptimizedSetPointOnState(state, rangeAction);
+                // Only go through activated remedial actions
+                if (raoResult.isActivatedDuringState(state, ra)) {
+                    if (ra instanceof RangeAction<?> rangeAction) {
+                        // Pst range actions will have optimizedSetpoint set to NaN
+                        if (rangeAction instanceof PstRangeAction pstRangeAction) {
+                            optimizedTap = raoResult.getOptimizedTapOnState(state, pstRangeAction);
+                        // Other than Pst range actions will have optimizedTap set to NaN
+                        } else {
+                            optimizedSetPoint = raoResult.getOptimizedSetPointOnState(state, rangeAction);
+                        }
                     }
+                    // Network actions will have optimizedTap and optimizedSetpoint set to NaN
+                    ActivatedRemedialActionResult result = new ActivatedRemedialActionResult(
+                        ra.getId(),
+                        state.getInstant(),
+                        contingencyOpt.isPresent() ? contingencyOpt.get().getId() : "",
+                        optimizedTap,
+                        optimizedSetPoint
+                    );
+                    results.add(result);
                 }
-                ActivatedRemedialActionResult result = new ActivatedRemedialActionResult(
-                    ra.getId(),
-                    state.getInstant(),
-                    contingencyOpt.isPresent() ? contingencyOpt.get().getId() : "",
-                    raoResult.isActivatedDuringState(state, ra),
-                    optimizedTap,
-                    optimizedSetPoint
-                );
-                results.add(result);
             }
         }
         return results;
@@ -266,7 +271,6 @@ public final class RaoDataframes {
             .strings("remedial_action_id", ActivatedRemedialActionResult::remedialActionId)
             .strings(OPTIMIZED_INSTANT, r -> r.instant() != null ? r.instant().getId() : INITIAL_INSTANT)
             .strings(CONTINGENCY, ActivatedRemedialActionResult::contingency)
-            .booleans("activated", ActivatedRemedialActionResult::activated)
             .doubles("optimized_tap", ActivatedRemedialActionResult::optimizedTap)
             .doubles("optimized_set_point", ActivatedRemedialActionResult::optimizedSetPoint)
             .build();

--- a/tests/test_rao.py
+++ b/tests/test_rao.py
@@ -235,14 +235,11 @@ def test_rao_ra_results():
     # Ra results
     ra_results = result.get_ra_results()
     ra_results = ra_results.sort_values(['remedial_action_id', 'optimized_instant'], ascending=[True, True]) # Sort to avoid row order difference
-    assert ['remedial_action_id', 'optimized_instant', 'contingency', 'activated', 'optimized_tap', 'optimized_set_point'] == list(ra_results.columns)
-    expected = pd.DataFrame(columns=['remedial_action_id', 'optimized_instant', 'contingency', 'activated', 'optimized_tap', 'optimized_set_point'],
-                            data=[['close NL2 BE3 2', 'outage', "Contingency DE2 DE3", False, nan, nan],
-                                  ['close NL2 BE3 2', 'curative', "Contingency DE2 DE3", False, nan, nan],
-                                  ['close NL2 BE3 2', 'preventive', "", True, nan, nan],
-                                  ['pst-range-action', 'outage', "Contingency DE2 DE3", False, -10, nan],
-                                  ['pst-range-action', 'curative', "Contingency DE2 DE3", True, 6, nan],
-                                  ['pst-range-action', 'preventive', "", True, -10, nan]])
+    assert ['remedial_action_id', 'optimized_instant', 'contingency', 'optimized_tap', 'optimized_set_point'] == list(ra_results.columns)
+    expected = pd.DataFrame(columns=['remedial_action_id', 'optimized_instant', 'contingency', 'optimized_tap', 'optimized_set_point'],
+                            data=[['close NL2 BE3 2', 'preventive', "", nan, nan],
+                                  ['pst-range-action', 'curative', "Contingency DE2 DE3", 6, nan],
+                                  ['pst-range-action', 'preventive', "", -10, nan]])
     expected = expected.sort_values(['remedial_action_id', 'optimized_instant'], ascending=[True, True]) # Sort to avoid row order difference
     pd.testing.assert_frame_equal(expected.reset_index(drop=True), ra_results.reset_index(drop=True), check_dtype=False, check_index_type=False, check_like=True)
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
fixs test_Rao::test_rao_ra_results NullPtrException



**What is the current behavior?**
getOptimizedTap and getOptimizedSetpoint are called by RaoDataframes::getActivatedRemedialActions on all remedial actions; they should only be called on activated remedial actions



**What is the new behavior (if this is a feature change)?**
only gather setpoint/tap information on activated remedial actions
delete "activated" attribute from ActivatedRemedialActionResult object


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
