### PR TITLE
feat(RAO): export initial set-point / tap in dataframes for range actions

### DIFF
--- a/java/pypowsybl/src/main/java/com/powsybl/python/rao/RaoCFunctions.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/python/rao/RaoCFunctions.java
@@ -770,12 +770,12 @@ public final class RaoCFunctions {
 
     @CEntryPoint(name = "getCracPstRangeActions")
     public static ArrayPointer<SeriesPointer> getCracPstRangeActions(IsolateThread thread, ObjectHandle cracHandle, ExceptionHandlerPointer exceptionHandlerPtr) {
-        return cracGenericMethod(thread, cracHandle, cracRangeActions(crac -> crac.getPstRangeActions().stream().toList()), exceptionHandlerPtr);
+        return cracGenericMethod(thread, cracHandle, cracPstRangeActions(crac -> crac.getPstRangeActions().stream().toList()), exceptionHandlerPtr);
     }
 
     @CEntryPoint(name = "getCracHvdcRangeActions")
     public static ArrayPointer<SeriesPointer> getCracHvdcRangeActions(IsolateThread thread, ObjectHandle cracHandle, ExceptionHandlerPointer exceptionHandlerPtr) {
-        return cracGenericMethod(thread, cracHandle, cracRangeActions(crac -> crac.getHvdcRangeActions().stream().toList()), exceptionHandlerPtr);
+        return cracGenericMethod(thread, cracHandle, cracHvdcRangeActions(crac -> crac.getHvdcRangeActions().stream().toList()), exceptionHandlerPtr);
     }
 
     @CEntryPoint(name = "getCracInjectionRangeActions")

--- a/java/pypowsybl/src/main/java/com/powsybl/python/rao/RaoDataframes.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/python/rao/RaoDataframes.java
@@ -522,18 +522,35 @@ public final class RaoDataframes {
         return thresholds;
     }
 
-    public static <T extends RangeAction<?>> DataframeMapper<Crac, Void> cracRangeActions(Function<Crac, List<T>> actionsSupplier) {
-        return new DataframeMapperBuilder<Crac, T, Void>()
+    public static DataframeMapper<Crac, Void> cracPstRangeActions(Function<Crac, List<PstRangeAction>> actionsSupplier) {
+        return new DataframeMapperBuilder<Crac, PstRangeAction, Void>()
             .itemsProvider(actionsSupplier)
-            .stringsIndex("id", T::getId)
-            .strings("name", T::getName)
-            .strings("operator", T::getOperator)
+            .stringsIndex("id", PstRangeAction::getId)
+            .strings("name", PstRangeAction::getName)
+            .strings("operator", PstRangeAction::getOperator)
             .strings("network_element_id", a -> a.getNetworkElements().stream().toList().getFirst().getId())
             .strings("group_id", a -> a.getGroupId().orElse(""))
             .optionalInts("speed", a -> a.getSpeed().map(OptionalInt::of).orElse(OptionalInt.empty()))
             .strings("activation_cost", a -> a.getActivationCost().map(Object::toString).orElse(""))
             .strings("variation_cost_up", a -> a.getVariationCost(VariationDirection.UP).map(Object::toString).orElse(""))
             .strings("variation_cost_down", a -> a.getVariationCost(VariationDirection.DOWN).map(Object::toString).orElse(""))
+            .ints("initial_tap", PstRangeAction::getInitialTap)
+            .build();
+    }
+
+    public static DataframeMapper<Crac, Void> cracHvdcRangeActions(Function<Crac, List<HvdcRangeAction>> actionsSupplier) {
+        return new DataframeMapperBuilder<Crac, HvdcRangeAction, Void>()
+            .itemsProvider(actionsSupplier)
+            .stringsIndex("id", HvdcRangeAction::getId)
+            .strings("name", HvdcRangeAction::getName)
+            .strings("operator", HvdcRangeAction::getOperator)
+            .strings("network_element_id", a -> a.getNetworkElements().stream().toList().getFirst().getId())
+            .strings("group_id", a -> a.getGroupId().orElse(""))
+            .optionalInts("speed", a -> a.getSpeed().map(OptionalInt::of).orElse(OptionalInt.empty()))
+            .strings("activation_cost", a -> a.getActivationCost().map(Object::toString).orElse(""))
+            .strings("variation_cost_up", a -> a.getVariationCost(VariationDirection.UP).map(Object::toString).orElse(""))
+            .strings("variation_cost_down", a -> a.getVariationCost(VariationDirection.DOWN).map(Object::toString).orElse(""))
+            .doubles("initial_set_point", StandardRangeAction::getInitialSetpoint)
             .build();
     }
 
@@ -548,6 +565,7 @@ public final class RaoDataframes {
             .optionalDoubles("activation_cost", a -> a.getActivationCost().map(OptionalDouble::of).orElseGet(OptionalDouble::empty))
             .optionalDoubles("variation_cost_up", a -> a.getVariationCost(VariationDirection.UP).map(OptionalDouble::of).orElseGet(OptionalDouble::empty))
             .optionalDoubles("variation_cost_down", a -> a.getVariationCost(VariationDirection.DOWN).map(OptionalDouble::of).orElseGet(OptionalDouble::empty))
+            .doubles("initial_set_point", StandardRangeAction::getInitialSetpoint)
             .build();
     }
 
@@ -579,6 +597,7 @@ public final class RaoDataframes {
             .optionalDoubles("activation_cost", a -> a.getActivationCost().map(OptionalDouble::of).orElseGet(OptionalDouble::empty))
             .optionalDoubles("variation_cost_up", a -> a.getVariationCost(VariationDirection.UP).map(OptionalDouble::of).orElseGet(OptionalDouble::empty))
             .optionalDoubles("variation_cost_down", a -> a.getVariationCost(VariationDirection.DOWN).map(OptionalDouble::of).orElseGet(OptionalDouble::empty))
+            .doubles("initial_set_point", StandardRangeAction::getInitialSetpoint)
             .build();
     }
 

--- a/tests/test_rao_crac.py
+++ b/tests/test_rao_crac.py
@@ -155,33 +155,36 @@ class TestRaoCrac:
     def test_pst_range_actions(self):
         df = self.crac.get_pst_range_actions()
         assert ['name', 'operator', 'network_element_id', 'group_id', 'speed', 'activation_cost',
-                'variation_cost_up', 'variation_cost_down'] == list(df.columns)
+                'variation_cost_up', 'variation_cost_down', 'initial_tap'] == list(df.columns)
         action = df.loc['pstRange1Id']
 
         assert 'pstRange1Name' == action['name']
         assert 'RTE' == action['operator']
         assert 'pst' == action['network_element_id']
+        assert 2 == action['initial_tap']
 
     def test_hvdc_range_actions(self):
         df = self.crac.get_hvdc_range_actions()
         assert ['name', 'operator', 'network_element_id', 'group_id', 'speed', 'activation_cost',
-                'variation_cost_up', 'variation_cost_down'] == list(df.columns)
+                'variation_cost_up', 'variation_cost_down', 'initial_set_point'] == list(df.columns)
         action = df.loc['hvdcRange1Id']
 
         assert 'hvdcRange1Name' == action['name']
         assert 'RTE' == action['operator']
         assert 'hvdc' == action['network_element_id']
