### PR TITLE
Fix loadflow provider parameters

### DIFF
--- a/docs/reference/loadflow.rst
+++ b/docs/reference/loadflow.rst
@@ -33,6 +33,8 @@ The execution of the loadflow can be customized using loadflow parameters.
     Parameters
     get_provider_parameters_names
     get_provider_parameters
+    Parameters.to_json
+    Parameters.from_json
 
 .. include it in the toctree
 .. toctree::

--- a/java/pypowsybl/src/main/java/com/powsybl/python/loadflow/LoadFlowCFunctions.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/python/loadflow/LoadFlowCFunctions.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.python.loadflow;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.extensions.Extension;
 import com.powsybl.commons.parameters.Parameter;
 import com.powsybl.commons.report.ReportNode;
@@ -72,7 +73,13 @@ public final class LoadFlowCFunctions {
         doCatch(exceptionHandlerPtr, new Runnable() {
             @Override
             public void run() {
-                PyPowsyblConfiguration.setDefaultLoadFlowProvider(CTypeUtil.toString(provider));
+                String providerName = CTypeUtil.toString(provider);
+                if (LoadFlowProvider.findAll().stream()
+                        .anyMatch(provider -> provider.getName().equals(providerName))) {
+                    PyPowsyblConfiguration.setDefaultLoadFlowProvider(providerName);
+                } else {
+                    throw new PowsyblException("No loadflow provider for name '" + providerName + "'");
+                }
             }
         });
     }
@@ -197,7 +204,7 @@ public final class LoadFlowCFunctions {
         return doCatch(exceptionHandlerPtr, new PointerProvider<>() {
             @Override
             public LoadFlowParametersPointer get() {
-                return convertToLoadFlowParametersPointer(LoadFlowCUtils.createLoadFlowParameters(), null);
+                return convertToLoadFlowParametersPointer(LoadFlowCUtils.createLoadFlowParameters(), PyPowsyblConfiguration.getDefaultLoadFlowProvider());
             }
         });
     }
@@ -210,7 +217,7 @@ public final class LoadFlowCFunctions {
             public LoadFlowParametersPointer get() throws IOException {
                 String parametersJson = CTypeUtil.toString(parametersJsonPtr);
                 try (InputStream is = new ByteArrayInputStream(parametersJson.getBytes(StandardCharsets.UTF_8))) {
-                    return convertToLoadFlowParametersPointer(JsonLoadFlowParameters.read(is), null);
+                    return convertToLoadFlowParametersPointer(JsonLoadFlowParameters.read(is), PyPowsyblConfiguration.getDefaultLoadFlowProvider());
                 }
             }
         });

--- a/pypowsybl/loadflow/impl/parameters.py
+++ b/pypowsybl/loadflow/impl/parameters.py
@@ -204,11 +204,22 @@ class Parameters:  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def from_json(json_str: str) -> "Parameters":
+        """
+        Creates a Parameters object from a JSON string.
+        Only provider parameters corresponding to the default_provider (see ``get_default_provider``) will be loaded from the JSON.
+
+        Args:
+            json_str: JSON string containing the parameters.
+        """
         parameters = Parameters()
         parameters._init_from_c(pypowsybl._pypowsybl.create_loadflow_parameters_from_json(json_str))
         return parameters
 
     def to_json(self) -> str:
+        """
+        Creates JSON string representation of the Parameters.
+        Only provider parameters corresponding to the default_provider (see ``get_default_provider``) will be loaded from the JSON.
+        """
         return pypowsybl._pypowsybl.write_loadflow_parameters_to_json(self._to_c_parameters())
 
     def __getstate__(self) -> Dict[str, Any]:

--- a/pypowsybl/loadflow/impl/parameters.py
+++ b/pypowsybl/loadflow/impl/parameters.py
@@ -30,7 +30,7 @@ class Parameters:  # pylint: disable=too-few-public-methods
     """
     Parameters for a loadflow execution.
 
-    All parameters are first read from you configuration file, then overridden with
+    All parameters are first read from your configuration file, then overridden with
     the constructor arguments.
 
     Please note that loadflow providers may not honor all parameters, according to their capabilities.

--- a/tests/test_loadflow.py
+++ b/tests/test_loadflow.py
@@ -27,14 +27,13 @@ def set_up():
 
 def test_config():
     assert 'OpenLoadFlow' == pp.loadflow.get_default_provider()
-    pp.loadflow.set_default_provider("provider")
-    assert 'provider' == pp.loadflow.get_default_provider()
     n = pp.network.create_ieee14()
     with pytest.raises(Exception, match='No loadflow provider for name \'provider\''):
-        lf.run_ac(n)
+        pp.loadflow.set_default_provider("provider")
+    pp.loadflow.set_default_provider("DynaFlow")
     results = lf.run_ac(n, provider='OpenLoadFlow')
     assert lf.ComponentStatus.CONVERGED == results[0].status
-    assert 'provider' == pp.loadflow.get_default_provider()
+    assert 'DynaFlow' == pp.loadflow.get_default_provider()
     pp.loadflow.set_default_provider("OpenLoadFlow")
     assert 'OpenLoadFlow' == pp.loadflow.get_default_provider()
 
@@ -326,6 +325,25 @@ def test_provider_parameters():
     result = pp.loadflow.run_ac(n, parameters)
     assert LoadFlowComponentStatus.MAX_ITERATION_REACHED == result[0].status
     assert 3 == result[0].iteration_count
+
+
+def test_parameters_json_round_trip():
+    params = lf.Parameters(
+        distributed_slack=True,
+        balance_type=lf.BalanceType.PROPORTIONAL_TO_GENERATION_P,
+        voltage_init_mode=lf.VoltageInitMode.DC_VALUES,
+        provider_parameters={"slackDistributionFailureBehavior": "LEAVE_ON_SLACK_BUS"},
+        dc_use_transformer_ratio=True,
+    )
+    json_str = params.to_json()
+
+    params_reloaded = lf.Parameters.from_json(json_str)
+    assert params_reloaded.distributed_slack == params.distributed_slack
+    assert params_reloaded.balance_type == params.balance_type
+    assert params_reloaded.voltage_init_mode == params.voltage_init_mode
+    assert params_reloaded.dc_use_transformer_ratio == params.dc_use_transformer_ratio
+    assert params_reloaded.provider_parameters != {}
+    assert params_reloaded.provider_parameters["slackDistributionFailureBehavior"] == "LEAVE_ON_SLACK_BUS"
 
 
 def test_run_lf_with_report():


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #1153, #1144


**What is the new behavior (if this is a feature change)?**
When creating loadflow Parameters, we now always pass from java to python the provider parameters associated with the default provider chosen in pypowsybl configuration (which is by default OpenLoadFlow, and can be set with set_default_provider method)

This way :
- a json parameters file created with OLF specific parameters will be correctly read (if the default provider is still OLF)
-  when default parameters are defined in java using the LoadFlowDefaultParametersLoader mecanism, users will see that the values corresponding to their default provider are set. 

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No