### PR TITLE
Support activePowerControl extension on batteries.

### DIFF
--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/adders/NetworkUtils.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/adders/NetworkUtils.java
@@ -90,6 +90,14 @@ public final class NetworkUtils {
         return (Injection<?>) identifiable;
     }
 
+    public static Injection<?> getGenOrBatteryOrThrow(Network network, String id) {
+        Identifiable<?> identifiable = getIdentifiableOrThrow(network, id);
+        if (!(identifiable instanceof Generator) && !(identifiable instanceof Battery)) {
+            throw new PowsyblException("Network element '" + id + "' is not a generator or a battery");
+        }
+        return (Injection<?>) identifiable;
+    }
+
     public static Area getAreaOrThrow(Network network, String id) {
         Area area = network.getArea(id);
         if (area == null) {

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/extensions/ActivePowerControlDataframeAdder.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/extensions/ActivePowerControlDataframeAdder.java
@@ -7,15 +7,15 @@
  */
 package com.powsybl.dataframe.network.extensions;
 
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.dataframe.SeriesMetadata;
 import com.powsybl.dataframe.network.adders.AbstractSimpleAdder;
+import com.powsybl.dataframe.network.adders.NetworkUtils;
 import com.powsybl.dataframe.network.adders.SeriesUtils;
 import com.powsybl.dataframe.update.DoubleSeries;
 import com.powsybl.dataframe.update.IntSeries;
 import com.powsybl.dataframe.update.StringSeries;
 import com.powsybl.dataframe.update.UpdatingDataframe;
-import com.powsybl.iidm.network.Generator;
+import com.powsybl.iidm.network.Injection;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.extensions.ActivePowerControlAdder;
 
@@ -60,12 +60,8 @@ public class ActivePowerControlDataframeAdder extends AbstractSimpleAdder {
         }
 
         void create(Network network, int row) {
-            String generatorId = this.id.get(row);
-            Generator g = network.getGenerator(generatorId);
-            if (g == null) {
-                throw new PowsyblException("Invalid generator id : could not find " + generatorId);
-            }
-            var adder = g.newExtension(ActivePowerControlAdder.class);
+            Injection<?> injection = NetworkUtils.getGenOrBatteryOrThrow(network, this.id.get(row));
+            var adder = injection.newExtension(ActivePowerControlAdder.class);
             SeriesUtils.applyIfPresent(droop, row, adder::withDroop);
             SeriesUtils.applyBooleanIfPresent(participate, row, adder::withParticipate);
             SeriesUtils.applyIfPresent(participationFactor, row, adder::withParticipationFactor);

--- a/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/extensions/ActivePowerControlDataframeProvider.java
+++ b/java/pypowsybl/src/main/java/com/powsybl/dataframe/network/extensions/ActivePowerControlDataframeProvider.java
@@ -13,8 +13,11 @@ import com.powsybl.dataframe.network.ExtensionInformation;
 import com.powsybl.dataframe.network.NetworkDataframeMapper;
 import com.powsybl.dataframe.network.NetworkDataframeMapperBuilder;
 import com.powsybl.dataframe.network.adders.NetworkElementAdder;
+import com.powsybl.dataframe.network.adders.NetworkUtils;
+import com.powsybl.iidm.network.Battery;
 import com.powsybl.iidm.network.Generator;
 import com.powsybl.iidm.network.Identifiable;
+import com.powsybl.iidm.network.Injection;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.extensions.ActivePowerControl;
 
@@ -36,7 +39,7 @@ public class ActivePowerControlDataframeProvider extends AbstractSingleDataframe
     @Override
     public ExtensionInformation getExtensionInformation() {
         return new ExtensionInformation(ActivePowerControl.NAME,
-                "Provides information about the participation of generators to balancing",
+                "Provides information about the participation of generators and batteries to balancing",
                 "index : id (str), " +
                         "participate (bool), " +
                         "droop (float), " +
@@ -46,19 +49,16 @@ public class ActivePowerControlDataframeProvider extends AbstractSingleDataframe
     }
 
     private Stream<ActivePowerControl> itemsStream(Network network) {
-        return network.getGeneratorStream()
-                .map(g -> (ActivePowerControl) g.getExtension(ActivePowerControl.class))
+        return Stream.<Injection<?>>concat(network.getGeneratorStream(), network.getBatteryStream())
+                .map(i -> (ActivePowerControl) i.getExtension(ActivePowerControl.class))
                 .filter(Objects::nonNull);
     }
 
     private ActivePowerControl getOrThrow(Network network, String id) {
-        Generator gen = network.getGenerator(id);
-        if (gen == null) {
-            throw new PowsyblException("Generator '" + id + "' not found");
-        }
-        ActivePowerControl apc = gen.getExtension(ActivePowerControl.class);
+        Injection<?> injection = NetworkUtils.getGenOrBatteryOrThrow(network, id);
+        ActivePowerControl apc = injection.getExtension(ActivePowerControl.class);
         if (apc == null) {
-            throw new PowsyblException("Generator '" + id + "' has no ActivePowerControl extension");
+            throw new PowsyblException("Network element '" + id + "' has no ActivePowerControl extension");
         }
         return apc;
     }
@@ -78,9 +78,9 @@ public class ActivePowerControlDataframeProvider extends AbstractSingleDataframe
     @Override
     public void removeExtensions(Network network, List<String> ids) {
         ids.stream().filter(Objects::nonNull)
-                .map(network::getGenerator)
-                .filter(Objects::nonNull)
-                .forEach(g -> g.removeExtension(ActivePowerControl.class));
+                .map(network::getIdentifiable)
+                .filter(i -> i instanceof Generator || i instanceof Battery)
+                .forEach(i -> i.removeExtension(ActivePowerControl.class));
     }
 
     @Override

--- a/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
+++ b/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/NetworkDataframesTest.java
@@ -10,15 +10,18 @@ package com.powsybl.dataframe.network;
 import com.google.common.collect.ImmutableMap;
 import com.powsybl.cgmes.extensions.CgmesMetadataModels;
 import com.powsybl.cgmes.extensions.CgmesMetadataModelsAdder;
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.dataframe.DataframeElementType;
 import com.powsybl.dataframe.DataframeFilter;
 import com.powsybl.dataframe.DoubleIndexedSeries;
 import com.powsybl.dataframe.impl.DefaultDataframeHandler;
 import com.powsybl.dataframe.impl.Series;
+import com.powsybl.dataframe.network.adders.NetworkElementAdders;
 import com.powsybl.dataframe.network.extensions.NetworkExtensions;
 import com.powsybl.dataframe.update.*;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.*;
+import com.powsybl.iidm.network.test.BatteryNetworkFactory;
 import com.powsybl.iidm.network.test.DcDetailedNetworkFactory;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.HvdcTestNetwork;
@@ -305,6 +308,72 @@ class NetworkDataframesTest {
                 network.getGeneratorStream().map(Generator::getNameOrId).collect(Collectors.toList()));
         series = createExtensionDataFrame("activePowerControl", network);
         assertEquals(0, series.get(0).getStrings().length);
+    }
+
+    @Test
+    void batteriesExtension() {
+        Network network = BatteryNetworkFactory.create();
+        network.getBattery("BAT2")
+                .newExtension(ActivePowerControlAdder.class)
+                .withParticipate(true)
+                .withDroop(1.1)
+                .add();
+        List<Series> series = createExtensionDataFrame("activePowerControl", network);
+        assertThat(series.get(0).getStrings())
+                .containsExactly("BAT2");
+        assertThat(series.get(1).getDoubles())
+                .containsExactly(1.1);
+        assertThat(series.get(2).getBooleans())
+                .containsExactly(true);
+
+        DefaultUpdatingDataframe dataframe = new DefaultUpdatingDataframe(1);
+        dataframe.addSeries("id", true, new TestStringSeries("BAT2"));
+        dataframe.addSeries("droop", false, new TestDoubleSeries(1.2));
+        dataframe.addSeries("participation_factor", false, new TestDoubleSeries(1.5));
+        dataframe.addSeries("max_target_p", false, new TestDoubleSeries(150.));
+        dataframe.addSeries("min_target_p", false, new TestDoubleSeries(-150.));
+        updateExtension("activePowerControl", network, dataframe);
+        series = createExtensionDataFrame("activePowerControl", network);
+        assertThat(series.get(1).getDoubles())
+                .containsExactly(1.2);
+        assertThat(series.get(3).getDoubles())
+                .containsExactly(1.5);
+        assertThat(series.get(4).getDoubles())
+                .containsExactly(150.);
+        assertThat(series.get(5).getDoubles())
+                .containsExactly(-150.);
+
+        NetworkExtensions.removeExtensions(network, "activePowerControl", List.of("BAT2"));
+        series = createExtensionDataFrame("activePowerControl", network);
+        assertEquals(0, series.get(0).getStrings().length);
+    }
+
+    @Test
+    void generatorsAndBatteriesExtension() {
+        Network network = BatteryNetworkFactory.create();
+        DefaultUpdatingDataframe dataframe = new DefaultUpdatingDataframe(2);
+        dataframe.addSeries("id", true, new TestStringSeries("GEN", "BAT"));
+        dataframe.addSeries("droop", false, new TestDoubleSeries(1.1, 2.2));
+        dataframe.addSeries("participate", false, new TestIntSeries(1, 0));
+        NetworkElementAdders.addExtensions("activePowerControl", network, List.of(dataframe));
+
+        List<Series> series = createExtensionDataFrame("activePowerControl", network);
+        // generators are listed first, then batteries
+        assertThat(series.get(0).getStrings())
+                .containsExactly("GEN", "BAT");
+        assertThat(series.get(1).getDoubles())
+                .containsExactly(1.1, 2.2);
+        assertThat(series.get(2).getBooleans())
+                .containsExactly(true, false);
+
+        // a load is neither a generator nor a battery
+        DefaultUpdatingDataframe loadDataframe = new DefaultUpdatingDataframe(1);
+        loadDataframe.addSeries("id", true, new TestStringSeries("LOAD"));
+        loadDataframe.addSeries("droop", false, new TestDoubleSeries(1.1));
+        List<UpdatingDataframe> loadDataframes = List.of(loadDataframe);
+        PowsyblException e = assertThrows(PowsyblException.class,
+                () -> NetworkElementAdders.addExtensions("activePowerControl", network, loadDataframes));
+        assertEquals("Network element 'LOAD' is not a generator or a battery", e.getMessage());
     }
 
     @Test

--- a/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/adders/NetworkElementAddersTest.java
+++ b/java/pypowsybl/src/test/java/com/powsybl/dataframe/network/adders/NetworkElementAddersTest.java
@@ -369,6 +369,41 @@ class NetworkElementAddersTest {
     }
 
     @Test
+    void activePowerControlExtensionOnBattery() {
+        var network = BatteryNetworkFactory.create();
+        String batteryId = "BAT2";
+        assertNull(network.getBattery(batteryId).getExtension(ActivePowerControl.class));
+        double droop = 4.0;
+
+        DefaultUpdatingDataframe dataframe = new DefaultUpdatingDataframe(1);
+        addStringColumn(dataframe, "id", batteryId);
+        addDoubleColumn(dataframe, "droop", droop);
+        addIntColumn(dataframe, "participate", 1);
+        addDoubleColumn(dataframe, "min_target_p", -150.0);
+        addDoubleColumn(dataframe, "max_target_p", 150.0);
+        NetworkElementAdders.addExtensions("activePowerControl", network, singletonList(dataframe));
+
+        ActivePowerControl extension = network.getBattery(batteryId).getExtension(ActivePowerControl.class);
+        assertNotNull(extension);
+        assertEquals(droop, extension.getDroop());
+        assertTrue(extension.isParticipate());
+        assertEquals(-150.0, extension.getMinTargetP().orElseThrow());
+        assertEquals(150.0, extension.getMaxTargetP().orElseThrow());
+    }
+
+    @Test
+    void activePowerControlExtensionOnUnsupportedElement() {
+        var network = BatteryNetworkFactory.create();
+        DefaultUpdatingDataframe dataframe = new DefaultUpdatingDataframe(1);
+        addStringColumn(dataframe, "id", "LOAD");
+        addDoubleColumn(dataframe, "droop", 4.0);
+        List<UpdatingDataframe> dataframes = singletonList(dataframe);
+        PowsyblException e = assertThrows(PowsyblException.class,
+                () -> NetworkElementAdders.addExtensions("activePowerControl", network, dataframes));
+        assertEquals("Network element 'LOAD' is not a generator or a battery", e.getMessage());
+    }
+
+    @Test
     void hvdcAngleDroopActivePowerControlExtension() {
         Network network = HvdcTestNetwork.createLcc();
         String lId = "L";

--- a/tests/test_network_extensions.py
+++ b/tests/test_network_extensions.py
@@ -651,6 +651,52 @@ def test_voltage_per_reactive_power_control():
     assert network.get_extensions('voltagePerReactivePowerControl').empty
 
 
+def test_batteries_active_power_control():
+    network = pn.load(str(TEST_DIR.joinpath('battery.xiidm')))
+    assert network.get_extensions('activePowerControl').empty
+
+    network.create_extensions('activePowerControl', id='BAT2', droop=1.2, participate=True,
+                              participation_factor=1.5, max_target_p=150., min_target_p=-150.)
+    e = network.get_extensions('activePowerControl')
+    expected = pd.DataFrame(
+        index=pd.Series(name='id', data=['BAT2']),
+        columns=['droop', 'participate', 'participation_factor', 'max_target_p', 'min_target_p'],
+        data=[[1.2, True, 1.5, 150., -150.]])
+    pd.testing.assert_frame_equal(expected, e, check_dtype=False)
+
+    network.update_extensions('activePowerControl', id='BAT2', droop=1.4, participate=False,
+                              participation_factor=1.8, max_target_p=120., min_target_p=-120.)
+    e = network.get_extensions('activePowerControl')
+    expected = pd.DataFrame(
+        index=pd.Series(name='id', data=['BAT2']),
+        columns=['droop', 'participate', 'participation_factor', 'max_target_p', 'min_target_p'],
+        data=[[1.4, False, 1.8, 120., -120.]])
+    pd.testing.assert_frame_equal(expected, e, check_dtype=False)
+
+    network.remove_extensions('activePowerControl', ['BAT2'])
+    assert network.get_extensions('activePowerControl').empty
+
+
+def test_generators_and_batteries_active_power_control():
+    network = pn.load(str(TEST_DIR.joinpath('battery.xiidm')))
+    network.create_extensions('activePowerControl', pd.DataFrame.from_records(index='id', data=[
+        {'id': 'GEN', 'droop': 1.2, 'participate': True},
+        {'id': 'BAT', 'droop': 2.3, 'participate': False}
+    ]))
+    e = network.get_extensions('activePowerControl')
+    # generators come first, then batteries
+    assert list(e.index) == ['GEN', 'BAT']
+    assert e['droop']['GEN'] == pytest.approx(1.2, abs=1e-3)
+    assert e['participate']['GEN']
+    assert e['droop']['BAT'] == pytest.approx(2.3, abs=1e-3)
+    assert not e['participate']['BAT']
+
+    # the extension is only supported by generators and batteries
+    with pytest.raises(pypowsybl.PyPowsyblError,
+                       match="Network element 'LOAD' is not a generator or a battery"):
+        network.create_extensions('activePowerControl', id='LOAD', droop=1.2)
+
+
 def test_batteries_voltage_regulation():
     network = pn.load(str(TEST_DIR.joinpath('battery.xiidm')))
     assert network.get_extensions('voltageRegulation').empty
@@ -700,7 +746,7 @@ def test_get_extensions_information():
                'attributes'] == 'index : id (str), fixed_p0 (float), variable_p0 (float), fixed_q0 (float), variable_q0 (float)'
     assert extensions_information.loc['hvdcOperatorActivePowerRange']['detail'] == ''
     assert extensions_information.loc['hvdcOperatorActivePowerRange']['attributes'] == 'index : id (str), opr_from_cs1_to_cs2 (float), opr_from_cs2_to_cs1 (float)'
-    assert extensions_information.loc['activePowerControl']['detail'] == 'Provides information about the participation of generators to balancing'
+    assert extensions_information.loc['activePowerControl']['detail'] == 'Provides information about the participation of generators and batteries to balancing'
     assert extensions_information.loc['activePowerControl']['attributes'] == 'index : id (str), participate (bool), droop (float), participation_factor (float), max_target_p (float), min_target_p (float)'
     assert extensions_information.loc['entsoeCategory']['detail'] == 'Provides Entsoe category code for a generator'
     assert extensions_information.loc['entsoeCategory']['attributes'] == 'index : id (str), code (int)'


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
The apc extension was not wired for batteries object whereas it is permitted in core.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
the apc extension is rejected on batteries


**What is the new behavior (if this is a feature change)?**
The apc extension is wlload on batteries


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
