### PR TITLE
Remove python 3.9 support, add python 3.14

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: echo "/opt/python/${{ matrix.python.name }}-${{ matrix.python.abi }}/bin/" >> $GITHUB_PATH
 
       - name: Install dependencies
-        run: pip3 install -r requirements.txt
+        run: pip install -r requirements.txt
 
       - name: Build wheel
         run: |
@@ -51,7 +51,7 @@ jobs:
           auditwheel repair dist/*.whl
 
       - name: Install wheel
-        run: pip3 install wheelhouse/*.whl --user
+        run: pip install wheelhouse/*.whl --user
 
       - name: Run basic pypowsybl import
         working-directory: ./tests
@@ -67,7 +67,7 @@ jobs:
 
       - name: Dev install  # In order to generate coverage and linting, we need to install in sources
         run: |
-          pip3 uninstall -y pypowsybl
+          pip uninstall -y pypowsybl
           python3 setup.py develop
 
       - name: Generate coverage

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -6,8 +6,8 @@ on:
 jobs:
   manylinux_build:
     name: Build linux ${{ matrix.python.name }} wheel
-    runs-on: ubuntu-22.04
-    container: quay.io/pypa/manylinux_2_28_x86_64:2024-11-16-d70d8cd
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux_2_28_x86_64:2026.03.09-1
     strategy:
       matrix:
         python:

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -39,8 +39,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup path
-        run: echo "/opt/python/${{ matrix.python.name }}-${{ matrix.python.abi }}/bin/" >> $GITHUB_PATH
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python.version }}
 
       - name: Install dependencies
         run: | 

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -12,9 +12,9 @@ jobs:
       matrix:
         python:
           - {
-            name: cp39,
-            abi: cp39,
-            version: '3.9',
+            name: cp314,
+            abi: cp314,
+            version: '3.14',
           }
 
     steps:
@@ -117,8 +117,8 @@ jobs:
           }
         python:
           - {
-            name: cp39,
-            version: '3.9',
+            name: cp314,
+            version: '3.14',
           }
 
     steps:

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -39,10 +39,8 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python.version }}
+      - name: Setup path
+        run: echo "/opt/python/${{ matrix.python.name }}-${{ matrix.python.abi }}/bin/" >> $GITHUB_PATH
 
       - name: Install dependencies
         run: | 

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -12,9 +12,9 @@ jobs:
       matrix:
         python:
           - {
-            name: cp314,
-            abi: cp314,
-            version: '3.14',
+            name: cp310,
+            abi: cp310,
+            version: '3.10',
           }
 
     steps:
@@ -43,21 +43,19 @@ jobs:
         run: echo "/opt/python/${{ matrix.python.name }}-${{ matrix.python.abi }}/bin/" >> $GITHUB_PATH
 
       - name: Install dependencies
-        run: | 
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+        run: pip3 install -r requirements.txt
 
       - name: Build wheel
         run: |
-          python setup.py bdist_wheel
+          python3 setup.py bdist_wheel
           auditwheel repair dist/*.whl
 
       - name: Install wheel
-        run: pip install wheelhouse/*.whl --user
+        run: pip3 install wheelhouse/*.whl --user
 
       - name: Run basic pypowsybl import
         working-directory: ./tests
-        run: python basic_import_test.py
+        run: python3 basic_import_test.py
 
       - name: Run tests
         working-directory: ./tests # Run in subdir to use installed lib, not sources
@@ -69,8 +67,8 @@ jobs:
 
       - name: Dev install  # In order to generate coverage and linting, we need to install in sources
         run: |
-          pip uninstall -y pypowsybl
-          python setup.py develop
+          pip3 uninstall -y pypowsybl
+          python3 setup.py develop
 
       - name: Generate coverage
         run: |
@@ -119,8 +117,8 @@ jobs:
           }
         python:
           - {
-            name: cp314,
-            version: '3.14',
+            name: cp310,
+            version: '3.10',
           }
 
     steps:

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -46,12 +46,12 @@ jobs:
 
       - name: Install dependencies
         run: | 
-          python3 -m pip install --upgrade pip
+          python -m pip install --upgrade pip
           pip install -r requirements.txt
 
       - name: Build wheel
         run: |
-          python3 setup.py bdist_wheel
+          python setup.py bdist_wheel
           auditwheel repair dist/*.whl
 
       - name: Install wheel
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run basic pypowsybl import
         working-directory: ./tests
-        run: python3 basic_import_test.py
+        run: python basic_import_test.py
 
       - name: Run tests
         working-directory: ./tests # Run in subdir to use installed lib, not sources
@@ -72,7 +72,7 @@ jobs:
       - name: Dev install  # In order to generate coverage and linting, we need to install in sources
         run: |
           pip uninstall -y pypowsybl
-          python3 setup.py develop
+          python setup.py develop
 
       - name: Generate coverage
         run: |

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -43,7 +43,9 @@ jobs:
         run: echo "/opt/python/${{ matrix.python.name }}-${{ matrix.python.abi }}/bin/" >> $GITHUB_PATH
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: | 
+          python3 -m pip install --upgrade pip
+          pip install -r requirements.txt
 
       - name: Build wheel
         run: |

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   manylinux_build:
     name: Build linux ${{ matrix.python.name }} wheel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: quay.io/pypa/manylinux_2_28_x86_64:2024-11-16-d70d8cd
     strategy:
       matrix:

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   manylinux_complete_build:
     name: Build linux native libraries and ${{ matrix.python.name }} wheel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: quay.io/pypa/manylinux_2_28_x86_64:2024-11-16-d70d8cd
     strategy:
       matrix:

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -17,14 +17,14 @@ permissions:
 jobs:
   manylinux_complete_build:
     name: Build linux native libraries and ${{ matrix.python.name }} wheel
-    runs-on: ubuntu-22.04
-    container: quay.io/pypa/manylinux_2_28_x86_64:2024-11-16-d70d8cd
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux_2_28_x86_64:2026.03.09-1
     strategy:
       matrix:
         python:
           - {
-            name: cp39,
-            abi: cp39,
+            name: cp310,
+            abi: cp310,
             version: '3.10'
           }
 

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: echo "/opt/python/${{ matrix.python.name }}-${{ matrix.python.abi }}/bin/" >> $GITHUB_PATH
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip3 install -r requirements.txt
 
       - name: Build wheel
         run: |
@@ -62,7 +62,7 @@ jobs:
           auditwheel repair dist/*.whl
 
       - name: Install wheel
-        run: pip install wheelhouse/*.whl --user
+        run: pip3 install wheelhouse/*.whl --user
 
       - name: Run basic pypowsybl import
         working-directory: ./tests
@@ -78,7 +78,7 @@ jobs:
 
       - name: Dev install  # In order to generate coverage and linting, we need to install in sources
         run: |
-          pip uninstall -y pypowsybl
+          pip3 uninstall -y pypowsybl
           python3 setup.py develop
 
       - name: Generate coverage
@@ -166,7 +166,7 @@ jobs:
         run: echo "/opt/python/${{ matrix.python.name }}-${{ matrix.python.abi }}/bin/" >> $GITHUB_PATH
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip3 install -r requirements.txt
 
       - name: Download native libraries
         uses: actions/download-artifact@v4
@@ -185,7 +185,7 @@ jobs:
           auditwheel repair dist/*.whl
 
       - name: Install wheel
-        run: pip install wheelhouse/*.whl --user
+        run: pip3 install wheelhouse/*.whl --user
 
       - name: Run basic pypowsybl import
         working-directory: ./tests

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: echo "/opt/python/${{ matrix.python.name }}-${{ matrix.python.abi }}/bin/" >> $GITHUB_PATH
 
       - name: Install dependencies
-        run: pip3 install -r requirements.txt
+        run: pip install -r requirements.txt
 
       - name: Build wheel
         run: |
@@ -62,7 +62,7 @@ jobs:
           auditwheel repair dist/*.whl
 
       - name: Install wheel
-        run: pip3 install wheelhouse/*.whl --user
+        run: pip install wheelhouse/*.whl --user
 
       - name: Run basic pypowsybl import
         working-directory: ./tests
@@ -78,7 +78,7 @@ jobs:
 
       - name: Dev install  # In order to generate coverage and linting, we need to install in sources
         run: |
-          pip3 uninstall -y pypowsybl
+          pip uninstall -y pypowsybl
           python3 setup.py develop
 
       - name: Generate coverage
@@ -166,7 +166,7 @@ jobs:
         run: echo "/opt/python/${{ matrix.python.name }}-${{ matrix.python.abi }}/bin/" >> $GITHUB_PATH
 
       - name: Install dependencies
-        run: pip3 install -r requirements.txt
+        run: pip install -r requirements.txt
 
       - name: Download native libraries
         uses: actions/download-artifact@v4
@@ -185,7 +185,7 @@ jobs:
           auditwheel repair dist/*.whl
 
       - name: Install wheel
-        run: pip3 install wheelhouse/*.whl --user
+        run: pip install wheelhouse/*.whl --user
 
       - name: Run basic pypowsybl import
         working-directory: ./tests

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -25,7 +25,7 @@ jobs:
           - {
             name: cp39,
             abi: cp39,
-            version: '3.9'
+            version: '3.10'
           }
 
     steps:
@@ -136,11 +136,6 @@ jobs:
       matrix:
         python:
           - {
-            name: cp310,
-            abi: cp310,
-            version: '3.10'
-          }
-          - {
             name: cp311,
             abi: cp311,
             version: '3.11'
@@ -154,6 +149,11 @@ jobs:
             name: cp313,
             abi: cp313,
             version: '3.13'
+          }
+          - {
+            name: cp314,
+            abi: cp314,
+            version: '3.14'
           }
 
     steps:
@@ -233,8 +233,8 @@ jobs:
           }
         python:
           - {
-            name: cp39,
-            version: '3.9',
+            name: cp310,
+            version: '3.10',
           }
 
     steps:
@@ -334,10 +334,6 @@ jobs:
           }
         python:
           - {
-            name: cp310,
-            version: '3.10',
-          }
-          - {
             name: cp311,
             version: '3.11',
           }
@@ -348,6 +344,10 @@ jobs:
           - {
             name: cp313,
             version: '3.13',
+          }
+          - {
+            name: cp314,
+            version: '3.14',
           }
 
     steps:

--- a/.github/workflows/snapshot-ci.yml
+++ b/.github/workflows/snapshot-ci.yml
@@ -26,7 +26,7 @@ jobs:
           #- { name: darwin-arm64, os: macos-15, macosx_deployment_target: "11", bdist_wheel_args: "--plat-name macosx-11.0-arm64" }
           - { name: windows, os: windows-2022 }
         python:
-          - { name: cp39, version: '3.9' }
+          - { name: cp310, version: '3.10' }
       fail-fast: false
     defaults:
       run:
@@ -378,10 +378,10 @@ jobs:
           #- { name: darwin-arm64, os: macos-15, macosx_deployment_target: "11", bdist_wheel_args: "--plat-name macosx-11.0-arm64" }
           - { name: windows, os: windows-2022 }
         python:
-          - { name: cp310, version: '3.10' }
           - { name: cp311, version: '3.11' }
           - { name: cp312, version: '3.12' }
           - { name: cp313, version: '3.13' }
+          - { name: cp314, version: '3.14' }
       fail-fast: false
     defaults:
       run:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 sphinx:
    configuration: docs/conf.py

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Notebooks demonstrating PyPowSyBl features can be found in this [repository](htt
 
 ## Installation
 
-PyPowSyBl is released on [PyPi](https://pypi.org/project/pypowsybl/) for Python 3.9 to 3.13, on Linux, Windows and MacOS.
+PyPowSyBl is released on [PyPi](https://pypi.org/project/pypowsybl/) for Python 3.10 to 3.14, on Linux, Windows and MacOS.
 
 First, make sure you have an up-to-date version of pip and setuptools:
 ```bash
@@ -96,7 +96,7 @@ Requirements:
 - Maven >= 3.1
 - Cmake >= 3.20
 - C++11 compiler
-- Python >= 3.9 for Linux, Windows and MacOS (amd64 and arm64)
+- Python >= 3.10 for Linux, Windows and MacOS (amd64 and arm64)
 - [Oracle GraalVM Java 21](https://www.graalvm.org/downloads/)
 
 To build from sources and install PyPowSyBl package:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 pandas>=2.2.3
 prettytable>=2.0.0
 networkx
-matplotlib==3.9.2
+matplotlib
 
 # optional dependencies
 pandapower>=2.14.11
@@ -22,3 +22,4 @@ pylint==3.2.0
 pybind11[global]>=2.13.6
 cmake>=3.20
 wheel
+matplotlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,11 +11,11 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Programming Language :: Python :: Implementation :: CPython
     License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
     Operating System :: POSIX :: Linux
@@ -26,7 +26,7 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     prettytable>=2.0.0
     pandas>=2.2.3


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #1164


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Technical change : python version 3.9 is removed from support (since it is EOL since october 2025) and python 3.14 is now in the released versions.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
Python 3.9 users will not be able to use new pypowsybl versions anymore, and will need to upgrade their python version.

