### PR TITLE
Improve Sonar workflow to handle fork branches and HEAD ref correctly

### DIFF
--- a/.github/workflows/fork-sonar.yml
+++ b/.github/workflows/fork-sonar.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ env.HEAD_REF }}
+          ref: ${{ env.HEAD_SHA }}
           repository: ${{ env.REPO_NAME }}
           fetch-depth: 0
 
@@ -59,6 +59,13 @@ jobs:
           git config --global --add safe.directory $GITHUB_WORKSPACE
           git remote add upstream https://github.com/${{ github.repository }}.git
           git fetch upstream ${{ env.BASE_REF }}
+          git branch ${{ env.BASE_REF }} refs/remotes/upstream/${{ env.BASE_REF }}
+          if [ "${{ env.HEAD_REF }}" = "${{ env.BASE_REF }}" ]; then
+            FORK_OWNER=$(echo "${{ env.REPO_NAME }}" | cut -d'/' -f1)
+            echo "SONAR_PR_BRANCH=${FORK_OWNER}:${{ env.HEAD_REF }}" >> $GITHUB_ENV
+          else
+            echo "SONAR_PR_BRANCH=${{ env.HEAD_REF }}" >> $GITHUB_ENV
+          fi
 
       - name: Download coverage report for SonarCloud
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -78,8 +85,8 @@ jobs:
           args: |
             -Dsonar.python.coverage.reportPaths=coverage.xml
             "-Dsonar.pullrequest.key=${{ env.PR_NUMBER }}"
-            "-Dsonar.pullrequest.branch=${{ env.HEAD_REF }}"
-            "-Dsonar.pullrequest.base=refs/remotes/upstream/${{ env.BASE_REF }}"
+            "-Dsonar.pullrequest.branch=${{ env.SONAR_PR_BRANCH }}"
+            "-Dsonar.pullrequest.base=${{ env.BASE_REF }}"
             -Dsonar.pullrequest.provider=github
             -Dsonar.pullrequest.github.repository=${{ github.repository }}
             -Dsonar.scm.provider=git
@@ -150,7 +157,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ env.HEAD_REF }}
+          ref: ${{ env.HEAD_SHA }}
           repository: ${{ env.REPO_NAME }}
           fetch-depth: 0
 
@@ -158,6 +165,13 @@ jobs:
         run: |
           git remote add upstream https://github.com/${{ github.repository }}.git
           git fetch upstream ${{ env.BASE_REF }}
+          git branch ${{ env.BASE_REF }} refs/remotes/upstream/${{ env.BASE_REF }}
+          if [ "${{ env.HEAD_REF }}" = "${{ env.BASE_REF }}" ]; then
+            FORK_OWNER=$(echo "${{ env.REPO_NAME }}" | cut -d'/' -f1)
+            echo "SONAR_PR_BRANCH=${FORK_OWNER}:${{ env.HEAD_REF }}" >> $GITHUB_ENV
+          else
+            echo "SONAR_PR_BRANCH=${{ env.HEAD_REF }}" >> $GITHUB_ENV
+          fi
 
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -239,8 +253,8 @@ jobs:
             "-Dsonar.java.test.libraries=${{ env.LIBRARIES }}"
             "-Dsonar.coverage.jacoco.xmlReportPaths=java/pypowsybl/target/site/jacoco/jacoco.xml"
             "-Dsonar.pullrequest.key=${{ env.PR_NUMBER }}"
-            "-Dsonar.pullrequest.branch=${{ env.HEAD_REF }}"
-            "-Dsonar.pullrequest.base=refs/remotes/upstream/${{ env.BASE_REF }}"
+            "-Dsonar.pullrequest.branch=${{ env.SONAR_PR_BRANCH }}"
+            "-Dsonar.pullrequest.base=${{ env.BASE_REF }}"
             -Dsonar.pullrequest.provider=github
             -Dsonar.pullrequest.github.repository=${{ github.repository }}
             -Dsonar.host.url=https://sonarcloud.io


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
Bug on sonar analysis for main branch on forks

**What is the new behavior (if this is a feature change)?**
It should now work for any branch

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
The changes are:
1. Checkout by SHA instead of branch name (ref: HEAD_SHA)

    - With ref: HEAD_REF, when the fork branch is main, a local branch named main is created pointing to the fork's head, making it impossible to later create main pointing to upstream's main.
    - SHA checkout gives a detached HEAD with no local branches, so the next step can create the needed local branch safely.
2. Create a local branch `$BASE_REF` pointing to `upstream/$BASE_REF`
`git branch ${{ env.BASE_REF }} refs/remotes/upstream/${{ env.BASE_REF }}`
    - SonarCloud uses local git history to compute diffs. Without a local ref named main pointing to upstream's main, git cannot resolve the merge-base, so SonarCloud falls back to treating all code as new → issues on existing code (your Case 2 symptom).
3. Compute SONAR_PR_BRANCH
    - When HEAD_REF == BASE_REF (e.g., both are main): uses FORK_OWNER:main (e.g., rolnico:main). This matches GitHub's own cross-fork PR notation and avoids SonarCloud seeing branch=main vs base=main as a no-op diff.
    - Otherwise: uses HEAD_REF as before.
4. Fix sonar.pullrequest.base - from r`efs/remotes/upstream/$BASE_REF` to `$BASE_REF`
    - SonarCloud expects a branch name (e.g., main) to look up the existing baseline analysis in its database. Using the git ref refs/remotes/upstream/main means SonarCloud looks for an analysis of a branch literally named refs/remotes/upstream/main, which doesn't exist → it can't find a baseline → both cases fail.