### PR TITLE
Add minimal pyproject.toml file to comply with PEP 517/518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools==78.1.1", "wheel", "pybind11[global]==2.13.6", "cmake>=3.20"]
+requires = ["setuptools>=78.1.1", "wheel", "pybind11[global]==2.13.6", "cmake>=3.20"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=78.1.1", "wheel", "pybind11[global]==2.13.6", "cmake>=3.20"]
+requires = ["setuptools>=78.1.1", "wheel", "pybind11[global]>=2.13.6", "cmake>=3.20"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools==78.1.1", "wheel", "pybind11[global]==2.13.6", "cmake>=3.20"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ pytest-asyncio==0.24.0
 mypy==1.15.0
 pandas-stubs==2.2.2.240603
 pylint==3.2.0
-pybind11[global]==2.13.6
+pybind11[global]>=2.13.6
 cmake>=3.20
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # actual dependencies
-pandas==2.2.3
+pandas>=2.2.3
 prettytable>=2.0.0
 networkx
 matplotlib==3.9.2
@@ -15,7 +15,7 @@ sphinx==7.1.2
 furo==2024.1.29
 
 # CI dependencies
-setuptools==78.1.1
+setuptools>=78.1.1
 wheel==0.46.2
 coverage==7.3.2
 pytest>=8.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,25 +1,15 @@
-# actual dependencies
-pandas>=2.2.3
-prettytable>=2.0.0
-networkx
-matplotlib==3.9.2
-pybind11[global]==2.13.6
-cmake>=3.20
-
 # optional dependencies
-pandapower==3.1.2; python_version<'3.13' # TO REMOVE WHEN COMPATIBLE VERSION AVAILABLE
-orderly-set==5.3.0 # TO REMOVE WHEN FIXED
+pandapower==3.1.2
 
 # documentation dependencies
 sphinx==7.1.2
 furo==2024.1.29
 
 # CI dependencies
-setuptools>=78.1.1
-wheel==0.46.2
 coverage==7.3.2
 pytest>=8.3.3
 pytest-asyncio==0.24.0
 mypy==1.15.0
 pandas-stubs==2.2.2.240603
 pylint==3.2.0
+matplotlib==3.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,6 @@ pandas>=2.2.3
 prettytable>=2.0.0
 networkx
 matplotlib==3.9.2
-pybind11[global]==2.13.6
-cmake>=3.20
 
 # optional dependencies
 pandapower>=2.14.11
@@ -14,9 +12,13 @@ sphinx==7.1.2
 furo==2024.1.29
 
 # CI dependencies
+setuptools>=78.1.1
 coverage==7.3.2
 pytest>=8.3.3
 pytest-asyncio==0.24.0
 mypy==1.15.0
 pandas-stubs==2.2.2.240603
 pylint==3.2.0
+pybind11[global]==2.13.6
+cmake>=3.20
+wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,13 @@
+# actual dependencies
+pandas>=2.2.3
+prettytable>=2.0.0
+networkx
+matplotlib==3.9.2
+pybind11[global]==2.13.6
+cmake>=3.20
+
 # optional dependencies
-pandapower==3.1.2
+pandapower>=2.14.11
 
 # documentation dependencies
 sphinx==7.1.2
@@ -12,4 +20,3 @@ pytest-asyncio==0.24.0
 mypy==1.15.0
 pandas-stubs==2.2.2.240603
 pylint==3.2.0
-matplotlib==3.9.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
 
 [options.extras_require]
 pandapower =
-    pandapower>=2.14.11; python_version<'3.13'
+    pandapower>=2.14.11
 
 [options.package_data]
 pypowsybl: py.typed, *.pyi


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Technical change/bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The build currently only relies on classic setup.py file, and does not work with pip >= 25.


**What is the new behavior (if this is a feature change)?**
The package is now compliant with PEP 517/518 and declares its build backend through a (minimalistic) pyproject.toml file.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No