### PR TITLE
Fix Grid2op element order issue after cloning

### DIFF
--- a/tests/test_grid2op.py
+++ b/tests/test_grid2op.py
@@ -31,13 +31,13 @@ def test_backend():
         npt.assert_array_equal(np.array(['LOAD']), backend.get_string_value(grid2op.StringValueType.LOAD_NAME))
         npt.assert_array_equal(np.array(['GEN', 'GEN2']), backend.get_string_value(grid2op.StringValueType.GENERATOR_NAME))
         npt.assert_array_equal(np.array([]), backend.get_string_value(grid2op.StringValueType.SHUNT_NAME))
-        npt.assert_array_equal(np.array(['NHV1_NHV2_1', 'NHV1_NHV2_2', 'NGEN_NHV1', 'NHV2_NLOAD']), backend.get_string_value(grid2op.StringValueType.BRANCH_NAME))
+        npt.assert_array_equal(np.array(['NGEN_NHV1', 'NHV1_NHV2_1', 'NHV1_NHV2_2', 'NHV2_NLOAD']), backend.get_string_value(grid2op.StringValueType.BRANCH_NAME))
 
         npt.assert_array_equal(np.array([3]), backend.get_integer_value(grid2op.IntegerValueType.LOAD_VOLTAGE_LEVEL_NUM))
         npt.assert_array_equal(np.array([0, 0]), backend.get_integer_value(grid2op.IntegerValueType.GENERATOR_VOLTAGE_LEVEL_NUM))
         npt.assert_array_equal(np.array([]), backend.get_integer_value(grid2op.IntegerValueType.SHUNT_VOLTAGE_LEVEL_NUM))
-        npt.assert_array_equal(np.array([1, 1, 0, 2]), backend.get_integer_value(grid2op.IntegerValueType.BRANCH_VOLTAGE_LEVEL_NUM_1))
-        npt.assert_array_equal(np.array([2, 2, 1, 3]), backend.get_integer_value(grid2op.IntegerValueType.BRANCH_VOLTAGE_LEVEL_NUM_2))
+        npt.assert_array_equal(np.array([0, 1, 1, 2]), backend.get_integer_value(grid2op.IntegerValueType.BRANCH_VOLTAGE_LEVEL_NUM_1))
+        npt.assert_array_equal(np.array([1, 2, 2, 3]), backend.get_integer_value(grid2op.IntegerValueType.BRANCH_VOLTAGE_LEVEL_NUM_2))
 
         npt.assert_allclose(np.array([600.0]), backend.get_double_value(grid2op.DoubleValueType.LOAD_P), rtol=TOLERANCE, atol=TOLERANCE)
         npt.assert_allclose(np.array([200.0]), backend.get_double_value(grid2op.DoubleValueType.LOAD_Q), rtol=TOLERANCE, atol=TOLERANCE)
@@ -54,23 +54,23 @@ def test_backend():
         npt.assert_allclose(np.array([]), backend.get_double_value(grid2op.DoubleValueType.SHUNT_V), rtol=TOLERANCE, atol=TOLERANCE)
         npt.assert_allclose(np.array([]), backend.get_double_value(grid2op.DoubleValueType.SHUNT_ANGLE), rtol=TOLERANCE, atol=TOLERANCE)
 
