### PR TITLE
Add access to minP and maxP attributes of Voltage Source Converters

### DIFF
--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/NetworkDataframes.java
@@ -1062,6 +1062,18 @@ public final class NetworkDataframes {
                         (conv, targetP, context) -> conv.setTargetP(unPerUnitPQ(context, targetP)))
                 .doubles("target_q", (conv, context) -> perUnitPQ(context, conv.getReactivePowerSetpoint()),
                         (conv, targetQ, context) -> conv.setReactivePowerSetpoint(unPerUnitPQ(context, targetQ)))
+                // The core represents the "unbounded" default as -/+ Double.MAX_VALUE; expose it as -/+ infinity
+                // Non-default columns, so absent from the default dataframe.
+                .doubles("min_p",
+                        (conv, context) -> conv.getMinP() == -Double.MAX_VALUE
+                                ? Double.NEGATIVE_INFINITY : perUnitPQ(context, conv.getMinP()),
+                        (conv, minP, context) -> conv.setMinP(minP == Double.NEGATIVE_INFINITY
+                                ? -Double.MAX_VALUE : unPerUnitPQ(context, minP)), false)
+                .doubles("max_p",
+                        (conv, context) -> conv.getMaxP() == Double.MAX_VALUE
+                                ? Double.POSITIVE_INFINITY : perUnitPQ(context, conv.getMaxP()),
+                        (conv, maxP, context) -> conv.setMaxP(maxP == Double.POSITIVE_INFINITY
+                                ? Double.MAX_VALUE : unPerUnitPQ(context, maxP)), false)
                 .doubles("idle_loss", (conv, context) -> perUnitPQ(context, conv.getIdleLoss()),
                         (conv, idleLoss, context) -> conv.setIdleLoss(unPerUnitPQ(context, idleLoss)))
                 .doubles("switching_loss", (conv, context) -> perUnitV(context, conv.getSwitchingLoss(), conv.getTerminal1()),

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/adders/VoltageSourceConverterDataFrameAdder.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/adders/VoltageSourceConverterDataFrameAdder.java
@@ -49,7 +49,9 @@ public class VoltageSourceConverterDataFrameAdder extends AbstractSimpleAdder {
             SeriesMetadata.doubles("target_v_ac"),
             SeriesMetadata.doubles("idle_loss"),
             SeriesMetadata.doubles("switching_loss"),
-            SeriesMetadata.doubles("resistive_loss")
+            SeriesMetadata.doubles("resistive_loss"),
+            SeriesMetadata.doubles("min_p"),
+            SeriesMetadata.doubles("max_p")
     );
 
     @Override
@@ -86,6 +88,8 @@ public class VoltageSourceConverterDataFrameAdder extends AbstractSimpleAdder {
         protected final DoubleSeries idleLoss;
         protected final DoubleSeries switchingLoss;
         protected final DoubleSeries resistiveLoss;
+        protected final DoubleSeries minP;
+        protected final DoubleSeries maxP;
 
         VoltageSourceConverterSeries(UpdatingDataframe dataframe) {
             super(dataframe);
@@ -111,6 +115,8 @@ public class VoltageSourceConverterDataFrameAdder extends AbstractSimpleAdder {
             this.idleLoss = dataframe.getDoubles("idle_loss");
             this.switchingLoss = dataframe.getDoubles("switching_loss");
             this.resistiveLoss = dataframe.getDoubles("resistive_loss");
+            this.minP = dataframe.getDoubles("min_p");
+            this.maxP = dataframe.getDoubles("max_p");
         }
 
         void setVoltageSourceConverterAttributes(VoltageSourceConverterAdder adder, int row, Network network) {
@@ -158,6 +164,8 @@ public class VoltageSourceConverterDataFrameAdder extends AbstractSimpleAdder {
             applyIfPresent(idleLoss, row, adder::setIdleLoss);
             applyIfPresent(switchingLoss, row, adder::setSwitchingLoss);
             applyIfPresent(resistiveLoss, row, adder::setResistiveLoss);
+            applyIfPresent(minP, row, adder::setMinP);
+            applyIfPresent(maxP, row, adder::setMaxP);
         }
 
         void createVoltageSourceConverter(Network network, int row) {

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/adders/VoltageSourceConverterDataFrameAdder.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/adders/VoltageSourceConverterDataFrameAdder.java
@@ -164,8 +164,11 @@ public class VoltageSourceConverterDataFrameAdder extends AbstractSimpleAdder {
             applyIfPresent(idleLoss, row, adder::setIdleLoss);
             applyIfPresent(switchingLoss, row, adder::setSwitchingLoss);
             applyIfPresent(resistiveLoss, row, adder::setResistiveLoss);
-            applyIfPresent(minP, row, adder::setMinP);
-            applyIfPresent(maxP, row, adder::setMaxP);
+            // Symmetric with the update path (NetworkDataframes): expose the "unbounded" state as -/+ inf,
+            // mapping it back to the core's -/+ Double.MAX_VALUE sentinel. Finite values pass through unchanged
+            // (creation dataframes are in SI, hence no per-unit conversion here).
+            applyIfPresent(minP, row, value -> adder.setMinP(value == Double.NEGATIVE_INFINITY ? -Double.MAX_VALUE : value));
+            applyIfPresent(maxP, row, value -> adder.setMaxP(value == Double.POSITIVE_INFINITY ? Double.MAX_VALUE : value));
         }
 
         void createVoltageSourceConverter(Network network, int row) {

--- a/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
+++ b/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
@@ -932,7 +932,7 @@ class NetworkDataframesTest {
         assertThat(attrs.get("min_p").getDoubles()).containsExactly(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
         assertThat(attrs.get("max_p").getDoubles()).containsExactly(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
 
-        // finite values via core API read back as the SI value (default ctx, no per-unit)
+        // finite values via core API read back
         network.getVoltageSourceConverter("VscFr").setMinP(-100.0).setMaxP(200.0);
         attrs = createDataFrame(VOLTAGE_SOURCE_CONVERTER, network, new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()))
                 .stream().collect(ImmutableMap.toImmutableMap(Series::getName, Function.identity()));

--- a/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
+++ b/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
@@ -922,6 +922,24 @@ class NetworkDataframesTest {
     }
 
     @Test
+    void voltageSourceConvertersMinMaxP() {
+        Network network = DcDetailedNetworkFactory.createVscSymmetricalMonopole();
+
+        Map<String, Series> attrs = createDataFrame(VOLTAGE_SOURCE_CONVERTER, network,
+                new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()))
+                .stream().collect(ImmutableMap.toImmutableMap(Series::getName, Function.identity()));
+        // default unbounded -> +/-inf for both converters (VscFr, VscGb)
+        assertThat(attrs.get("min_p").getDoubles()).containsExactly(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
+        assertThat(attrs.get("max_p").getDoubles()).containsExactly(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
+
+        // finite value via core API reads back as the SI value (default ctx, no per-unit)
+        network.getVoltageSourceConverter("VscFr").setMinP(-100.0);
+        double minP = createDataFrame(VOLTAGE_SOURCE_CONVERTER, network, new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()))
+                .stream().filter(s -> s.getName().equals("min_p")).findFirst().orElseThrow().getDoubles()[0];
+        assertThat(minP).isEqualTo(-100.0);
+    }
+
+    @Test
     void dcGrounds() {
         Network network = DcDetailedNetworkFactory.createVscAsymmetricalMonopole();
         List<Series> series = createDataFrame(DC_GROUND, network);

--- a/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
+++ b/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
@@ -932,11 +932,14 @@ class NetworkDataframesTest {
         assertThat(attrs.get("min_p").getDoubles()).containsExactly(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
         assertThat(attrs.get("max_p").getDoubles()).containsExactly(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
 
-        // finite value via core API reads back as the SI value (default ctx, no per-unit)
-        network.getVoltageSourceConverter("VscFr").setMinP(-100.0);
-        double minP = createDataFrame(VOLTAGE_SOURCE_CONVERTER, network, new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()))
-                .stream().filter(s -> s.getName().equals("min_p")).findFirst().orElseThrow().getDoubles()[0];
-        assertThat(minP).isEqualTo(-100.0);
+        // finite values via core API read back as the SI value (default ctx, no per-unit)
+        network.getVoltageSourceConverter("VscFr").setMinP(-100.0).setMaxP(200.0);
+        attrs = createDataFrame(VOLTAGE_SOURCE_CONVERTER, network, new DataframeFilter(ALL_ATTRIBUTES, Collections.emptyList()))
+                .stream().collect(ImmutableMap.toImmutableMap(Series::getName, Function.identity()));
+        int row = Arrays.asList(attrs.get("id").getStrings()).indexOf("VscFr");
+        assertThat(row).isNotNegative();
+        assertThat(attrs.get("min_p").getDoubles()[row]).isEqualTo(-100.0);
+        assertThat(attrs.get("max_p").getDoubles()[row]).isEqualTo(200.0);
     }
 
     @Test

--- a/pypowsybl/network/impl/network.py
+++ b/pypowsybl/network/impl/network.py
@@ -3323,6 +3323,11 @@ class Network:  # pylint: disable=too-many-public-methods
               - **p_dc2**: the DC flow on the converter, side 2 ``NaN`` if no loadflow has been computed (in MW)
               - **fictitious** (optional): ``True`` if the area is part of the model and not of the actual network
 
+            .. warning::
+
+                A finite ``min_p`` / ``max_p`` (any value other than ``-inf`` / ``inf``) is not yet supported
+                by IIDM serialization: saving a network that contains one raises a ``PowsyblException``.
+
             This dataframe is indexed on the converter ID.
         """
         return self.get_elements(ElementType.VOLTAGE_SOURCE_CONVERTER, all_attributes, attributes, **kwargs)
@@ -4551,6 +4556,11 @@ class Network:  # pylint: disable=too-many-public-methods
             - `p_dc1`
             - `p_dc2`
             - `fictitious`
+
+            .. warning::
+
+                A finite ``min_p`` / ``max_p`` (any value other than ``-inf`` / ``inf``) is not yet supported
+                by IIDM serialization: saving a network that contains one raises a ``PowsyblException``.
 
         See Also:
             :meth:`get_voltage_source_converters`
@@ -5982,6 +5992,11 @@ class Network:  # pylint: disable=too-many-public-methods
             - **resistive_loss** the resistive loss coefficient
             - **min_p** the minimum active power in MW (optional, unbounded by default)
             - **max_p** the maximum active power in MW (optional, unbounded by default)
+
+            .. warning::
+
+                A finite ``min_p`` / ``max_p`` (any value other than ``-inf`` / ``inf``) is not yet supported
+                by IIDM serialization: saving a network that contains one raises a ``PowsyblException``.
 
         Examples:
             Using keyword arguments:

--- a/pypowsybl/network/impl/network.py
+++ b/pypowsybl/network/impl/network.py
@@ -3323,6 +3323,12 @@ class Network:  # pylint: disable=too-many-public-methods
               - **p_dc2**: the DC flow on the converter, side 2 ``NaN`` if no loadflow has been computed (in MW)
               - **fictitious** (optional): ``True`` if the area is part of the model and not of the actual network
 
+            .. note::
+
+                ``target_p``, ``min_p`` and ``max_p`` follow the load sign convention at the point of
+                common coupling (PCC): a positive value means active power absorbed by the converter from
+                the AC grid.
+
             .. warning::
 
                 A finite ``min_p`` / ``max_p`` (any value other than ``-inf`` / ``inf``) is not yet supported
@@ -4556,6 +4562,12 @@ class Network:  # pylint: disable=too-many-public-methods
             - `p_dc1`
             - `p_dc2`
             - `fictitious`
+
+            .. note::
+
+                ``target_p``, ``min_p`` and ``max_p`` follow the load sign convention at the point of
+                common coupling (PCC): a positive value means active power absorbed by the converter from
+                the AC grid.
 
             .. warning::
 
@@ -5992,6 +6004,12 @@ class Network:  # pylint: disable=too-many-public-methods
             - **resistive_loss** the resistive loss coefficient
             - **min_p** the minimum active power in MW (optional, unbounded by default)
             - **max_p** the maximum active power in MW (optional, unbounded by default)
+
+            .. note::
+
+                ``target_p``, ``min_p`` and ``max_p`` follow the load sign convention at the point of
+                common coupling (PCC): a positive value means active power absorbed by the converter from
+                the AC grid.
 
             .. warning::
 

--- a/pypowsybl/network/impl/network.py
+++ b/pypowsybl/network/impl/network.py
@@ -3315,6 +3315,8 @@ class Network:  # pylint: disable=too-many-public-methods
               - **idle_loss**: the idle loss coefficient (in MW)
               - **switching_loss**: the switching loss coefficient (in MW/A)
               - **resistive_loss**: the resistive loss coefficient (in Ohm)
+              - **min_p** (optional): the minimum active power, ``-inf`` if unbounded (in MW)
+              - **max_p** (optional): the maximum active power, ``inf`` if unbounded (in MW)
               - **p_ac**: the AC active flow on the converter, ``NaN`` if no loadflow has been computed (in MW)
               - **q_ac**: the AC reactive flow on the converter, ``NaN`` if no loadflow has been computed  (in MVAr)
               - **p_dc1**: the DC flow on the converter, side 1 ``NaN`` if no loadflow has been computed (in MW)
@@ -4539,6 +4541,8 @@ class Network:  # pylint: disable=too-many-public-methods
             - `target_v_ac`
             - `target_p`
             - `target_q`
+            - `min_p`
+            - `max_p`
             - `idle_loss`
             - `switching_loss`
             - `resistive_loss`
@@ -5976,6 +5980,8 @@ class Network:  # pylint: disable=too-many-public-methods
             - **idle_loss** the idle loss coefficient
             - **switching_loss** the switching loss coefficient
             - **resistive_loss** the resistive loss coefficient
+            - **min_p** the minimum active power in MW (optional, unbounded by default)
+            - **max_p** the maximum active power in MW (optional, unbounded by default)
 
         Examples:
             Using keyword arguments:

--- a/pypowsybl/network/impl/network.py
+++ b/pypowsybl/network/impl/network.py
@@ -5997,13 +5997,13 @@ class Network:  # pylint: disable=too-many-public-methods
             - **control_mode** the control mode of the converter (V_DC or P_PCC)
             - **target_p** the AC active power setpoint
             - **target_q** the AC reactive power setpoint
+            - **min_p** the minimum active power in MW (optional, unbounded by default)
+            - **max_p** the maximum active power in MW (optional, unbounded by default)
             - **target_v_ac** the AC voltage setpoint
             - **target_v_dc** the DC voltage setpoint
             - **idle_loss** the idle loss coefficient
             - **switching_loss** the switching loss coefficient
             - **resistive_loss** the resistive loss coefficient
-            - **min_p** the minimum active power in MW (optional, unbounded by default)
-            - **max_p** the maximum active power in MW (optional, unbounded by default)
 
             .. note::
 

--- a/tests/test_java_perunit.py
+++ b/tests/test_java_perunit.py
@@ -9,6 +9,7 @@ import pytest
 
 import pypowsybl as pp
 import pandas as pd
+import numpy as np
 from numpy import nan
 
 import util
@@ -227,6 +228,28 @@ def test_get_static_var_compensators_per_unit():
                  'p', 'q', 'i', 'voltage_level_id', 'bus_id', 'connected'],
         data=[['SVC', '', -0.05, 0.05, 3, 4, 'VOLTAGE', True, 'SVC', 0, -0.13, 0.13, 'S4VL1', 'S4VL1_0', True]])
     pd.testing.assert_frame_equal(expected, n.get_static_var_compensators(), check_dtype=False, atol=1e-2)
+
+
+def test_voltage_source_converters_min_max_p():
+    n = pp.network.create_dc_detailed_vsc_symmetrical_monopole_network()
+    n.per_unit = True
+
+    # unbounded default stays +/-inf regardless of per-unit (Sbase-independent by design)
+    df = n.get_voltage_source_converters(all_attributes=True)
+    assert np.isneginf(df['min_p']['VscFr'])
+    assert np.isposinf(df['max_p']['VscFr'])
+
+    # finite limits are written in per-unit (Sbase default 100 MVA) and read back in per-unit
+    n.update_voltage_source_converters(id='VscFr', min_p=-1.0, max_p=1.0)
+    df = n.get_voltage_source_converters(all_attributes=True)
+    assert df['min_p']['VscFr'] == pytest.approx(-1.0)
+    assert df['max_p']['VscFr'] == pytest.approx(1.0)
+
+    # switching back to SI confirms the per-unit write was scaled by Sbase (-1 pu -> -100 MW)
+    n.per_unit = False
+    df = n.get_voltage_source_converters(all_attributes=True)
+    assert df['min_p']['VscFr'] == pytest.approx(-100.0)
+    assert df['max_p']['VscFr'] == pytest.approx(100.0)
 
 
 def test_voltage_level_per_unit():

--- a/tests/test_java_perunit.py
+++ b/tests/test_java_perunit.py
@@ -234,7 +234,7 @@ def test_voltage_source_converters_min_max_p():
     n = pp.network.create_dc_detailed_vsc_symmetrical_monopole_network()
     n.per_unit = True
 
-    # unbounded default stays +/-inf regardless of per-unit (Sbase-independent by design)
+    # unbounded default stays +/-inf regardless of per-unit
     df = n.get_voltage_source_converters(all_attributes=True)
     assert np.isneginf(df['min_p']['VscFr'])
     assert np.isposinf(df['max_p']['VscFr'])

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -2852,6 +2852,46 @@ def test_voltage_source_converters():
     assert e2.value.args[0] == "Terminal2 of converter VscFr is missing"
 
 
+def test_voltage_source_converters_min_max_p():
+    n = pp.network.create_dc_detailed_vsc_symmetrical_monopole_network()
+
+    # optional: absent from the default frame (regression-safety of optionality)
+    default_cols = n.get_voltage_source_converters().columns
+    assert 'min_p' not in default_cols and 'max_p' not in default_cols
+
+    # visible with all_attributes; unbounded core default reads as +/-inf
+    df = n.get_voltage_source_converters(all_attributes=True)
+    assert 'min_p' in df.columns and 'max_p' in df.columns
+    assert np.isneginf(df['min_p']['VscFr'])
+    assert np.isposinf(df['max_p']['VscFr'])
+
+    # explicit attribute selection works too
+    sel = n.get_voltage_source_converters(attributes=['min_p', 'max_p'])
+    assert list(sel.columns) == ['min_p', 'max_p']
+
+
+def test_voltage_source_converters_update_min_max_p():
+    n = pp.network.create_dc_detailed_vsc_symmetrical_monopole_network()
+
+    # set finite limits (SI, default mode), read back
+    n.update_voltage_source_converters(id='VscFr', min_p=-100.0, max_p=100.0)
+    df = n.get_voltage_source_converters(all_attributes=True)
+    assert df['min_p']['VscFr'] == pytest.approx(-100.0)
+    assert df['max_p']['VscFr'] == pytest.approx(100.0)
+
+    # updating only max_p must leave min_p untouched
+    n.update_voltage_source_converters(id='VscFr', max_p=150.0)
+    df = n.get_voltage_source_converters(all_attributes=True)
+    assert df['min_p']['VscFr'] == pytest.approx(-100.0)   # unchanged
+    assert df['max_p']['VscFr'] == pytest.approx(150.0)
+
+    # +/-inf round-trips back to "unbounded"
+    n.update_voltage_source_converters(id='VscFr', min_p=-np.inf, max_p=np.inf)
+    df = n.get_voltage_source_converters(all_attributes=True)
+    assert np.isneginf(df['min_p']['VscFr'])
+    assert np.isposinf(df['max_p']['VscFr'])
+
+
 def test_dc_grounds():
     n = pp.network.create_dc_detailed_lcc_bipole_ground_return_network()
     n.update_dc_grounds(pd.DataFrame(data={'r': 1.0, 'connected': False}, index=['dcGroundGb']))

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -2873,7 +2873,7 @@ def test_voltage_source_converters_min_max_p():
 def test_voltage_source_converters_update_min_max_p():
     n = pp.network.create_dc_detailed_vsc_symmetrical_monopole_network()
 
-    # set finite limits (SI, default mode), read back
+    # set finite limits in MW, read back
     n.update_voltage_source_converters(id='VscFr', min_p=-100.0, max_p=100.0)
     df = n.get_voltage_source_converters(all_attributes=True)
     assert df['min_p']['VscFr'] == pytest.approx(-100.0)

--- a/tests/test_network_elements_creation.py
+++ b/tests/test_network_elements_creation.py
@@ -1284,6 +1284,11 @@ def test_voltage_source_converter_creation():
     assert conv.dc_connected2 == False
     assert conv.pcc_terminal_id == 'TRDC-GB-xNodeDc1gb'
 
+    # min_p / max_p not set at creation -> core default is unbounded (+/-inf)
+    convAll = n.get_voltage_source_converters(all_attributes=True).loc['CONV_TEST']
+    assert np.isneginf(convAll.min_p)
+    assert np.isposinf(convAll.max_p)
+
     # Test without specifying dc_connected1/2 and replacing bus1/2_id by connectable_bus1/2_id;
     # The DC side should be connected, but not the AC side
     connection_params_dict2 = {
@@ -1317,6 +1322,23 @@ def test_voltage_source_converter_creation():
     assert conv3.bus_breaker_bus2_id == ""
     assert conv3.connected1
     assert not conv3.connected2
+
+
+def test_voltage_source_converter_creation_min_max_p():
+    n = pypowsybl.network.create_dc_detailed_vsc_symmetrical_monopole_network()
+    n.create_buses(id='BUS_TEST', voltage_level_id='VLDC-GB-xNodeDc1gb-150')
+    n.create_voltage_source_converters(pd.DataFrame(index=pd.Series(name='id', data=['CONV_TEST']),
+                                                    columns=['id', 'name', 'voltage_level_id', 'bus1_id', 'bus2_id',
+                                                             'dc_node1_id', 'dc_node2_id', 'control_mode', 'target_p',
+                                                             'voltage_regulator_on', 'idle_loss', 'switching_loss',
+                                                             'resistive_loss', 'target_v_ac', 'dc_connected1',
+                                                             'dc_connected2', 'pcc_terminal_id', 'min_p', 'max_p'], data=[
+            ['CONV_TEST', '', 'VLDC-GB-xNodeDc1gb-150', 'BUSDC-GB-xNodeDc1gb-150', 'BUS_TEST', 'dcNodeGbNeg',
+             'dcNodeGbPos', 'P_PCC', 300, True, 1.0, 1.0, 1.0, 400, True, False, 'TRDC-GB-xNodeDc1gb', -100, 100]]))
+    conv = n.get_voltage_source_converters(all_attributes=True).loc['CONV_TEST']
+
+    assert conv.min_p == -100
+    assert conv.max_p == 100
 
 
 def test_dc_ground_creation():

--- a/tests/test_network_elements_creation.py
+++ b/tests/test_network_elements_creation.py
@@ -1327,14 +1327,27 @@ def test_voltage_source_converter_creation():
 def test_voltage_source_converter_creation_min_max_p():
     n = pypowsybl.network.create_dc_detailed_vsc_symmetrical_monopole_network()
     n.create_buses(id='BUS_TEST', voltage_level_id='VLDC-GB-xNodeDc1gb-150')
-    n.create_voltage_source_converters(pd.DataFrame(index=pd.Series(name='id', data=['CONV_TEST']),
-                                                    columns=['id', 'name', 'voltage_level_id', 'bus1_id', 'bus2_id',
-                                                             'dc_node1_id', 'dc_node2_id', 'control_mode', 'target_p',
-                                                             'voltage_regulator_on', 'idle_loss', 'switching_loss',
-                                                             'resistive_loss', 'target_v_ac', 'dc_connected1',
-                                                             'dc_connected2', 'pcc_terminal_id', 'min_p', 'max_p'], data=[
-            ['CONV_TEST', '', 'VLDC-GB-xNodeDc1gb-150', 'BUSDC-GB-xNodeDc1gb-150', 'BUS_TEST', 'dcNodeGbNeg',
-             'dcNodeGbPos', 'P_PCC', 300, True, 1.0, 1.0, 1.0, 400, True, False, 'TRDC-GB-xNodeDc1gb', -100, 100]]))
+    n.create_voltage_source_converters(pd.DataFrame.from_records(index='id', data=[{
+        'id': 'CONV_TEST',
+        'name': '',
+        'voltage_level_id': 'VLDC-GB-xNodeDc1gb-150',
+        'bus1_id': 'BUSDC-GB-xNodeDc1gb-150',
+        'bus2_id': 'BUS_TEST',
+        'dc_node1_id': 'dcNodeGbNeg',
+        'dc_node2_id': 'dcNodeGbPos',
+        'control_mode': 'P_PCC',
+        'target_p': 300,
+        'voltage_regulator_on': True,
+        'idle_loss': 1.0,
+        'switching_loss': 1.0,
+        'resistive_loss': 1.0,
+        'target_v_ac': 400,
+        'dc_connected1': True,
+        'dc_connected2': False,
+        'pcc_terminal_id': 'TRDC-GB-xNodeDc1gb',
+        'min_p': -100,
+        'max_p': 100
+    }]))
     conv = n.get_voltage_source_converters(all_attributes=True).loc['CONV_TEST']
 
     assert conv.min_p == -100


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [X] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
https://github.com/powsybl/pypowsybl/issues/1236


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Add access to minP and maxP attributes of Voltage Source Converters, recently added to Core.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
No access to minP and maxP in PyPowSyBl.


**What is the new behavior (if this is a feature change)?**
Added min_p and max_p attributes to Network.get_voltage_source_converters, Network.create_voltage_source_converters and Network.update_voltage_source_converters.

The following design choice was made: convert default values to/from inf/Double.POSITIVE_INFINITY and -inf/Double.NEGATIVE_INFINITY for simplicity of usage. An added benefit is that default values remain the same in pu and in MW.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**Additional information**
I used this opportunity to change `public Collection<OperationalLimitsGroup> getAllSelectedOperationalLimitsGroups()` to `public List<OperationalLimitsGroup> getAllSelectedOperationalLimitsGroups()` to follow a change in OLF but I am not sure if it's the right place to do so.
