### PR TITLE
adds missing EdgeInfoMetadata in NAD's reflect-config

### DIFF
--- a/java/pypowsybl/src/main/resources/META-INF/native-image/com.powsybl/powsybl-network-area-diagram/reflect-config.json
+++ b/java/pypowsybl/src/main/resources/META-INF/native-image/com.powsybl/powsybl-network-area-diagram/reflect-config.json
@@ -24,6 +24,12 @@
     "allDeclaredConstructors":true
   },
   {
+    "name":"com.powsybl.nad.svg.metadata.EdgeInfoMetadata",
+    "allDeclaredFields":true,
+    "allDeclaredMethods":true,
+    "allDeclaredConstructors":true
+  },
+  {
     "name":"com.powsybl.nad.svg.metadata.EdgeMetadata",
     "allDeclaredFields":true,
     "allDeclaredMethods":true,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

bug fix

**What is the current behavior?**
<!-- You can also link to an open issue here -->

Edges' edgeInfo1 and  edgeInfo2 are always empty, in the NAD metadata


**What is the new behavior (if this is a feature change)?**

edgeInfo1 and  edgeInfo2 are correctly inserted in the metadata

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
