### PR TITLE
Perform round trip on RAO result

### DIFF
--- a/tests/test_rao.py
+++ b/tests/test_rao.py
@@ -209,8 +209,8 @@ def test_rao_cnec_results():
     nl_be_cnec_side1 = nl_be_cnec.loc[nl_be_cnec['side'] == 'ONE'][['cnec_id', 'optimized_instant', 'flow', 'margin']]
     nl_be_cnec_side1 = nl_be_cnec_side1.sort_values(['optimized_instant'], ascending=[True])
     expected = pd.DataFrame(columns=['cnec_id', 'optimized_instant', 'flow', 'margin'],
-                            data=[['NNL2AA1  BBE3AA1  1 - preventive', 'initial', 499.996955, -89.996955],
-                                  ['NNL2AA1  BBE3AA1  1 - preventive', 'preventive', 211.496250, 198.503750]])
+                            data=[['NNL2AA1  BBE3AA1  1 - preventive', 'initial', 500.0, -90.0],
+                                  ['NNL2AA1  BBE3AA1  1 - preventive', 'preventive', 211.5, 198.50]])
     expected = expected.sort_values(['optimized_instant'], ascending=[True])
     pd.testing.assert_frame_equal(expected.reset_index(drop=True), nl_be_cnec_side1.reset_index(drop=True), check_dtype=False, check_index_type=False, check_like=True)
 
@@ -258,10 +258,10 @@ def test_rao_cost_results():
     assert ['functional_cost', 'virtual_cost', 'cost'] == list(cost_results_df.columns)
     expected = pd.DataFrame(index=pd.Series(name='optimized_instant', data=['initial', 'preventive', 'outage', 'curative']),
                             columns=['functional_cost', 'virtual_cost', 'cost'],
-                            data=[[133.304310, 0.0, 133.304310],
-                                  [237.646702, 0.0, 237.646702],
-                                  [237.646702, 0.0, 237.646702],
-                                  [-187.219238, 0.0, -187.219238]])
+                            data=[[133.3, 0.0, 133.3],
+                                  [237.65, 0.0, 237.65],
+                                  [237.65, 0.0, 237.65],
+                                  [-187.22, 0.0, -187.22]])
     pd.testing.assert_frame_equal(expected, cost_results_df, check_dtype=False, check_like=True)
 
     assert ['sensitivity-failure-cost'] == result.get_virtual_cost_names()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
When running a RAO, if only the preventive state was optimized, a [OneStateOnlyRaoResultImpl](https://github.com/powsybl/powsybl-open-rao/blob/main/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/OneStateOnlyRaoResultImpl.java) object is returned by OpenRAO. When calling `get_ra_results`, if curative RAs are defined in the CRAC, an exception is thrown because results based on curative state a queried whereas the RAO Result only supports preventive results.

Running a round trip on the RAO result forces the RAO to export a [RaoResultImpl](https://github.com/powsybl/powsybl-open-rao/blob/main/data/rao-result/rao-result-impl/src/main/java/com/powsybl/openrao/data/raoresult/impl/RaoResultImpl.java) object all the time which fixes the issue.


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
