### PR TITLE
Fix empty curve result in dynamic simulation

### DIFF
--- a/integration_tests/test_dynawo.py
+++ b/integration_tests/test_dynawo.py
@@ -100,6 +100,8 @@ def test_minimal_simulation():
     assert DynamicSimulationStatus.SUCCESS == res.status()
     assert "" == res.status_text()
     assert False == res.timeline().empty
+    assert True == res.final_state_values().empty
+    assert True == res.curves().empty
 
 def test_provider_parameters_list():
     assert dyn.Simulation.get_provider_parameters_names()

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/dynamic/TimeSeriesConverter.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/dynamic/TimeSeriesConverter.java
@@ -44,6 +44,7 @@ public final class TimeSeriesConverter {
     private static void convertDoubleTimeSeries(List<DoubleTimeSeries> timeSeriesList, DataframeHandler dataframeHandler) {
         Objects.requireNonNull(timeSeriesList);
         if (timeSeriesList.isEmpty()) {
+            dataframeHandler.newStringIndex(INDEX_NAME, 0);
             return;
         }
         // check index unicity

--- a/java/pypowsybl/src/test/java/com/powsybl/dataframe/dynamic/DynamicSimulationDataframeMappersTest.java
+++ b/java/pypowsybl/src/test/java/com/powsybl/dataframe/dynamic/DynamicSimulationDataframeMappersTest.java
@@ -67,6 +67,15 @@ class DynamicSimulationDataframeMappersTest {
     }
 
     @Test
+    void testEmptyCurveDataframesMapper() {
+        List<Series> series = TimeSeriesConverter.createSeries(List.of());
+        assertThat(series)
+                .extracting(Series::getName)
+                .containsExactly("timestamp");
+        assertThat(series).satisfiesExactly(index -> assertThat(index.getStrings()).isEmpty());
+    }
+
+    @Test
     void testTimelineDataframesMapper() {
         List<TimelineEvent> timelineEvents = List.of(
                 new TimelineEvent(0.0, "BBM_GEN6", "PMIN : activation"),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
In dynamic simulation when `DynamicSimulationResult::getCurves` map is empty, the `TimeSeriesConverter` returns an empty `Series` list leading to the error `ValueError: No index in returned dataframe`.


**What is the new behavior (if this is a feature change)?**
`TimeSeriesConverter` returns a list with one empty index series.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
