### PR TITLE
Force RAO implementation to "SearchTreeRao"

### DIFF
--- a/java/pypowsybl/src/main/java/com/powsybl/python/rao/RaoContext.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/python/rao/RaoContext.java
@@ -50,7 +50,7 @@ public class RaoContext {
         if (glsks != null) {
             inputBuilder.withGlskProvider(glsks.getZonalGlsks(network));
         }
-        return Rao.run(inputBuilder.build(), parameters);
+        return Rao.find("SearchTreeRao").run(inputBuilder.build(), parameters);
     }
 
     public RaoResultWithVoltageMonitoring runVoltageMonitoring(Network network, RaoResult resultIn, String provider, LoadFlowParameters parameters) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
In OpenRAO's next release, a new RAO implementation called "FastRao" will be available. Currently, we load the default implementation which is "SearchTreeRao". However, with the two implementations, we get the following error:

```
Several RAO implementations found ([SearchTreeRao, FastRao]), you must add configuration to select the implementation
```

FastRAO will possibly be included in future PyPowSyBl versions. In the meantime, we force the RAO implementation to "SearchTreeRao" to avoid issues.

**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
