### PR TITLE
Adding static var compensator extension

### DIFF
--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/extensions/VoltagePerReactivePowerControlDataframeAdder.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/extensions/VoltagePerReactivePowerControlDataframeAdder.java
@@ -1,0 +1,60 @@
+package com.powsybl.dataframe.network.extensions;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.dataframe.SeriesMetadata;
+import com.powsybl.dataframe.network.adders.AbstractSimpleAdder;
+import com.powsybl.dataframe.network.adders.SeriesUtils;
+import com.powsybl.dataframe.update.DoubleSeries;
+import com.powsybl.dataframe.update.StringSeries;
+import com.powsybl.dataframe.update.UpdatingDataframe;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.StaticVarCompensator;
+import com.powsybl.iidm.network.extensions.VoltagePerReactivePowerControlAdder;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Hugo Kulesza {@literal <hugo.kulesza at rte-france.com>}
+ */
+public class VoltagePerReactivePowerControlDataframeAdder extends AbstractSimpleAdder {
+
+    private static final List<SeriesMetadata> METADATA = List.of(
+            SeriesMetadata.stringIndex("id"),
+            SeriesMetadata.doubles("slope")
+    );
+
+    @Override
+    public List<List<SeriesMetadata>> getMetadata() {
+        return Collections.singletonList(METADATA);
+    }
+
+    private static class VoltagePerReactivePowerControlSeries {
+        private final StringSeries id;
+        private final DoubleSeries slope;
+
+        VoltagePerReactivePowerControlSeries(UpdatingDataframe dataframe) {
+            this.id = dataframe.getStrings("id");
+            this.slope = dataframe.getDoubles("slope");
+        }
+
+        void create(Network network, int row) {
+            String id = this.id.get(row);
+            StaticVarCompensator svc = network.getStaticVarCompensator(id);
+            if (svc == null) {
+                throw new PowsyblException("Invalid static var compensator id : could not find " + id);
+            }
+            VoltagePerReactivePowerControlAdder adder = svc.newExtension(VoltagePerReactivePowerControlAdder.class);
+            SeriesUtils.applyIfPresent(slope, row, adder::withSlope);
+            adder.add();
+        }
+    }
+
+    @Override
+    public void addElements(Network network, UpdatingDataframe dataframe) {
+        VoltagePerReactivePowerControlSeries series = new VoltagePerReactivePowerControlSeries(dataframe);
+        for (int row = 0; row < dataframe.getRowCount(); row++) {
+            series.create(network, row);
+        }
+    }
+}

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/extensions/VoltagePerReactivePowerControlDataframeAdder.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/extensions/VoltagePerReactivePowerControlDataframeAdder.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
 package com.powsybl.dataframe.network.extensions;
 
 import com.powsybl.commons.PowsyblException;

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/extensions/VoltagePerReactivePowerControlDataframeProvider.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/extensions/VoltagePerReactivePowerControlDataframeProvider.java
@@ -1,0 +1,73 @@
+package com.powsybl.dataframe.network.extensions;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.dataframe.network.ExtensionInformation;
+import com.powsybl.dataframe.network.NetworkDataframeMapper;
+import com.powsybl.dataframe.network.NetworkDataframeMapperBuilder;
+import com.powsybl.dataframe.network.adders.NetworkElementAdder;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.StaticVarCompensator;
+import com.powsybl.iidm.network.extensions.VoltagePerReactivePowerControl;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * @author Hugo Kulesza {@literal <hugo.kulesza at rte-france.com>}
+ */
+@AutoService(NetworkExtensionDataframeProvider.class)
+public class VoltagePerReactivePowerControlDataframeProvider extends AbstractSingleDataframeNetworkExtension {
+    @Override
+    public String getExtensionName() {
+        return VoltagePerReactivePowerControl.NAME;
+    }
+
+    @Override
+    public ExtensionInformation getExtensionInformation() {
+        return new ExtensionInformation(VoltagePerReactivePowerControl.NAME,
+                "Models the voltage control static var compensators",
+                "index : id (str), slope (float)");
+    }
+
+    private Stream<VoltagePerReactivePowerControl> itemsStream(Network network) {
+        return network.getStaticVarCompensatorStream()
+                .map(svc -> (VoltagePerReactivePowerControl) svc.getExtension(VoltagePerReactivePowerControl.class))
+                .filter(Objects::nonNull);
+    }
+
+    private VoltagePerReactivePowerControl getOrThrow(Network network, String id) {
+        StaticVarCompensator svc = network.getStaticVarCompensator(id);
+        if (svc == null) {
+            throw new PowsyblException("Static var compensator '" + id + "' not found");
+        }
+        VoltagePerReactivePowerControl ext = svc.getExtension(VoltagePerReactivePowerControl.class);
+        if (ext == null) {
+            throw new PowsyblException("Static var compensator '" + id + "' has no VoltagePerReactivePowerControl extension");
+        }
+        return ext;
+    }
+
+    @Override
+    public NetworkDataframeMapper createMapper() {
+        return NetworkDataframeMapperBuilder.ofStream(this::itemsStream, this::getOrThrow)
+                .stringsIndex("id", ext -> ext.getExtendable().getId())
+                .doubles("slope", VoltagePerReactivePowerControl::getSlope, (ext, val, context) -> ext.setSlope(val))
+                .build();
+    }
+
+    @Override
+    public void removeExtensions(Network network, List<String> ids) {
+        ids.stream().filter(Objects::nonNull)
+                .map(network::getStaticVarCompensator)
+                .filter(Objects::nonNull)
+                .forEach(svc -> svc.removeExtension(VoltagePerReactivePowerControl.class));
+    }
+
+    @Override
+    public NetworkElementAdder createAdder() {
+        return new VoltagePerReactivePowerControlDataframeAdder();
+    }
+
+}

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/extensions/VoltagePerReactivePowerControlDataframeProvider.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/extensions/VoltagePerReactivePowerControlDataframeProvider.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
 package com.powsybl.dataframe.network.extensions;
 
 import com.google.auto.service.AutoService;