+        assert 100.0 == action['initial_set_point']
 
     def test_injection_range_actions(self):
         df = self.crac.get_injection_range_actions()
         assert ['name', 'operator', 'group_id', 'speed', 'activation_cost',
-                'variation_cost_up', 'variation_cost_down'] == list(df.columns)
+                'variation_cost_up', 'variation_cost_down', 'initial_set_point'] == list(df.columns)
         action = df.loc['injectionRange1Id']
 
         assert 'injectionRange1Name' == action['name']
         assert 30 == action['speed']
         assert math.isclose(800.0, action['activation_cost'])
         assert math.isclose(2000.0, action['variation_cost_up'])
+        assert 50.0 == action['initial_set_point']
 
     def test_network_elements_ids_and_keys(self):
         df = self.crac.get_network_element_ids_and_keys()
@@ -195,11 +198,12 @@ class TestRaoCrac:
     def test_counter_trade_range_actions(self):
         df = self.crac.get_counter_trade_range_actions()
         assert ['name', 'operator', 'exporting_country', 'importing_country', 'group_id', 'speed', 'activation_cost',
-                'variation_cost_up', 'variation_cost_down'] == list(df.columns)
+                'variation_cost_up', 'variation_cost_down', 'initial_set_point'] == list(df.columns)
         action = df.loc['counterTradeRange1Id']
         assert 'counterTradeRange1Name' == action['name']
         assert 30 == action['speed']
         assert math.isclose(10000.0, action['activation_cost'])
+        assert 0.0 == action['initial_set_point']
 
     def test_ranges(self):
         df = self.crac.get_ranges()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Initial taps and set-points of range actions are now available in the CRAC dataframe.



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
