### PR TITLE
Fix Snapshot CI download of IPOpt for Linux

### DIFF
--- a/.github/workflows/snapshot-ci.yml
+++ b/.github/workflows/snapshot-ci.yml
@@ -323,7 +323,7 @@ jobs:
         working-directory: ./pypowsybl
 
       - name: Install Ipopt (Linux, via micromamba)
-        if: matrix.config.name == 'linux'
+        if: matrix.config.name == 'ubuntu'
         shell: bash
         run: |
           curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
@@ -449,7 +449,7 @@ jobs:
           unzip binaries.zip
 
       - name: Install Ipopt (Linux, via micromamba)
-        if: matrix.config.name == 'linux'
+        if: matrix.config.name == 'ubuntu'
         shell: bash
         run: |
           curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Technical fix : Snapshot CI does not download correctly IPOpt for testing purpose due to the linux environment being named "ubuntu" and not "linux"

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