--- a/tests/test_network_extensions.py
+++ b/tests/test_network_extensions.py
@@ -541,6 +541,30 @@ def test_reference_priorities():
     assert network.get_extensions('referencePriorities').empty
 
 
+def test_voltage_per_reactive_power_control():
+    network = pn.create_four_substations_node_breaker_network()
+    assert network.get_extensions('voltagePerReactivePowerControl').empty
+
+    network.create_extensions('voltagePerReactivePowerControl', id="SVC", slope=0.5)
+    e = network.get_extensions('voltagePerReactivePowerControl')
+    expected = pd.DataFrame(
+        index=pd.Series(name='id', data=['SVC']),
+        columns=['slope'],
+        data=[[0.5]])
+    pd.testing.assert_frame_equal(expected, e, check_dtype=False)
+
+    network.update_extensions('voltagePerReactivePowerControl', id="SVC", slope=0.8)
+    e = network.get_extensions('voltagePerReactivePowerControl')
+    expected = pd.DataFrame(
+        index=pd.Series(name='id', data=['SVC']),
+        columns=['slope'],
+        data=[[0.8]])
+    pd.testing.assert_frame_equal(expected, e, check_dtype=False)
+
+    network.remove_extensions('voltagePerReactivePowerControl', ids="SVC")
+    assert network.get_extensions('voltagePerReactivePowerControl').empty
+
+
 def test_get_extensions_information():
     extensions_information = pypowsybl.network.get_extensions_information()
     assert extensions_information.loc['cgmesMetadataModels']['detail'] == 'Provides information about CGMES metadata models'
@@ -588,3 +612,5 @@ def test_get_extensions_information():
     assert extensions_information.loc['linePosition']['attributes'] == 'index : id (str), num (int), latitude (float), longitude (float)'
     assert extensions_information.loc['referencePriorities']['detail'] == 'Defines the angle reference generator, busbar section or load of a power flow calculation, i.e. which bus will be used with a zero-voltage angle.'
     assert extensions_information.loc['referencePriorities']['attributes'] == 'index : id (str), priority (int)'
+    assert extensions_information.loc['voltagePerReactivePowerControl']['detail'] == 'Models the voltage control static var compensators'
+    assert extensions_information.loc['voltagePerReactivePowerControl']['attributes'] == 'index : id (str), slope (float)'


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**
The java extension VoltagePerReactivePowerControl is now accessible in python (to add, update, and remove) 


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No