-        npt.assert_allclose(np.array([302.444, 302.444, 605.561, 600.867]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_P1), rtol=TOLERANCE, atol=TOLERANCE)
-        npt.assert_allclose(np.array([-300.433, -300.433, -604.893, -600.]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_P2), rtol=TOLERANCE, atol=TOLERANCE)
-        npt.assert_allclose(np.array([98.74, 98.74, 225.282, 274.376]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_Q1), rtol=TOLERANCE, atol=TOLERANCE)
-        npt.assert_allclose(np.array([-137.188, -137.188, -197.48, -200.0]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_Q2), rtol=TOLERANCE, atol=TOLERANCE)
-        npt.assert_allclose(np.array([402.142, 402.142, 24.5, 389.952]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_V1), rtol=TOLERANCE, atol=TOLERANCE)
-        npt.assert_allclose(np.array([389.952, 389.952, 402.142, 147.578]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_V2), rtol=TOLERANCE, atol=TOLERANCE)
-        npt.assert_allclose(np.array([0.0,  0.0, 0.040596, -0.061197]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_ANGLE1), rtol=TOLERANCE, atol=TOLERANCE)
-        npt.assert_allclose(np.array([-0.061197, -0.061197, 0.0, -0.167804]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_ANGLE2), rtol=TOLERANCE, atol=TOLERANCE)
-        npt.assert_allclose(np.array([456.768, 456.768, 15225.756, 977.985]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_I1), rtol=TOLERANCE, atol=TOLERANCE)
-        npt.assert_allclose(np.array([488.992, 488.992, 913.545, 2474.263]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_I2), rtol=TOLERANCE, atol=TOLERANCE)
+        npt.assert_allclose(np.array([605.561, 302.444, 302.444, 600.867]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_P1), rtol=TOLERANCE, atol=TOLERANCE)
+        npt.assert_allclose(np.array([-604.893, -300.433, -300.433, -600.]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_P2), rtol=TOLERANCE, atol=TOLERANCE)
+        npt.assert_allclose(np.array([225.282, 98.74, 98.74, 274.376]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_Q1), rtol=TOLERANCE, atol=TOLERANCE)
+        npt.assert_allclose(np.array([-197.48, -137.188, -137.188, -200.0]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_Q2), rtol=TOLERANCE, atol=TOLERANCE)
+        npt.assert_allclose(np.array([24.5, 402.142, 402.142, 389.952]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_V1), rtol=TOLERANCE, atol=TOLERANCE)
+        npt.assert_allclose(np.array([402.142, 389.952, 389.952, 147.578]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_V2), rtol=TOLERANCE, atol=TOLERANCE)
+        npt.assert_allclose(np.array([0.040596, 0.0,  0.0, -0.061197]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_ANGLE1), rtol=TOLERANCE, atol=TOLERANCE)
+        npt.assert_allclose(np.array([0.0, -0.061197, -0.061197, -0.167804]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_ANGLE2), rtol=TOLERANCE, atol=TOLERANCE)
+        npt.assert_allclose(np.array([15225.756, 456.768, 456.768, 977.985]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_I1), rtol=TOLERANCE, atol=TOLERANCE)
+        npt.assert_allclose(np.array([913.545, 488.992, 488.992, 2474.263]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_I2), rtol=TOLERANCE, atol=TOLERANCE)
 
         npt.assert_array_equal(np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]), backend.get_integer_value(grid2op.IntegerValueType.TOPO_VECT))
 
         backend.update_double_value(grid2op.UpdateDoubleValueType.UPDATE_LOAD_P, np.array([630]), np.array([True]))
         npt.assert_allclose(np.array([630.0]), backend.get_double_value(grid2op.DoubleValueType.LOAD_P), rtol=TOLERANCE, atol=TOLERANCE)
         backend.run_pf()
-        npt.assert_allclose(np.array([317.697, 317.697, 636.14, 630.954]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_P1), rtol=TOLERANCE, atol=TOLERANCE)
+        npt.assert_allclose(np.array([636.14, 317.697, 317.697, 630.954]), backend.get_double_value(grid2op.DoubleValueType.BRANCH_P1), rtol=TOLERANCE, atol=TOLERANCE)
 
         backend.update_double_value(grid2op.UpdateDoubleValueType.UPDATE_LOAD_P, np.array([640]), np.array([False]))
         npt.assert_allclose(np.array([630.0]), backend.get_double_value(grid2op.DoubleValueType.LOAD_P), rtol=TOLERANCE, atol=TOLERANCE)
@@ -81,7 +81,7 @@ def test_backend():
         backend.update_integer_value(grid2op.UpdateIntegerValueType.UPDATE_GENERATOR_BUS, np.array([2, -1]), np.array([True, True]))
         npt.assert_array_equal(np.array([2, -1, 1, 1, 1, 1, 1, 1, 1, -1, 1]), backend.get_integer_value(grid2op.IntegerValueType.TOPO_VECT))
 
