### PR TITLE
Split reduce method in 3 by usage

### DIFF
--- a/docs/reference/network.rst
+++ b/docs/reference/network.rst
@@ -281,6 +281,9 @@ Miscellaneous network functions
    :nosignatures:
 
    Network.reduce
+   Network.reduce_by_ids
+   Network.reduce_by_voltage_range
+   Network.reduce_by_ids_and_depths
    Network.merge
    Network.get_single_line_diagram
    Network.write_single_line_diagram_svg

--- a/docs/user_guide/network.rst
+++ b/docs/user_guide/network.rst
@@ -946,7 +946,7 @@ For this example we will keep only voltage levels with voltage superior or equal
     S3VL1                 S3      400.0               440.0              390.0
     S4VL1                 S4      400.0               440.0              390.0
 
-    >>> net.reduce(v_min=400)
+    >>> net.reduce_by_voltage_range(v_min=400)
     >>> net.get_voltage_levels()
           name substation_id  nominal_v  high_voltage_limit  low_voltage_limit
     id
@@ -969,7 +969,7 @@ For the next example we will keep voltage level S1VL1 with a depth of 1.
     S2VL1                 S2      400.0               440.0              390.0
     S3VL1                 S3      400.0               440.0              390.0
     S4VL1                 S4      400.0               440.0              390.0
-    >>> net.reduce(vl_depths=[['S1VL1', 1]])
+    >>> net.reduce_by_ids_and_depths(vl_depths=[('S1VL1', 1)])
     >>> net.get_voltage_levels()
           name substation_id  nominal_v  high_voltage_limit  low_voltage_limit
     id
@@ -979,7 +979,7 @@ For the next example we will keep voltage level S1VL1 with a depth of 1.
 S1VL1 is connected to S1VL2 by the transformer TWT, so it is kept after the network reduction.
 It is the only voltage level connected to S1VL1 by one branch.
 
-the parameter "ids" can be used to specify the exact voltage levels that will be kept
+Reduction can also be done by specifying directly the list of voltage levels to keep using the :meth:reduce_by_ids method.
 
 Using operational limits
 ------------------------

--- a/java/pypowsybl/src/main/java/com/powsybl/python/network/NetworkCFunctions.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/python/network/NetworkCFunctions.java
@@ -458,9 +458,9 @@ public final class NetworkCFunctions {
                 }
                 if (depthsCount != 0) {
                     final List<Integer> depths = CTypeUtil.toIntegerList(depthsPtr, depthsCount);
-                    final List<String> voltageLeveles = toStringList(vlsPtrPtr, vlsCount);
+                    final List<String> voltageLevels = toStringList(vlsPtrPtr, vlsCount);
                     for (int i = 0; i < depths.size(); i++) {
-                        predicates.add(new SubNetworkPredicate(network.getVoltageLevel(voltageLeveles.get(i)), depths.get(i)));
+                        predicates.add(new SubNetworkPredicate(network.getVoltageLevel(voltageLevels.get(i)), depths.get(i)));
                     }
                 }
                 final OrNetworkPredicate orNetworkPredicate = new OrNetworkPredicate(predicates);

--- a/pypowsybl/network/impl/network.py
+++ b/pypowsybl/network/impl/network.py
@@ -294,6 +294,7 @@ class Network:  # pylint: disable=too-many-public-methods
         """
         .. deprecated:: 1.14.0
           Use :meth:`reduce_by_voltage_range`, :meth:`reduce_by_ids` or :meth:`reduce_by_ids_and_depths` instead depending on your use case.
+        
         Reduce to a smaller network according to the following parameters
 
         :param v_min: minimum voltage of the voltage levels kept after reducing

--- a/tests/test_network_reduction.py
+++ b/tests/test_network_reduction.py
@@ -21,7 +21,7 @@ def test_reduce_by_voltage():
     n = pp.network.create_eurostag_tutorial_example1_network()
     pp.loadflow.run_ac(n)
     assert 4 == len(n.get_buses())
-    n.reduce(v_min=240, v_max=400)
+    n.reduce_by_voltage_range(v_min=240, v_max=400)
     assert 2 == len(n.get_buses())
 
 
@@ -29,7 +29,7 @@ def test_reduce_by_ids():
     n = pp.network.create_eurostag_tutorial_example1_network()
     pp.loadflow.run_ac(n)
     assert 4 == len(n.get_buses())
-    n.reduce(ids=['P2'])
+    n.reduce_by_ids(ids=['P2'])
     assert 2 == len(n.get_buses())
 
 
@@ -37,5 +37,8 @@ def test_reduce_by_subnetwork():
     n = pp.network.create_eurostag_tutorial_example1_network()
     pp.loadflow.run_ac(n)
     assert 4 == len(n.get_buses())
-    n.reduce(vl_depths=(('VLGEN', 1), ('VLLOAD', 1)))
+    n.reduce_by_ids_and_depths(vl_depths=[('VLGEN', 1), ('VLLOAD', 1)])
     assert 4 == len(n.get_buses())
+
+def test_deprecated_reduce():
+    with pytest.warns(DeprecationWarning, match=re.escape("operation limits is_fictitious attribute has been renamed fictitious")):

--- a/tests/test_network_reduction.py
+++ b/tests/test_network_reduction.py
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 import pytest
+import re
 
 import pypowsybl as pp
 import pathlib
@@ -41,4 +42,9 @@ def test_reduce_by_subnetwork():
     assert 4 == len(n.get_buses())
 
 def test_deprecated_reduce():
-    with pytest.warns(DeprecationWarning, match=re.escape("operation limits is_fictitious attribute has been renamed fictitious")):
+    n = pp.network.create_eurostag_tutorial_example1_network()
+    pp.loadflow.run_ac(n)
+    assert 4 == len(n.get_buses())
+    with pytest.warns(DeprecationWarning, match=re.escape("reduce is deprecated, use `reduce_by_voltage_range`")):
+        n.reduce(v_min=240, v_max=400)
+    assert 2 == len(n.get_buses())


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature refactor


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Network reduce method allow to use multiple filters at the same time that can be confusing when used together. 


**What is the new behavior (if this is a feature change)?**
Current reduce method is deprecated, and one method for each use case is created.
The typing of the "ids+depths" reduction method is fixed to make it clearer.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