-        npt.assert_allclose(np.array([500.0, 1100.0, 999999.0, 999999.0]),
+        npt.assert_allclose(np.array([999999.0, 500.0, 1100.0, 999999.0]),
                             backend.get_double_value(grid2op.DoubleValueType.BRANCH_PERMANENT_LIMIT_A), rtol=TOLERANCE, atol=TOLERANCE)
 
 
@@ -94,7 +94,7 @@ def test_backend_ieee14():
         npt.assert_allclose(np.array([-21.184]), backend.get_double_value(grid2op.DoubleValueType.SHUNT_Q), rtol=TOLERANCE, atol=TOLERANCE)
         npt.assert_allclose(np.array([12.671]), backend.get_double_value(grid2op.DoubleValueType.SHUNT_V), rtol=TOLERANCE, atol=TOLERANCE)
         npt.assert_allclose(np.array([-0.260726]), backend.get_double_value(grid2op.DoubleValueType.SHUNT_ANGLE), rtol=TOLERANCE, atol=TOLERANCE)
-        npt.assert_allclose(np.array([141.075, 136.35, 137.385, 137.634, 12.84, 12.671,  12.611,  12.682,  12.662, 12.604, 12.426]), backend.get_double_value(grid2op.DoubleValueType.LOAD_V), rtol=TOLERANCE, atol=TOLERANCE)
+        npt.assert_allclose(np.array([12.611, 12.682, 12.662, 12.604, 12.426, 141.075, 136.35, 137.385, 137.634, 12.84, 12.671]), backend.get_double_value(grid2op.DoubleValueType.LOAD_V), rtol=TOLERANCE, atol=TOLERANCE)
 
         backend.update_integer_value(grid2op.UpdateIntegerValueType.UPDATE_SHUNT_BUS, np.array([-1]), np.array([True]))
         npt.assert_allclose(np.array([-1]), backend.get_integer_value(grid2op.IntegerValueType.SHUNT_LOCAL_BUS))
@@ -102,7 +102,7 @@ def test_backend_ieee14():
         npt.assert_allclose(np.array([0.0]), backend.get_double_value(grid2op.DoubleValueType.SHUNT_Q), rtol=TOLERANCE, atol=TOLERANCE)
         npt.assert_allclose(np.array([0.0]), backend.get_double_value(grid2op.DoubleValueType.SHUNT_V), rtol=TOLERANCE, atol=TOLERANCE)
         npt.assert_allclose(np.array([0.0]), backend.get_double_value(grid2op.DoubleValueType.SHUNT_ANGLE), rtol=TOLERANCE, atol=TOLERANCE)
-        npt.assert_allclose(np.array([141.075, 136.35, 136.9, 137.313, 12.84, 12.398, 12.385, 12.567, 12.641, 12.564, 12.252]), backend.get_double_value(grid2op.DoubleValueType.LOAD_V), rtol=TOLERANCE, atol=TOLERANCE)
+        npt.assert_allclose(np.array([12.385, 12.567, 12.641, 12.564, 12.252, 141.075, 136.35, 136.9, 137.313, 12.84, 12.398]), backend.get_double_value(grid2op.DoubleValueType.LOAD_V), rtol=TOLERANCE, atol=TOLERANCE)
 
 
 def test_backend_copy():
@@ -128,15 +128,15 @@ def test_backend_disconnection_issue():
     with grid2op.Backend(n, check_isolated_and_disconnected_injections=False) as backend:
         npt.assert_array_equal(np.array([1] * 56), # all is connected to bus 1
                                backend.get_integer_value(grid2op.IntegerValueType.TOPO_VECT))
-        npt.assert_array_equal(np.array(['L1-2-1', 'L1-5-1', 'L2-3-1', 'L2-4-1', 'L2-5-1', 'L3-4-1', 'L4-5-1', 'L6-11-1', 'L6-12-1', 'L6-13-1', 'L7-8-1', 'L7-9-1', 'L9-10-1', 'L9-14-1', 'L10-11-1', 'L12-13-1', 'L13-14-1', 'T4-7-1', 'T4-9-1', 'T5-6-1']),
+        npt.assert_array_equal(np.array(['L1-2-1', 'L1-5-1', 'L10-11-1', 'L12-13-1', 'L13-14-1', 'L2-3-1', 'L2-4-1', 'L2-5-1', 'L3-4-1', 'L4-5-1', 'L6-11-1', 'L6-12-1', 'L6-13-1', 'L7-8-1', 'L7-9-1', 'L9-10-1', 'L9-14-1', 'T4-7-1', 'T4-9-1', 'T5-6-1']),
                                backend.get_string_value(grid2op.StringValueType.BRANCH_NAME))
         # disconnect L7-8-1
         backend.update_integer_value(grid2op.UpdateIntegerValueType.UPDATE_BRANCH_BUS1, np.array([1] * 10 + [-1] + [1] * 9), np.array([False] * 10 + [True] + [False] * 9))
         backend.update_integer_value(grid2op.UpdateIntegerValueType.UPDATE_BRANCH_BUS2, np.array([1] * 10 + [-1] + [1] * 9), np.array([False] * 10 + [True] + [False] * 9))
         backend.run_pf()
         # we can see than L7-8-1 is disconnected at both side but also generator at bus 8
-        npt.assert_array_equal(np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-                                         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, -1, 1, 1, -1,
-                                         -1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-                                         1, 1, 1, 1, 1]),
+        npt.assert_array_equal(np.array([1,  1,  1,  1,  1,  1,  1,  1, -1,  1,  1,  1,  1,  1,  1,  1,  1,
+                                         1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+                                         1,  1,  1,  1,  1,  1,  1,  1, -1,  1,  1,  1,  1,  1,  1,  1,  1,
+                                         1,  1,  1,  1,  1]),
                                backend.get_integer_value(grid2op.IntegerValueType.TOPO_VECT))


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When cloning the backend we sometimes have an issue with elements not in the same order in the clone that in the original grid (because of node/breaker to bus/breaker voltage level conversion). It is responsible for serious Grid2op issue with incorrect data (like flows) associated to an element.


**What is the new behavior (if this is a feature change)?**
We always sort elements before creating grid2op vectors.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
